### PR TITLE
Fix incorrect tensorboard loss calculation

### DIFF
--- a/deepspeed/pt/deepspeed_light.py
+++ b/deepspeed/pt/deepspeed_light.py
@@ -630,8 +630,7 @@ class DeepSpeedLight(Module):
             self.summary_events = [
                 (f'Train/Samples/train_loss',
                  loss.mean().item(),
-                 self.sample_count)
-            ]
+                 self.sample_count)]            
             for event in self.summary_events:  # write_summary_events
                 self.summary_writer.add_scalar(event[0], event[1], event[2])
             self.summary_writer.flush()

--- a/deepspeed/pt/deepspeed_light.py
+++ b/deepspeed/pt/deepspeed_light.py
@@ -625,7 +625,7 @@ class DeepSpeedLight(Module):
                                   self.gradient_accumulation_steps())
             self.summary_events = [
                 (f'Train/Samples/train_loss',
-                 loss.mean().item() * self.gradient_accumulation_steps(),
+                 loss.mean().item(),
                  self.sample_count)
             ]
             for event in self.summary_events:  # write_summary_events


### PR DESCRIPTION
The loss is scaled by the gradient_accumulation_steps value unnecessarily. Probably a leftover from when gradient scaling was done in the backward pass?