### PR TITLE
Update fan out flag for pdsh

### DIFF
--- a/deepspeed/pt/deepspeed_run.py
+++ b/deepspeed/pt/deepspeed_run.py
@@ -23,6 +23,7 @@ DEEPSPEED_ENVIRONMENT_NAME = ".deepspeed_env"
 DEEPSPEED_ENVIRONMENT_PATHS = [os.path.expanduser("~"), '.']
 PDSH_MAX_FAN_OUT = 1024
 
+
 def parse_args(args=None):
     parser = argparse.ArgumentParser(
         description="DeepSpeed runner to help launch distributed "

--- a/deepspeed/pt/deepspeed_run.py
+++ b/deepspeed/pt/deepspeed_run.py
@@ -295,6 +295,8 @@ def main(args=None):
         active_workers = ",".join(active_resources.keys())
         logger.info("Running on the following workers: %s" % active_workers)
 
+        # PDSH flags for max node fan out and specific hosts to launch on
+        # See https://linux.die.net/man/1/pdsh for flag details
         pdsh_cmd_args = ['pdsh', '-f', str(PDSH_MAX_FAN_OUT), '-w', active_workers]
 
         num_nodes = len(active_resources.keys())

--- a/deepspeed/pt/deepspeed_run.py
+++ b/deepspeed/pt/deepspeed_run.py
@@ -21,7 +21,7 @@ DLTS_HOSTFILE = "/job/hostfile"
 EXPORT_ENVS = ["NCCL", "PYTHON"]
 DEEPSPEED_ENVIRONMENT_NAME = ".deepspeed_env"
 DEEPSPEED_ENVIRONMENT_PATHS = [os.path.expanduser("~"), '.']
-
+PDSH_MAX_FAN_OUT = 1024
 
 def parse_args(args=None):
     parser = argparse.ArgumentParser(
@@ -294,7 +294,7 @@ def main(args=None):
         active_workers = ",".join(active_resources.keys())
         logger.info("Running on the following workers: %s" % active_workers)
 
-        pdsh_cmd_args = ['pdsh', '-w', active_workers]
+        pdsh_cmd_args = ['pdsh', '-f', str(PDSH_MAX_FAN_OUT), '-w', active_workers]
 
         num_nodes = len(active_resources.keys())
         num_gpus_per_node = None


### PR DESCRIPTION
The default max fan out of pdsh is 32 nodes, we've run into this in the past and manually patched but never propagated to the repo. In the future when supporting different launcher backends we will have support for passing launcher args which would help improve this. However, currently this flag is hardcoded which is not ideal.