### PR TITLE
Modify deepspeed_lr_schedules

### DIFF
--- a/deepspeed/pt/args.py
+++ b/deepspeed/pt/args.py
@@ -1,0 +1,115 @@
+"""
+Argument definitions for deepspeed
+"""
+
+import argparse
+
+from deepspeed.pt.log_utils import logger
+
+
+def _add_lr_scheduler(parser):
+    group = parser.add_argument_group(title="LR Scheduler")
+    group.add_argument("--lr_schedule", help="LR schedule for training")
+    group.add_argument("--lr_range_test_min_lr",
+                       type=float,
+                       default=0.001,
+                       help="Staring lr value")
+    group.add_argument("--lr_range_test_step_rate",
+                       type=float,
+                       default=1.0,
+                       help="Scaling rate for LR range test")
+    group.add_argument("--lr_range_test_step_size",
+                       type=int,
+                       default=1000,
+                       help="Training steps per LR change")
+    group.add_argument("--lr_range_test_staircase",
+                       action="store_true",
+                       help="Use staircase scaling for LR range test")
+
+
+def _add_one_cycle_scheduler(parser):
+    group = parser.add_argument_group(title="One Cycle")
+    group.add_argument("--cycle_first_step_size",
+                       type=int,
+                       default=1000,
+                       help="Size of first step of 1Cycle schedule (training steps).")
+    group.add_argument("--cycle_first_stair_count",
+                       type=int,
+                       default=1,
+                       help="First stair count for 1Cycle schedule.")
+    group.add_argument("--second_stair_count",
+                       type=int,
+                       default=1,
+                       help="Second stair count for 1Cycle schedule.")
+    group.add_argument(
+        "--decay_step_size",
+        type=int,
+        default=100,
+        help="Size of intervals for applying post cycle decay (training steps).")
+
+    # 1Cycle LR
+    group.add_argument("--cycle_min_lr",
+                       type=float,
+                       default=0.01,
+                       help="1Cycle LR lower bound.")
+    group.add_argument("--cycle_max_lr",
+                       type=float,
+                       default=0.1,
+                       help="1Cycle upper bound.")
+    group.add_argument("--decay_lr_rate",
+                       type=float,
+                       default=0.0,
+                       help="Post cycle LR decay rate")
+
+    # 1Cycle Momentum
+    group.add_argument("--cycle_momentum",
+                       action="store_true",
+                       help="Enable 1Cycle momentum schedule.")
+    group.add_argument("--cycle_min_mom",
+                       type=float,
+                       default=0.8,
+                       help="1Cycle momentum lower bound")
+    group.add_argument("--cycle_max_mom",
+                       type=float,
+                       default=0.9,
+                       help="1Cycle momentum upper bound")
+    group.add_argument("--decay_mom_rate",
+                       type=float,
+                       default=0.0,
+                       help="Pos cycle momentum decay rate")
+
+
+def _add_warmup_lr(parser):
+    group = parser.add_argument_group(title="Warmup LR")
+    group.add_argument("--warmup_min_lr",
+                       type=float,
+                       default=0,
+                       help="WarmupLR minimum/initial LR value")
+    group.add_argument("--warmup_max_lr",
+                       type=float,
+                       default=0.001,
+                       help="WarmupLR maximum LR value.")
+    group.add_argument("--warmup_num_steps",
+                       type=int,
+                       default=1000,
+                       help="WarmupLR step count for LR warmup.")
+
+
+def create_lr_tuning_parser(parser=None):
+    """Create learning related parser"""
+    parser = parser or argparse.ArgumentParser(description="tuning parser arguments")
+
+    _add_lr_scheduler(parser)
+    _add_one_cycle_scheduler(parser)
+    _add_warmup_lr(parser)
+
+    return parser
+
+
+def parse_lr_tuning_args(args=None):
+    """Paring arguments for lr tuning"""
+    parser = create_lr_tuning_parser()
+    args, _ = parser.parse_known_args(args=args)
+    if _:
+        logger.warning("Unknown args for lr tuning: %s", _)
+    return args, _

--- a/deepspeed/pt/deepspeed_constants.py
+++ b/deepspeed/pt/deepspeed_constants.py
@@ -291,7 +291,7 @@ class LRScheduleConstants:
     LR_RANGE_TEST = Constant("LRRangeTest")
     ONE_CYCLE = Constant("OneCycle")
     WARMUP_LR = Constant("WarmupLR")
-    VALID_LR_SCHEDULES = [LR_RANGE_TEST, ONE_CYCLE, WARMUP_LR]
+    VALID_LR_SCHEDULES = [LR_RANGE_TEST.name, ONE_CYCLE.name, WARMUP_LR.name]
 
     LR_RANGE_TEST_MIN_LR = Constant("lr_range_test_min_lr")
     LR_RANGE_TEST_STEP_RATE = Constant("lr_range_test_step_rate")

--- a/deepspeed/pt/deepspeed_constants.py
+++ b/deepspeed/pt/deepspeed_constants.py
@@ -266,3 +266,55 @@ TENSORBOARD_OUTPUT_PATH_DEFAULT = ""
 # Tensorboard job name
 TENSORBOARD_JOB_NAME = "job_name"
 TENSORBOARD_JOB_NAME_DEFAULT = "DeepSpeedJobName"
+
+# TODO Refact above constants
+
+
+class Constant:
+    """A single constant"""
+    def __init__(self, name, default=None):
+        self._name = name
+        self._default = default
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def default(self):
+        return self._default
+
+
+class LRScheduleConstants:
+    """Learning relate constants"""
+    LR_SCHEDULE = Constant("lr_schedule")
+    LR_RANGE_TEST = Constant("LRRangeTest")
+    ONE_CYCLE = Constant("OneCycle")
+    WARMUP_LR = Constant("WarmupLR")
+    VALID_LR_SCHEDULES = [LR_RANGE_TEST, ONE_CYCLE, WARMUP_LR]
+
+    LR_RANGE_TEST_MIN_LR = Constant("lr_range_test_min_lr")
+    LR_RANGE_TEST_STEP_RATE = Constant("lr_range_test_step_rate")
+    LR_RANGE_TEST_STEP_SIZE = Constant("lr_range_test_step_size")
+    LR_RANGE_TEST_STAIRCASE = Constant("lr_range_test_staircase")
+
+    EDGE_VALUE = Constant("edge_value")
+    MID_VALUE = Constant("mid_value")
+
+    CYCLE_FIRST_STEP_SIZE = Constant("cycle_first_step_size")
+    CYCLE_FIRST_STAIR_COUNT = Constant("cycle_first_stair_count")
+    CYCLE_SECOND_STEP_SIZE = Constant("cycle_second_step_size")
+    CYCLE_SECOND_STAIR_COUNT = Constant("cycle_second_stair_count")
+    DECAY_STEP_SIZE = Constant("decay_step_size")
+
+    CYCLE_MIN_LR = Constant("cycle_min_lr")
+    CYCLE_MAX_LR = Constant("cycle_max_lr")
+    DECAY_LR_RATE = Constant("decay_lr_rate")
+
+    CYCLE_MIN_MOM = Constant("cycle_min_mom")
+    CYCLE_MAX_MOM = Constant("cycle_max_mom")
+    DECAY_MOM_RATE = Constant("decay_mom_rate")
+
+    WARMUP_MIN_LR = Constant("warmup_min_lr")
+    WARMUP_MAX_LR = Constant("warmup_max_lr")
+    WARMUP_NUM_STEPS = Constant("warmup_num_steps")

--- a/deepspeed/pt/deepspeed_lr_schedules.py
+++ b/deepspeed/pt/deepspeed_lr_schedules.py
@@ -87,7 +87,7 @@ def get_config_from_args(args):
     if getattr(args, LRScheduleConstants.LR_SCHEDULE.name, None) is None:
         return None, '--{} not specified on command line'.format(LRScheduleConstants.LR_SCHEDULE.name)
 
-    if not args.lr_schedule in LRScheduleConstants.VALID_LR_SCHEDULES:
+    if args.lr_schedule not in LRScheduleConstants.VALID_LR_SCHEDULES:
         return None, '{} is not supported LR schedule'.format(args.lr_schedule)
 
     config = {}
@@ -105,16 +105,16 @@ def get_config_from_args(args):
 
 
 def get_lr_from_config(config):
-    if not 'type' in config:
+    if 'type' not in config:
         return None, 'LR schedule type not defined in config'
 
-    if not 'params' in config:
+    if 'params' not in config:
         return None, 'LR schedule params not defined in config'
 
     lr_schedule = config['type']
     lr_params = config['params']
 
-    if not lr_schedule in LRScheduleConstants.VALID_LR_SCHEDULES:
+    if lr_schedule not in LRScheduleConstants.VALID_LR_SCHEDULES:
         return None, '{} is not a valid LR schedule'.format(lr_schedule)
 
     if lr_schedule == LRScheduleConstants.LR_RANGE_TEST.name:


### PR DESCRIPTION
+ Add `args` module to store all parser needed by deepspeed
  + Still exists other work to achieve this target: arguments in deepspeed_run/deepspeed_launch
+ move constants to constants module
  + Move constants to a central place for easy reference and management
+ clean up duplicate code