### PR TITLE
Use parentesis around min and max to enable Windows build

### DIFF
--- a/csrc/includes/context.h
+++ b/csrc/includes/context.h
@@ -33,8 +33,8 @@
 
 inline int DS_GET_BLOCKS(const int N)
 {
-    return std::max(
-        std::min((N + DS_CUDA_NUM_THREADS - 1) / DS_CUDA_NUM_THREADS, DS_MAXIMUM_NUM_BLOCKS),
+    return (std::max)(
+        (std::min)((N + DS_CUDA_NUM_THREADS - 1) / DS_CUDA_NUM_THREADS, DS_MAXIMUM_NUM_BLOCKS),
         // Use at least 1 block, since CUDA does not allow empty block
         1);
 }

--- a/csrc/includes/gemm_test.h
+++ b/csrc/includes/gemm_test.h
@@ -97,7 +97,7 @@ public:
     template <typename Func>
     int Run(int loops, Func f)
     {
-        float fast_latency = std::numeric_limits<float>::max();
+        float fast_latency = (std::numeric_limits<float>::max)();
         int fast_algo = 0;
 
         for (int algo = (int)CUBLAS_GEMM_DEFAULT_TENSOR_OP;
@@ -252,7 +252,7 @@ public:
     template <typename Func>
     int Run(int loops, Func f)
     {
-        float fast_latency = std::numeric_limits<float>::max();
+        float fast_latency = (std::numeric_limits<float>::max)();
         int fast_algo = 0;
 
         for (int algo = (int)CUBLAS_GEMM_DEFAULT_TENSOR_OP;

--- a/csrc/transformer/ds_transformer_cuda.cpp
+++ b/csrc/transformer/ds_transformer_cuda.cpp
@@ -27,7 +27,7 @@ size_t get_workspace_size(int maxBatchSize,
 {
     size_t workSpacesize = 4 * (size_t(maxBatchSize) * seq_len * hidden_size);
     if (training) {
-        workSpacesize += (std::max((size_t(maxBatchSize) * seq_len * intermediate_size),
+        workSpacesize += ((std::max)((size_t(maxBatchSize) * seq_len * intermediate_size),
                                    2 * (size_t(maxBatchSize) * heads * seq_len * seq_len)));
         if (gelu_checkpoint) workSpacesize += 2 * (size_t(maxBatchSize) * seq_len * hidden_size);
     }

--- a/csrc/transformer/ds_transformer_cuda.cpp
+++ b/csrc/transformer/ds_transformer_cuda.cpp
@@ -28,7 +28,7 @@ size_t get_workspace_size(int maxBatchSize,
     size_t workSpacesize = 4 * (size_t(maxBatchSize) * seq_len * hidden_size);
     if (training) {
         workSpacesize += ((std::max)((size_t(maxBatchSize) * seq_len * intermediate_size),
-                                   2 * (size_t(maxBatchSize) * heads * seq_len * seq_len)));
+                                     2 * (size_t(maxBatchSize) * heads * seq_len * seq_len)));
         if (gelu_checkpoint) workSpacesize += 2 * (size_t(maxBatchSize) * seq_len * hidden_size);
     }
     return workSpacesize * sizeof(T);


### PR DESCRIPTION
Hello,

Visual C++ defines min and max as macros somewhere in windows.h, and they interfere the use of standard functions min and max.

With those changes I was able to build transformers and sparse_attention on Python 3.8 with a standard Visual Studio Build Tools 2019. I´m still working on changes to setup.py to make it work out of box, but this will be another PR.