### PR TITLE
Fix ThroughputTimer with hybrid parallelism.

### DIFF
--- a/deepspeed/pt/deepspeed_light.py
+++ b/deepspeed/pt/deepspeed_light.py
@@ -142,17 +142,17 @@ class DeepSpeedLight(Module):
 
         self._init_distributed(dist_init_required)
 
+        # Configure distributed model
+        self._configure_distributed_model(model)
+
         # Throughput timer
         self.tput_timer = ThroughputTimer(
             batch_size=self.train_micro_batch_size_per_gpu(),
-            num_workers=self.world_size,
+            num_workers=self.dp_world_size,
             monitor_memory=False)
 
         self.training_dataloader = self.deepspeed_io(
             training_data) if training_data else None
-
-        # Configure distributed model
-        self._configure_distributed_model(model)
 
         # Configure optimizer and scheduler
         self.optimizer = None


### PR DESCRIPTION
`ThroughputTimer` computes the number of samples as `batch_size * num_workers`. The global world size will cause the timer to over-count samples if model parallelism is used, and so we should use `self.dp_world_size` in case `mpu` was supplied.