### PR TITLE
Fix nv_peer_mem version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,16 +70,19 @@ RUN cd ${STAGE_DIR} && \
 ##############################################################################
 # nv_peer_mem
 ##############################################################################
+ENV NV_PEER_MEM_VERSION=1.1
+ENV NV_PEER_MEM_TAG=1.1-0
 RUN mkdir -p ${STAGE_DIR} && \
-    git clone https://github.com/Mellanox/nv_peer_memory.git ${STAGE_DIR}/nv_peer_memory && \
+    git clone https://github.com/Mellanox/nv_peer_memory.git --branch ${NV_PEER_MEM_TAG} ${STAGE_DIR}/nv_peer_memory && \
     cd ${STAGE_DIR}/nv_peer_memory && \
     ./build_module.sh && \
     cd ${STAGE_DIR} && \
-    tar xzf ${STAGE_DIR}/nvidia-peer-memory_1.0.orig.tar.gz && \
-    cd ${STAGE_DIR}/nvidia-peer-memory-1.0 && \
+    tar xzf ${STAGE_DIR}/nvidia-peer-memory_${NV_PEER_MEM_VERSION}.orig.tar.gz && \
+    cd ${STAGE_DIR}/nvidia-peer-memory-${NV_PEER_MEM_VERSION} && \
+    apt-get update && \
     apt-get install -y dkms && \
     dpkg-buildpackage -us -uc && \
-    dpkg -i ${STAGE_DIR}/nvidia-peer-memory_1.0-9_all.deb
+    dpkg -i ${STAGE_DIR}/nvidia-peer-memory_${NV_PEER_MEM_TAG}_all.deb
 
 ##############################################################################
 ## Ucomment and set SSH Daemon port

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 torch>=1.2
 torchvision>=0.4.0
-pillow==6.2.2
 tqdm
 psutil
 tensorboardX==1.8


### PR DESCRIPTION
1) Fix nv_peer_mem version, we didn't previously specify a version which broke our build
2) fix security issue, remove pillow dependency (this is only needed for cifar example which has its own requirements.txt)