### PR TITLE
Update deepspeed_lr_schedules.py

### DIFF
--- a/deepspeed/pt/deepspeed_lr_schedules.py
+++ b/deepspeed/pt/deepspeed_lr_schedules.py
@@ -679,7 +679,7 @@ class WarmupLR(object):
         if self.last_batch_iteration < 0:
             logger.warning(
                 "Attempting to get learning rate from scheduler before it has started")
-            return 0.0
+            return [0.0]
         gamma = self._get_gamma()
         return [
             min_lr + (delta_lr * gamma) for min_lr,


### PR DESCRIPTION
get_lr() should return a list not a single float, fixes this issue