### PR TITLE
add adamW to CPU-ADAM implementation

### DIFF
--- a/csrc/includes/cpu_adam.h
+++ b/csrc/includes/cpu_adam.h
@@ -50,7 +50,8 @@ public:
                    float betta1 = 0.9,
                    float betta2 = 0.999,
                    float eps = 1e-8,
-                   float weight_decay = 0)
+                   float weight_decay = 0,
+                   bool adamw_mode = true)
         : _alpha(alpha),
           _betta1(betta1),
           _betta2(betta2),
@@ -58,7 +59,8 @@ public:
           _weight_decay(weight_decay),
           _betta1_t(1.0),
           _betta2_t(1.0),
-          _buf_index(false)
+          _buf_index(false),
+          _adamw_mode(adamw_mode)
     {
         cudaMallocHost((void**)_doubled_buffer, TILE * sizeof(float));
         cudaMallocHost((void**)(_doubled_buffer + 1), TILE * sizeof(float));
@@ -115,4 +117,5 @@ private:
 
     float* _doubled_buffer[2];
     bool _buf_index;
+    bool _adamw_mode;
 };

--- a/deepspeed/ops/adam/cpu_adam.py
+++ b/deepspeed/ops/adam/cpu_adam.py
@@ -16,7 +16,8 @@ class DeepSpeedCPUAdam(torch.optim.Optimizer):
                         0.999),
                  eps=1e-8,
                  weight_decay=0,
-                 amsgrad=False):
+                 amsgrad=False,
+                 adamw_mode=True):
 
         default_args = dict(lr=lr,
                             betas=betas,
@@ -30,7 +31,13 @@ class DeepSpeedCPUAdam(torch.optim.Optimizer):
 
         global ds_opt_adam
         ds_opt_adam = importlib.import_module('deepspeed.ops.adam.cpu_adam_op')
-        ds_opt_adam.create_adam(self.opt_id, lr, betas[0], betas[1], eps, weight_decay)
+        ds_opt_adam.create_adam(self.opt_id,
+                                lr,
+                                betas[0],
+                                betas[1],
+                                eps,
+                                weight_decay,
+                                adamw_mode)
 
     def __setstate__(self, state):
         super(DeepSpeedCPUAdam, self).__setstate__(state)


### PR DESCRIPTION
I modified DeepSpeed CPU-Adam implementation to add the Adam-W option. I also add a new parameter for DeepSpeedCPUAdam, called adamw_mode, which is set to true by default to fix the zero-offload convergence issue. This is also consistent with the apex fused-adam implementation.