### PR TITLE
Add requirements for cifar10

### DIFF
--- a/docs/tutorials/CIFAR-10.md
+++ b/docs/tutorials/CIFAR-10.md
@@ -18,7 +18,7 @@ Original model code from [CIFAR-10 Tutorial](https://github.com/pytorch/tutorial
 git submodule update --init --recursive
 ```
 
-To install requirements for cifar 10:
+To install requirements for CIFAR-10:
 ```
 cd DeepSpeedExamples/cifar
 pip install -r requirements.txt

--- a/docs/tutorials/CIFAR-10.md
+++ b/docs/tutorials/CIFAR-10.md
@@ -18,6 +18,12 @@ Original model code from [CIFAR-10 Tutorial](https://github.com/pytorch/tutorial
 git submodule update --init --recursive
 ```
 
+To install requirements for cifar 10:
+```
+cd DeepSpeedExamples/cifar
+pip install -r requirements.txt
+```
+
 Run `python cifar10_tutorial.py`, it downloads the training data set at first run.
 ```less
 Downloading https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz to ./data/cifar-10-python.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 torch==1.2
 torchvision==0.4.0
+pillow==6.2.2
 tqdm
 psutil
 tensorboardX==1.8


### PR DESCRIPTION
When I following cifar tutorial, I couldn't execute cifar code directly.
so, I have two suggestions.

 

1. Add `$ pip install -r requirements.txt` in [cifar tutorial md file.](https://github.com/microsoft/DeepSpeed/blob/master/docs/tutorials/CIFAR-10.md)
If you didn't install requirements.txt in deepspeedexamples repo, you can't execute cifar tutorial directly.

 

2. Move pillow library from [deepspeedexamples/cifar10's requirements](https://github.com/microsoft/DeepSpeedExamples/blob/master/cifar/requirements.txt) to [deepspeed's requirements](https://github.com/microsoft/DeepSpeed/blob/master/requirements.txt)
 
When you use torchvision==0.4.0, pillow have to set 6.2.*.
If not, you failed whenever you import torchvision because of [this bug](https://github.com/pytorch/vision/issues/1712).
 
Thank you.