### PR TITLE
Update deepspeed_light.py

### DIFF
--- a/deepspeed/pt/deepspeed_light.py
+++ b/deepspeed/pt/deepspeed_light.py
@@ -840,6 +840,7 @@ class DeepSpeedLight(Module):
             if numel > numel_per_bucket:
                 self.allreduce_and_copy(small_bucket)
                 small_bucket = []
+                numel = 0
         if len(small_bucket) > 0:
             self.allreduce_and_copy(small_bucket)
 


### PR DESCRIPTION
The numel in allreduce was not being reset after allreduce bucket was full causing each parameter to be allreduced one at a time. While correct, the performance was significantly impacted.