### PR TITLE
removing duplicated CNAME

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
         exclude: "examples/"
     -   id: end-of-file-fixer
         exclude: "examples/"
+        exclude: "docs/CNAME"
 
 
 -   repo: https://github.com/pre-commit/mirrors-yapf

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.deepspeed.ai


### PR DESCRIPTION
GitHub created a CNAME for us automatically. Cool.