### PR TITLE
Test matrix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,10 +35,10 @@ jobs:
   - script: |
       conda create --force --yes -n $(conda_env) python=$(python.version) cudatoolkit=$(cuda.version)
       source $(conda_root)/bin/activate $(conda_env_path)
-      conda install --yes conda
-      conda install --yes -c conda-forge cudatoolkit-dev=$(cuda.version)
-      conda install --yes gxx_linux-64
       conda install --yes -c pytorch pytorch=$(pytorch.version) cudatoolkit=$(cuda.version)
+      conda install --yes conda
+      conda install --yes gxx_linux-64
+      conda install --yes -c conda-forge cudatoolkit-dev=$(cuda.version)
     displayName: 'Setup environment python=$(python.version) pytorch=$(pytorch.version) cuda=$(cuda.version)'
 
   - script: |
@@ -51,8 +51,8 @@ jobs:
   - script: |
       source $(conda_root)/bin/activate $(conda_env_path)
       ./install.sh
-    env:
-      CUDA_HOME: $(conda_env_path)/pkgs/cudatoolkit-dev
+    #env:
+    #  #CUDA_HOME: $(conda_env_path)/pkgs/cudatoolkit-dev
     displayName: 'Install DeepSpeed'
 
   - script: |
@@ -75,7 +75,7 @@ jobs:
       targetPath: '$(Build.SourcesDirectory)/tests/model/BingBertSquad/test/'
       artifactName: BingBertSquad_logs
     displayName: 'BingBertSquad log uploads'
-    condition: always()
+    condition: eq(variables['runmodeltests'], true)
 
 
 - job: Code_Checks

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,16 +12,11 @@ jobs:
         cuda.version: '10.0'
         pytorch.version: '1.2'
         runmodeltests: false
-      PyTorch13:
-        python.version: '3.7'
-        cuda.version: '10.1'
-        pytorch.version: '1.3'
-        runmodeltests: false
       PyTorch15:
         python.version: '3.7'
         cuda.version: '10.1'
         pytorch.version: '1.5'
-        runmodeltests: false
+        runmodeltests: true
 
   variables:
     conda_root: '/home/deepspeed/miniconda3'
@@ -46,7 +41,7 @@ jobs:
       python --version
       which nvcc
       nvcc --version
-      python -c "import torch; print(torch.__version__)"
+      python -c "import torch; print('torch:', torch.__version__)"
     displayName: 'Show environment'
 
   - script: |
@@ -56,8 +51,6 @@ jobs:
       rm -rf build/
       rm -rf dist/
       ./install.sh
-    #env:
-    #  #CUDA_HOME: $(conda_env_path)/pkgs/cudatoolkit-dev
     displayName: 'Install DeepSpeed'
 
   - script: |
@@ -68,7 +61,7 @@ jobs:
   - script: |
       source $(conda_root)/bin/activate $(conda_env_path)
       ln -s /data/Megatron-LM/data DeepSpeedExamples/Megatron-LM/
-      pip install --user -r DeepSpeedExamples/Megatron-LM/requirements.txt
+      pip install -r DeepSpeedExamples/Megatron-LM/requirements.txt
       cd tests/model/
       pytest -s run_sanity_check.py
     condition: eq(variables['runmodeltests'], true)
@@ -83,7 +76,7 @@ jobs:
     condition: eq(variables['runmodeltests'], true)
 
 
-- job: Code_Checks
+- job: Code_Quality_Checks
   pool:
     name: 'DS_testing'
   variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,13 @@ jobs:
 
   - script: |
       source $(conda_root)/bin/activate $(conda_env_path)
+      which nvcc
+      nvcc --version
+      python -c "import torch; print(torch.__version__)"
+    displayName: 'Show environment'
+
+  - script: |
+      source $(conda_root)/bin/activate $(conda_env_path)
       ./install.sh
     env:
       CUDA_HOME: $(conda_env_path)/pkgs/cudatoolkit-dev
@@ -59,6 +66,7 @@ jobs:
       pip install --user -r DeepSpeedExamples/Megatron-LM/requirements.txt
       cd tests/model/
       pytest -s run_sanity_check.py
+    condition: eq(variables['runmodeltests'], true)
     displayName: 'Model tests'
 
    #BingBertSquad logs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
         python.version: '3.7'
         cuda.version: '10.1'
         pytorch.version: '1.5'
-        runmodeltests: true
+        runmodeltests: false
 
   variables:
     conda_root: '/home/deepspeed/miniconda3'
@@ -43,6 +43,7 @@ jobs:
 
   - script: |
       source $(conda_root)/bin/activate $(conda_env_path)
+      python --version
       which nvcc
       nvcc --version
       python -c "import torch; print(torch.__version__)"
@@ -50,6 +51,10 @@ jobs:
 
   - script: |
       source $(conda_root)/bin/activate $(conda_env_path)
+      rm -rf third_party/apex/build/
+      rm -rf third_party/apex/dist/
+      rm -rf build/
+      rm -rf dist/
       ./install.sh
     #env:
     #  #CUDA_HOME: $(conda_env_path)/pkgs/cudatoolkit-dev

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,50 +1,60 @@
 
 jobs:
-- job: Default
+- job: DeepSpeed_Tests
   timeoutInMinutes: 360
   pool:
-    name: 'GPU_testing'
+    name: 'DS_testing'
 
   strategy:
     matrix:
-      Python36:
+      PyTorch12:
         python.version: '3.6'
-      #Python35:
-      #  python.version: '3.5'
-      #Python37:
-      #  python.version: '3.7'
-      #Python38:
-      #  python.version: '3.8'
+        cuda.version: '10.0'
+        pytorch.version: '1.2'
+        runmodeltests: false
+      PyTorch13:
+        python.version: '3.7'
+        cuda.version: '10.1'
+        pytorch.version: '1.3'
+        runmodeltests: false
+      PyTorch15:
+        python.version: '3.7'
+        cuda.version: '10.1'
+        pytorch.version: '1.5'
+        runmodeltests: true
 
+  variables:
+    conda_root: '/home/deepspeed/miniconda3'
+    conda_env: 'ds_test_py$(python.version)_cuda$(cuda.version)_pytorch$(pytorch.version)'
+    conda_env_path: '$(conda_root)/envs/$(conda_env)'
 
   steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '$(python.version)'
-      addToPath: true
-      architecture: 'x64'
-    displayName: 'Use Python $(python.version)'
+    # Unfortunately nvidia's nvcc_linux-64=<version> seems to install 10.1 regardless?
+    # Most of this complexity is a workaround to get the compiler toolchain to match the
+    # cudatoolkit runtime
+  - script: |
+      conda create --force --yes -n $(conda_env) python=$(python.version) cudatoolkit=$(cuda.version)
+      source $(conda_root)/bin/activate $(conda_env_path)
+      conda install --yes conda
+      conda install --yes -c conda-forge cudatoolkit-dev=$(cuda.version)
+      conda install --yes gxx_linux-64
+      conda install --yes -c pytorch pytorch=$(pytorch.version) cudatoolkit=$(cuda.version)
+    displayName: 'Setup environment python=$(python.version) pytorch=$(pytorch.version) cuda=$(cuda.version)'
 
   - script: |
-      python -m pip install --upgrade pip
-      pip install --user -r requirements.txt
-      ./install.sh --pip_sudo
-    displayName: 'Install dependencies'
+      source $(conda_root)/bin/activate $(conda_env_path)
+      ./install.sh
+    env:
+      CUDA_HOME: $(conda_env_path)/pkgs/cudatoolkit-dev
+    displayName: 'Install DeepSpeed'
 
   - script: |
-      pre-commit run --all-files
-    displayName: 'Formatting checks'
-
-  - script: |
-      pip install --user pylint
-      pylint --exit-zero deepspeed/
-    displayName: 'Code linter'
-
-  - script: |
+      source $(conda_root)/bin/activate $(conda_env_path)
       pytest --forked --verbose tests/unit/
     displayName: 'Unit tests'
 
   - script: |
+      source $(conda_root)/bin/activate $(conda_env_path)
       ln -s /data/Megatron-LM/data DeepSpeedExamples/Megatron-LM/
       pip install --user -r DeepSpeedExamples/Megatron-LM/requirements.txt
       cd tests/model/
@@ -59,33 +69,27 @@ jobs:
     displayName: 'BingBertSquad log uploads'
     condition: always()
 
-  # Megatron test logs
-  #- task: PublishPipelineArtifact@1
-  #  inputs:
-  #    targetPath: '$(Build.SourcesDirectory)/tests/model/Megatron_GPT2/test/'
-  #    artifactName: Megatron_GPT2_logs
-  #  displayName: 'Megatron GPT2 log uploads'
-  #  condition: always()
 
-  #- task: PublishPipelineArtifact@1
-  #  inputs:
-  #    targetPath: '$(Build.SourcesDirectory)/tests/model/Megatron_GPT2/checkpoint_test_logs/'
-  #    artifactName: Megatron_GPT2_checkpoint_logs
-  #  displayName: 'Megatron GPT2 checkpoint log uploads'
-  #  condition: always()
+- job: Code_Checks
+  variables:
+    conda_root: '/home/deepspeed/miniconda3'
+    conda_env: 'ds_codetest'
+    conda_env_path: '$(conda_root)/envs/$(conda_env)'
 
+  steps:
+  - script: |
+      conda create --force --yes -n $(conda_env) python=3.7
+      source $(conda_root)/bin/activate $(conda_env_path)
+    displayName: 'Create code test environment'
 
-  #BingBert logs
-  #- task: PublishPipelineArtifact@1
-  #  inputs:
-  #    targetPath: '$(Build.SourcesDirectory)/tests/model/bing_bert/pretrain_test/'
-  #    artifactName: BingBert_pretrain_logs
-  #  displayName: 'BingBert pretrain logs'
-  #  condition: always()
+  - script: |
+      source $(conda_root)/bin/activate $(conda_env_path)
+      pip install pre-commit
+      pre-commit run --all-files
+    displayName: 'Formatting checks'
 
-  #- task: PublishPipelineArtifact@1
-  #  inputs:
-  #    targetPath: '$(Build.SourcesDirectory)/tests/model/bing_bert/checkpoint_test_logs/'
-  #    artifactName: BingBert_checkpoint_logs
-  #  displayName: 'BingBert checkpoint logs'
-  #  condition: always()
+  - script: |
+      source $(conda_root)/bin/activate $(conda_env_path)
+      pip install pylint
+      pylint --exit-zero deepspeed/
+    displayName: 'Code linter'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,6 +71,8 @@ jobs:
 
 
 - job: Code_Checks
+  pool:
+    name: 'DS_testing'
   variables:
     conda_root: '/home/deepspeed/miniconda3'
     conda_env: 'ds_codetest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,8 @@ jobs:
       ln -s /data/Megatron-LM/data DeepSpeedExamples/Megatron-LM/
       pip install -r DeepSpeedExamples/Megatron-LM/requirements.txt
       cd tests/model/
+      rm -rf BingBertSquad/baseline
+      rm -rf Megatron_GPT2/baseline
       pytest -s run_sanity_check.py
     condition: eq(variables['runmodeltests'], true)
     displayName: 'Model tests'


### PR DESCRIPTION
This is a near rewrite of our testing configuration. We now use conda to matrix tests against various PyTorch and CUDA versions. The new configuration: runs unit tests with:

1. python=3.6, torch=1.2, cudatoolkit=10.0
2. python=3.7, torch=1.5, cudatoolkit=10.1

The more expensive model tests are only run on the second configuration. We can next extend our configuration to do nightly builds and include torch=1.3 and 1.4 and to also run model tests for all configurations. We should also include cudatoolkit=10.2 soon.

 