### PR TITLE
Add two CLI options to help with the installation inside of conda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,6 @@ RUN git clone https://github.com/microsoft/DeepSpeed.git ${STAGE_DIR}/DeepSpeed
 RUN cd ${STAGE_DIR}/DeepSpeed && \
     git checkout . && \
     git checkout master && \
-    ./install.sh
+    ./install.sh --pip_sudo
 RUN rm -rf ${STAGE_DIR}/DeepSpeed
 RUN python -c "import deepspeed; print(deepspeed.__version__)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
   - script: |
       python -m pip install --upgrade pip
       pip install --user -r requirements.txt
-      ./install.sh
+      ./install.sh --pip_sudo
     displayName: 'Install dependencies'
 
   - script: |

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ hostfile (hostfile: /job/hostfile). If no hostfile exists, will only install loc
 [optional]
     -d, --deepspeed_only    Install only deepspeed and no third party dependencies
     -t, --third_party_only  Install only third party dependencies and not deepspeed
-    -l, --local_only        Installs only on local machine
+    -l, --local_only        Install only on local machine
     -s, --pip_sudo          Run pip with sudo (default: no sudo)
     -m, --pip_mirror        Use the specified pip mirror (default: the default pip mirror)
     -H, --hostfile          Path to MPI-style hostfile (default: /job/hostfile)

--- a/install.sh
+++ b/install.sh
@@ -18,8 +18,8 @@ hostfile (hostfile: /job/hostfile). If no hostfile exists, will only install loc
     -d, --deepspeed_only    Install only deepspeed and no third party dependencies
     -t, --third_party_only  Install only third party dependencies and not deepspeed
     -l, --local_only        Installs only on local machine
-    -u, --no_sudo           Do not invoke sudo
-    -m, --pip_mirror        Use the specified pip mirror
+    -s, --pip_sudo          Run pip with sudo (default: no sudo)
+    -m, --pip_mirror        Use the specified pip mirror (default: the default pip mirror)
     -H, --hostfile          Path to MPI-style hostfile (default: /job/hostfile)
     -h, --help              This help text
   """
@@ -30,7 +30,7 @@ tp_only=0
 deepspeed_install=1
 third_party_install=1
 local_only=0
-no_sudo=0
+pip_sudo=0
 entire_dlts_job=1
 hostfile=/job/hostfile
 pip_mirror=""
@@ -55,8 +55,8 @@ case $key in
     local_only=1;
     shift
     ;;
-    -u|--no_sudo)
-    no_sudo=1;
+    -s|--pip_sudo)
+    pip_sudo=1;
     shift
     ;;
     -m|--pip_mirror)
@@ -97,10 +97,10 @@ echo "git_hash = '$(git rev-parse --short HEAD)'" > deepspeed/git_version_info.p
 echo "git_branch = '$(git rev-parse --abbrev-ref HEAD)'" >> deepspeed/git_version_info.py
 cat deepspeed/git_version_info.py
 
-if [ "$no_sudo" == "1" ]; then
-  SUDO=""
+if [ "$pip_sudo" == "1" ]; then
+  PIP_SUDO="sudo -H"
 else
-  SUDO="sudo -H"
+  PIP_SUDO=""
 fi
 
 if [ "$pip_mirror" != "" ]; then
@@ -111,7 +111,7 @@ fi
 
 
 
-install_apex="$SUDO"" $PIP_INSTALL "'-v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" third_party/apex'
+install_apex="$PIP_SUDO"" $PIP_INSTALL "'-v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" third_party/apex'
 
 if [ ! -f $hostfile ]; then
         echo "No hostfile exists at $hostfile, installing locally"
@@ -119,7 +119,7 @@ if [ ! -f $hostfile ]; then
 fi
 
 # Ensure dependencies are installed locally
-$SUDO $PIP_INSTALL -r requirements.txt
+$PIP_SUDO $PIP_INSTALL -r requirements.txt
 
 # Build wheels
 if [ "$third_party_install" == "1" ]; then
@@ -132,8 +132,8 @@ if [ "$third_party_install" == "1" ]; then
     cd -
 
     echo "Installing apex locally so that deepspeed will build"
-    $SUDO pip uninstall -y apex
-    $SUDO $PIP_INSTALL third_party/apex/dist/apex*.whl
+    $PIP_SUDO pip uninstall -y apex
+    $PIP_SUDO $PIP_INSTALL third_party/apex/dist/apex*.whl
 fi
 if [ "$deepspeed_install" == "1" ]; then
     echo "Building deepspeed wheel"
@@ -143,8 +143,8 @@ fi
 if [ "$local_only" == "1" ]; then
     if [ "$deepspeed_install" == "1" ]; then
         echo "Installing deepspeed"
-        $SUDO pip uninstall -y deepspeed
-        $SUDO $PIP_INSTALL dist/deepspeed*.whl
+        $PIP_SUDO pip uninstall -y deepspeed
+        $PIP_SUDO $PIP_INSTALL dist/deepspeed*.whl
         python -c 'import deepspeed; print("deepspeed info:", deepspeed.__version__, deepspeed.__git_branch__, deepspeed.__git_hash__)'
         echo "Installation is successful"
     fi
@@ -161,18 +161,18 @@ else
 
     pdsh -w $hosts "if [ -d $tmp_wheel_path ]; then rm $tmp_wheel_path/*.whl; else mkdir -pv $tmp_wheel_path; fi"
     pdcp -w $hosts requirements.txt ${tmp_wheel_path}/
-    pdsh -w $hosts "$SUDO $PIP_INSTALL -r ${tmp_wheel_path}/requirements.txt"
+    pdsh -w $hosts "$PIP_SUDO $PIP_INSTALL -r ${tmp_wheel_path}/requirements.txt"
     if [ "$third_party_install" == "1" ]; then
-        pdsh -w $hosts "$SUDO pip uninstall -y apex"
+        pdsh -w $hosts "$PIP_SUDO pip uninstall -y apex"
         pdcp -w $hosts third_party/apex/dist/apex*.whl $tmp_wheel_path/
-        pdsh -w $hosts "$SUDO $PIP_INSTALL $tmp_wheel_path/apex*.whl"
+        pdsh -w $hosts "$PIP_SUDO $PIP_INSTALL $tmp_wheel_path/apex*.whl"
         pdsh -w $hosts 'python -c "import apex"'
     fi
     if [ "$deepspeed_install" == "1" ]; then
         echo "Installing deepspeed"
-        pdsh -w $hosts "$SUDO pip uninstall -y deepspeed"
+        pdsh -w $hosts "$PIP_SUDO pip uninstall -y deepspeed"
         pdcp -w $hosts dist/deepspeed*.whl $tmp_wheel_path/
-        pdsh -w $hosts "$SUDO $PIP_INSTALL $tmp_wheel_path/deepspeed*.whl"
+        pdsh -w $hosts "$PIP_SUDO $PIP_INSTALL $tmp_wheel_path/deepspeed*.whl"
         pdsh -w $hosts "python -c 'import deepspeed; print(\"deepspeed info:\", deepspeed.__version__, deepspeed.__git_branch__, deepspeed.__git_hash__)'"
         echo "Installation is successful"
     fi


### PR DESCRIPTION
Two CLI options are added to `install.sh`:

- `--no_sudo` runs all commands without `sudo`
- `--pip_mirror` allows the user to set the pip mirror

with these two options, user can install deepspeed to their conda environment.