### PR TITLE
Support multi-output models

### DIFF
--- a/tests/model/run_sanity_check.py
+++ b/tests/model/run_sanity_check.py
@@ -33,8 +33,8 @@ def test_run():
     runner = unittest.TextTestRunner(failfast=True)
 
     # Add test suites here.
-    #pytest_hack(runner.run(Megatron_GPT2.suite()))
-    #pytest_hack(runner.run(Megatron_GPT2.checkpoint_suite()))
+    pytest_hack(runner.run(Megatron_GPT2.suite()))
+    pytest_hack(runner.run(Megatron_GPT2.checkpoint_suite()))
     pytest_hack(runner.run(BingBertSquad.suite()))
 
 

--- a/tests/unit/multi_output_model.py
+++ b/tests/unit/multi_output_model.py
@@ -20,17 +20,13 @@ class MultiOutputModel(torch.nn.Module):
         return tuple(losses)
 
 
-def multi_output_dataloader(model,
-                            total_samples,
-                            hidden_dim,
-                            device,
-                            inputs,
-                            targets):
+def multi_output_dataloader(model, total_samples, hidden_dim, device, inputs, targets):
     assert len(inputs) == len(targets)
     batch_size = model.train_micro_batch_size_per_gpu()
 
     train_data = [
-        torch.full(size=(total_samples, hidden_dim),
+        torch.full(size=(total_samples,
+                         hidden_dim),
                    fill_value=x,
                    device=device,
                    dtype=torch.half,
@@ -39,11 +35,10 @@ def multi_output_dataloader(model,
 
     train_label = [
         torch.empty(total_samples,
-                   device=device,
-                   dtype=torch.long).fill_(y) for y in targets
+                    device=device,
+                    dtype=torch.long).fill_(y) for y in targets
     ]
 
     train_dataset = torch.utils.data.TensorDataset(*train_data, *train_label)
     train_loader = torch.utils.data.DataLoader(train_dataset, batch_size=batch_size)
     return train_loader
-

--- a/tests/unit/multi_output_model.py
+++ b/tests/unit/multi_output_model.py
@@ -1,0 +1,53 @@
+import os
+import json
+import argparse
+import torch
+
+
+class MultiOutputModel(torch.nn.Module):
+    def __init__(self, hidden_dim, num_output=2):
+        super(MultiOutputModel, self).__init__()
+        self.linear = torch.nn.Linear(hidden_dim, hidden_dim)
+        self.num_output = num_output
+        self.cross_entropy_loss = torch.nn.CrossEntropyLoss()
+
+    def forward(self, inputs, labels):
+        losses = []
+        for x, y in zip(inputs, labels):
+            hidden_dim = self.linear(x)
+            losses.append(self.cross_entropy_loss(hidden_dim, y))
+        return losses
+
+
+def random_dataloader(model, total_samples, hidden_dim, device):
+    batch_size = model.train_micro_batch_size_per_gpu()
+
+    train_data = [torch.randn(total_samples,
+                              hidden_dim,
+                              device=device,
+                              dtype=torch.half) for _ in range(model.num_outputs)]
+
+    train_label = [torch.empty(total_samples,
+                              dtype=torch.long,
+                              device=device).random_(hidden_dim) for _ in range(model.num_output)]
+
+    train_dataset = torch.utils.data.TensorDataset(*train_data, *train_label)
+    train_loader = torch.utils.data.DataLoader(train_dataset, batch_size=batch_size)
+    return train_loader
+
+
+def create_config_from_dict(tmpdir, config_dict):
+    config_path = os.path.join(tmpdir, 'temp_config.json')
+    with open(config_path, 'w') as fd:
+        json.dump(config_dict, fd)
+    return config_path
+
+
+def args_from_dict(tmpdir, config_dict):
+    config_path = create_config_from_dict(tmpdir, config_dict)
+    parser = argparse.ArgumentParser()
+    args = parser.parse_args(args='')
+    args.deepspeed = True
+    args.deepspeed_config = config_path
+    args.local_rank = 0
+    return args

--- a/tests/unit/test_multi_output_model.py
+++ b/tests/unit/test_multi_output_model.py
@@ -1,0 +1,135 @@
+import torch
+import deepspeed
+import argparse
+import pytest
+from pytest import approx
+import json
+import os
+from common import distributed_test
+from simple_model import args_from_dict
+from multi_output_model import MultiOutputModel, multi_output_dataloader
+
+def create_config_dict(micro_batch_size, grad_accumulation_steps, world_size):
+    return {
+        "train_micro_batch_size_per_gpu": micro_batch_size,
+        "gradient_accumulation_steps": grad_accumulation_steps,
+        "train_batch_size": micro_batch_size * grad_accumulation_steps * world_size,
+        "steps_per_print": 1,
+            "optimizer": {
+            "type": "Adam",
+            "params": {
+                "lr": 0.00015
+            }
+        },
+            "fp16": {
+            "enabled": True
+        }
+}
+
+def test_two_output_model(tmpdir):
+    gradient_accumulation_steps = 2
+    micro_batch_size = 1
+    world_size = 1
+    config_dict = create_config_dict(micro_batch_size,
+                                     gradient_accumulation_steps,
+                                     world_size)
+
+    hidden_dim = 10
+    weight_value = 0.1
+    args = args_from_dict(tmpdir, config_dict)
+
+    model = MultiOutputModel(hidden_dim, weight_value)
+
+    @distributed_test(world_size=[1])
+    def _test_two_output_model(args, model, hidden_dim):
+        model, _, _, _ = deepspeed.initialize(args=args,
+                                              model=model,
+                                              model_parameters=model.parameters())
+        total_samples = 4
+        data_loader = multi_output_dataloader(model=model,
+                                            total_samples=total_samples,
+                                            hidden_dim=hidden_dim,
+                                            device=model.device,
+                                            inputs=[1.0, 2.0],
+                                            targets=[1, 2])
+        for n, batch in enumerate(data_loader):
+            assert len(batch) % 2 == 0, \
+                 f"multi_output_dataloader failed to return even number of data samples (input+target)"
+
+            midpoint = len(batch) // 2
+            inputs, targets = batch[:midpoint],  batch[midpoint:]
+            loss_tuple = model(inputs, targets)
+
+            expected_loss = torch.tensor(2.302734375,
+                                         dtype=torch.half,
+                                         device=model.device)
+            for loss in loss_tuple:
+                assert loss.shape == torch.Size([])
+                assert loss.item() == approx(expected_loss.item())
+
+            summed_loss =  sum(loss_tuple)
+            scaled_loss = model.backward(summed_loss)
+            expected_scaled_loss = summed_loss / gradient_accumulation_steps
+            assert scaled_loss.item() == approx(expected_scaled_loss.item())
+
+            model.step()
+
+    _test_two_output_model(args=args,
+                            model=model,
+                            hidden_dim=hidden_dim)
+
+
+def test_three_output_model(tmpdir):
+    gradient_accumulation_steps = 3
+    micro_batch_size = 1
+    world_size = 1
+    config_dict = create_config_dict(micro_batch_size,
+                                     gradient_accumulation_steps,
+                                     world_size)
+
+    hidden_dim = 10
+    weight_value = 0.1
+    args = args_from_dict(tmpdir, config_dict)
+
+    model = MultiOutputModel(hidden_dim, weight_value)
+
+    @distributed_test(world_size=[1])
+    def _test_three_output_model(args, model, hidden_dim):
+        model, _, _, _ = deepspeed.initialize(args=args,
+                                              model=model,
+                                              model_parameters=model.parameters())
+
+        total_samples = gradient_accumulation_steps * micro_batch_size * 2
+        data_loader = multi_output_dataloader(model=model,
+                                            total_samples=total_samples,
+                                            hidden_dim=hidden_dim,
+                                            device=model.device,
+                                            inputs=[1.0, 2.0, 3.0],
+                                            targets=[1, 2, 3])
+        for n, batch in enumerate(data_loader):
+            assert len(batch) % 2 == 0, \
+                 f"multi_output_dataloader failed to return even number of data samples (input+target)"
+
+            midpoint = len(batch) // 2
+            inputs, targets = batch[:midpoint],  batch[midpoint:]
+            loss_tuple = model(inputs, targets)
+            assert len(loss_tuple) == 3
+
+            expected_loss = torch.tensor(2.302734375,
+                                         dtype=torch.half,
+                                         device=model.device)
+
+            for loss in loss_tuple:
+                assert loss.shape == torch.Size([])
+                assert loss.item() == approx(expected_loss.item())
+
+            summed_loss = sum(loss_tuple)
+            scaled_loss = model.backward(summed_loss)
+            expected_scaled_loss = summed_loss / gradient_accumulation_steps
+            assert scaled_loss.item() == approx(expected_scaled_loss.item())
+
+            model.step()
+
+    _test_three_output_model(args=args,
+                            model=model,
+                            hidden_dim=hidden_dim)

--- a/tests/unit/test_multi_output_model.py
+++ b/tests/unit/test_multi_output_model.py
@@ -137,3 +137,4 @@ def test_three_output_model(tmpdir):
             model.step()
 
     _test_three_output_model(args=args, model=model, hidden_dim=hidden_dim)
+

--- a/tests/unit/test_multi_output_model.py
+++ b/tests/unit/test_multi_output_model.py
@@ -137,4 +137,3 @@ def test_three_output_model(tmpdir):
             model.step()
 
     _test_three_output_model(args=args, model=model, hidden_dim=hidden_dim)
-


### PR DESCRIPTION
Correctly handle multi-output models by performing loss scaling in backward() instead of forward()