### PR TITLE
ZeRO-1 tune max-elems + bug fix

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -659,7 +659,7 @@ class DeepSpeedEngine(Module):
     def _configure_zero_optimizer(self, optimizer):
         zero_stage = self.zero_optimization_stage()
         logger.info('Creating fp16 ZeRO stage {} optimizer'.format(zero_stage))
-
+        assert not self.allreduce_always_fp32(), "ZeRO does not support 'fp32_allreduce': true"
         if zero_stage == ZERO_OPTIMIZATION_OPTIMIZER_STATES:
             assert self.zero_reduce_scatter(), 'Stage 1 only supports reduce scatter mode'
             optimizer = FP16_DeepSpeedZeroOptimizer_Stage1(

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -79,7 +79,7 @@ class CheckOverflow(object):
                 for param in group:
                     params.append(param)
 
-        return self.has_overflow(params, raw_grad_tensors)
+        return self.has_overflow(params)
 
     # `params` is a list / generator of torch.Variable
     def has_overflow_serial(self, params):

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -67,13 +67,7 @@ class CheckOverflow(object):
 
         return bool(overflow)
 
-    def check(self, param_groups=None, raw_grad_tensors=False):
-
-        #TODO: what's the equivalent here? do we need this?
-        # for group in self.fp32_from_fp32_groups:
-        #     for param in group:
-        #         params.append(param)
-
+    def check(self, param_groups=None):
         params = []
         if param_groups is None:
             params = self.params
@@ -88,17 +82,14 @@ class CheckOverflow(object):
         return self.has_overflow(params, raw_grad_tensors)
 
     # `params` is a list / generator of torch.Variable
-    def has_overflow_serial(self, params, raw_grad_tensors=False):
+    def has_overflow_serial(self, params):
         for i, p in enumerate(params):
-            grad = p if raw_grad_tensors else p.grad
-            if grad is not None and self._has_inf_or_nan(grad.data, i):
+            if p.grad is not None and self._has_inf_or_nan(p.grad.data, i):
                 return True
         return False
 
-    def has_overflow(self, params, raw_grad_tensors=False):
-        # print(f'rank=[torch.distributed.get_rank()] CheckOverflow.check.has_overflow params={params}')
-        overflow = self.has_overflow_serial(params, raw_grad_tensors)
-        # print(f'rank=[torch.distributed.get_rank()] overflow={overflow}')
+    def has_overflow(self, params):
+        overflow = self.has_overflow_serial(params)
         # Since each model parallel GPU carries only part of the model,
         # make sure overflow flag is synced across all the model parallel GPUs
         overflow_gpu = torch.cuda.ByteTensor([overflow])

--- a/deepspeed/runtime/zero/stage1.py
+++ b/deepspeed/runtime/zero/stage1.py
@@ -328,7 +328,8 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
             log_dist(f'Using default max_elements_per_comm {max_elements_per_comm}',
                      ranks=[0])
             return max_elements_per_comm
-        padding_for_min_comm = math.ceil(num_elements / min_comm_intervals) - max_elements_per_comm
+        padding_for_min_comm = math.ceil(
+            num_elements / min_comm_intervals) - max_elements_per_comm
 
         # choose padding that uses least amount of overhead
         if padding_for_max_comm > padding_for_min_comm:

--- a/deepspeed/runtime/zero/stage1.py
+++ b/deepspeed/runtime/zero/stage1.py
@@ -330,13 +330,12 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
             log_dist(f'Using default max_elements_per_comm {max_elements_per_comm}',
                      ranks=[0])
             return max_elements_per_comm
-        padding_for_min_comm = math.ceil(
-            num_elements / min_comm_intervals) - max_elements_per_comm
+
+        padding_for_min_comm = math.ceil(num_elements / (dp * min_comm_intervals))
 
         # choose padding that uses least amount of overhead
         if padding_for_max_comm > padding_for_min_comm:
-            # add dp size to ensure we have enough padding to split partitions across all ranks
-            new_max_elements_per_comm = padding_for_min_comm + max_elements_per_comm + dp
+            new_max_elements_per_comm = padding_for_min_comm + max_elements_per_comm
             log_dist(
                 f'Updating max_elements_per_comm from {max_elements_per_comm} -> {new_max_elements_per_comm}',
                 ranks=[0])

--- a/deepspeed/runtime/zero/stage1.py
+++ b/deepspeed/runtime/zero/stage1.py
@@ -324,8 +324,11 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
 
         # if we use 1 less comm interval how much extra comm padding would be required
         min_comm_intervals = num_elements // max_elements_per_comm
-        padding_for_min_comm = math.ceil(
-            num_elements / min_comm_intervals) - max_elements_per_comm
+        if min_comm_intervals == 0:
+            log_dist(f'Using default max_elements_per_comm {max_elements_per_comm}',
+                     ranks=[0])
+            return max_elements_per_comm
+        padding_for_min_comm = math.ceil(num_elements / min_comm_intervals) - max_elements_per_comm
 
         # choose padding that uses least amount of overhead
         if padding_for_max_comm > padding_for_min_comm:

--- a/deepspeed/runtime/zero/stage1.py
+++ b/deepspeed/runtime/zero/stage1.py
@@ -890,7 +890,9 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
     # rank 0 = [sub_0_0, sub_0_1]
     # rank 1 = [sub_1_0, sub_1_1]
     # Merge to get [sub_0_0, sub_1_0, sub_0_1, sub_1_1] => original un-padded flattened tensor.
-    def _retrieve_group_sub_partition_weights(self, all_partition_fp32_weights, max_elems_per_comm):
+    def _retrieve_group_sub_partition_weights(self,
+                                              all_partition_fp32_weights,
+                                              max_elems_per_comm):
         num_partitions = len(all_partition_fp32_weights)
         num_comm_intervals = len(all_partition_fp32_weights[0])
         num_sub_partitions = num_partitions * num_comm_intervals

--- a/deepspeed/runtime/zero/stage1.py
+++ b/deepspeed/runtime/zero/stage1.py
@@ -194,6 +194,7 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
 
         # max elems per param group
         self.max_elems_per_comm = []
+        self.legacy_max_elements_per_comm = max_elements_per_comm
 
         # loop to deal with groups
         for i, param_group in enumerate(self.optimizer.param_groups):
@@ -857,6 +858,7 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
         state_dict['zero_stage'] = ZERO_OPTIMIZATION_OPTIMIZER_STATES
         state_dict['partition_count'] = self.partition_count
         state_dict['num_comm_intervals_per_group'] = self.num_comm_intervals_per_group
+        state_dict['max_elems_per_comm'] = self.max_elems_per_comm
 
         # Remove paddings for DP alignment to enable loading for other alignment values
         fp32_groups_without_padding = self._get_groups_without_padding(
@@ -888,7 +890,7 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
     # rank 0 = [sub_0_0, sub_0_1]
     # rank 1 = [sub_1_0, sub_1_1]
     # Merge to get [sub_0_0, sub_1_0, sub_0_1, sub_1_1] => original un-padded flattened tensor.
-    def _retrieve_group_sub_partition_weights(self, all_partition_fp32_weights):
+    def _retrieve_group_sub_partition_weights(self, all_partition_fp32_weights, max_elems_per_comm):
         num_partitions = len(all_partition_fp32_weights)
         num_comm_intervals = len(all_partition_fp32_weights[0])
         num_sub_partitions = num_partitions * num_comm_intervals
@@ -903,13 +905,13 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
         flat_merged_weights = flatten_dense_tensors_sub_partition_aligned(
             tensor_list=all_sub_partition_weights,
             dp=dist.get_world_size(group=self.dp_process_group),
-            max_elements_per_comm=self.max_elements_per_comm,
+            max_elements_per_comm=max_elems_per_comm,
             pg=self.dp_process_group)
 
         comm_partitions, dp_sub_partitions, element_intervals, sub_partition_size, num_comm_intervals = \
             self.get_data_parallel_sub_partitions(
                 tensor=flat_merged_weights,
-                max_elements_per_comm=self.max_elements_per_comm,
+                max_elements_per_comm=max_elems_per_comm,
                 world_size=dist.get_world_size(group=self.dp_process_group),
                 dp_process_group=self.dp_process_group
             )
@@ -928,8 +930,14 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
                 sd['local_sub_partitions_of_fp32_groups'][group_idx]
                 for sd in all_state_dict
             ]
+            if 'max_elems_per_comm' in all_state_dict[0]:
+                max_elems_per_comm = all_state_dict[0]['max_elems_per_comm'][group_idx]
+            else:
+                max_elems_per_comm = self.legacy_max_elements_per_comm
+
             sub_partition_weights = self._retrieve_group_sub_partition_weights(
-                all_partition_fp32_weights)
+                all_partition_fp32_weights,
+                max_elems_per_comm)
             sub_partition_of_fp32_groups.append(sub_partition_weights)
 
         for current_group, saved_group in zip(self.local_sub_partitions_of_fp32_groups, sub_partition_of_fp32_groups):
@@ -937,20 +945,23 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
                 current_sub_part.data.copy_(saved_sub_part.data)
 
     # Extract optimizer state for current partition from merged states of all partitions
-    def _partition_base_optimizer_state(self, state_key, all_partition_states):
+    def _partition_base_optimizer_state(self,
+                                        state_key,
+                                        all_partition_states,
+                                        max_elems_per_comm):
         partition_id = dist.get_rank(group=self.dp_process_group)
         alignment = dist.get_world_size(group=self.dp_process_group)
 
         flat_merged_partitions = flatten_dense_tensors_sub_partition_aligned(
             tensor_list=all_partition_states,
             dp=dist.get_world_size(group=self.dp_process_group),
-            max_elements_per_comm=self.max_elements_per_comm,
+            max_elements_per_comm=max_elems_per_comm,
             pg=self.dp_process_group)
 
         comm_partitions, dp_sub_partitions, element_intervals, sub_partition_size, num_comm_intervals = \
             self.get_data_parallel_sub_partitions(
                 tensor=flat_merged_partitions,
-                max_elements_per_comm=self.max_elements_per_comm,
+                max_elements_per_comm=max_elems_per_comm,
                 world_size=dist.get_world_size(group=self.dp_process_group),
                 dp_process_group=self.dp_process_group
             )
@@ -961,7 +972,7 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
     # 1) Merging state values across the previous partitioning.
     # 2) Repartition state values for the new partitioning
     # 3) Return state corresponding to local partition
-    def _retrieve_group_optimizer_states(self, all_partition_states):
+    def _retrieve_group_optimizer_states(self, all_partition_states, max_elems_per_comm):
         merged_optimizer_states = {}
         num_partitions = len(all_partition_states)
         num_comm_intervals = len(all_partition_states[0])
@@ -980,7 +991,8 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
         for key, value in merged_optimizer_states.items():
             group_optimizer_states[key] = self._partition_base_optimizer_state(
                 key,
-                value)
+                value,
+                max_elems_per_comm)
 
         return group_optimizer_states
 
@@ -994,8 +1006,13 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
             all_partition_group_states = [
                 sd['base_optimizer_state'][group_idx] for sd in state_dict_list
             ]
+            if 'max_elems_per_comm' in state_dict_list[0]:
+                max_elems_per_comm = state_dict_list[0]['max_elems_per_comm'][group_idx]
+            else:
+                max_elems_per_comm = self.legacy_max_elements_per_comm
             group_optimizer_states = self._retrieve_group_optimizer_states(
-                all_partition_group_states)
+                all_partition_group_states,
+                max_elems_per_comm)
             base_optimizer_group_states.append(group_optimizer_states)
 
         for group_idx, group in enumerate(self.optimizer.param_groups):

--- a/deepspeed/runtime/zero/stage1.py
+++ b/deepspeed/runtime/zero/stage1.py
@@ -423,10 +423,11 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
     def get_flat_sub_partitions(comm_tensor_list,
                                 comm_param_offsets,
                                 sub_partition_size,
-                                dtype=None,
+                                dtype,
+                                default_device,
                                 num_comm_intervals=None,
-                                default_device=None,
                                 return_partition_params=False):
+
         partition_params = []
         final_param_offsets = []
         flat_sub_partitions = []
@@ -435,12 +436,6 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
             current_size = 0
             my_offsets = []
             my_params = []
-
-            if dtype is None:
-                dtype = tensor_list[0].dtype
-
-            if default_device is None:
-                default_device = tensor_list[0].device
 
             for i, tensor in enumerate(tensor_list):
                 if tensor.grad is None:
@@ -555,6 +550,8 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
                     comm_tensor_list=self.params_in_rank_sub_partitions[i][rank],
                     comm_param_offsets=self.params_in_rank_sub_partitions_offsets[i]
                     [rank],
+                    dtype=torch.half,
+                    default_device=self.default_device,
                     sub_partition_size=self.sub_partition_sizes[i],
                     num_comm_intervals=self.num_comm_intervals_per_group[i])
                 all_sub_partitions.append(grad_sub_partitions)
@@ -624,7 +621,7 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
                 sub_partition_size=self.sub_partition_sizes[i],
                 dtype=self.local_sub_partitions_of_fp32_groups[i][0].dtype,
                 num_comm_intervals=self.num_comm_intervals_per_group[i],
-                default_device=self.local_sub_partitions_of_fp32_groups[i][0].device)
+                default_device=self.default_device)
 
             #RS: update all our local params with sub-partition grads
             for idx, sub_partition_param in enumerate(self.local_sub_partitions_of_fp32_groups[i]):

--- a/deepspeed/runtime/zero/stage1.py
+++ b/deepspeed/runtime/zero/stage1.py
@@ -192,6 +192,8 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
 
         self.default_device = self.optimizer.param_groups[0]['params'][0].device
 
+        self.local_sub_partitions = []
+
         # loop to deal with groups
         for i, param_group in enumerate(self.optimizer.param_groups):
             # push this group to list before modify

--- a/deepspeed/runtime/zero/stage1.py
+++ b/deepspeed/runtime/zero/stage1.py
@@ -73,7 +73,8 @@ def flatten_dense_tensors_sub_partition_aligned(tensor_list,
                                  dtype=tensor_list[0].dtype)
         aligned_tensor_list = tensor_list + [pad_tensor]
 
-    return _flatten_dense_tensors(aligned_tensor_list)
+    flat_tensors = _flatten_dense_tensors(aligned_tensor_list)
+    return flat_tensors
 
 
 def _single_range_check(current_index, start_index, end_index, tensor_size):
@@ -196,12 +197,12 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
 
             # flattens all tensors into single 1d tensor aligned with sub-partition size for later dividing
             # RS: create aligned sub-partitions
-            self.fp16_groups_flat.append(
-                flatten_dense_tensors_sub_partition_aligned(
-                    tensor_list=self.fp16_groups[i],
-                    dp=dist.get_world_size(group=self.dp_process_group),
-                    max_elements_per_comm=self.max_elements_per_comm,
-                    pg=self.dp_process_group))
+            flat_aligned_params = flatten_dense_tensors_sub_partition_aligned(
+                tensor_list=self.fp16_groups[i],
+                dp=dist.get_world_size(group=self.dp_process_group),
+                max_elements_per_comm=self.max_elements_per_comm,
+                pg=self.dp_process_group)
+            self.fp16_groups_flat.append(flat_aligned_params)
 
             # TODO: I don't think this does anything?
             # set model fp16 weight to slices of flattened buffer
@@ -537,6 +538,7 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
         world_size = dist.get_world_size(group=self.dp_process_group)
         local_rank = dist.get_rank(group=self.dp_process_group)
 
+        self.local_sub_partitions = []
         for i, group in enumerate(self.fp16_groups):
             partition_param_map = {}
             param_partition_map = {}
@@ -579,6 +581,7 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
             if not postscale_gradients:
                 raise NotImplementedError("pre-scale_gradients is not implemented")
 
+            local_comm_partitions = []
             all_comm_partitions = []
             for comm_idx in range(num_comm_intervals):
                 single_comm_all_partitions = []
@@ -589,26 +592,63 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
                                     group=self.dp_process_group)
 
                 if gradient_average:
-                    for partition in single_comm_all_partitions:
-                        partition.mul_(gradient_predivide_factor / world_size)
+                    single_comm_all_partitions[local_rank].mul_(
+                        gradient_predivide_factor / world_size)
+                    # for partition in single_comm_all_partitions:
+                    #     partition.mul_(gradient_predivide_factor / world_size)
 
                 all_comm_partitions.append(single_comm_all_partitions)
+                # TODO: can we update fp16_groups_flat here to copy the the updated grads directly into the flat
+                #       comm_idx grads          rank0     rank1
+                # single_comm_all_partitions = [[a,b,c], [d,e,f]]
+                #
+                # known: rank, comm-idx, partition-size
+                # e.g.,  rank=2 comm-idx=1, partition-size 10
 
-            # stitch together all rank sub partitions for each comm idx
-            flat_comm_grads = []
-            for comm_idx, rank_partitions in enumerate(all_comm_partitions):
-                flat_comm_grads.append(torch.cat(rank_partitions))
+                #TODO: megatron example never escapes overflow for some reason, what's going on there? did we break overflow checks?
+                #TODO: check with small model, easier repro of never escaping overflow
 
-            flat_all_grads = torch.cat(flat_comm_grads)
+                # append comm-idx partition
+                local_comm_partitions.append(single_comm_all_partitions[local_rank].to(
+                    torch.float32))
 
-            # copy back reduced gradients but only those needed for this local rank
-            for param, updated_grad in zip(self.fp16_groups[i], _unflatten_dense_tensors(flat_all_grads, self.fp16_groups[i])):
-                if param in my_params:
-                    param.grad.copy_(updated_grad)
+            # append group partitions
+            self.local_sub_partitions.append(local_comm_partitions)
+
+        # print(f'rank={dist.get_rank()}, local_sub_partitions={self.local_sub_partitions}')
+
+        # Copy back reduced gradients for this partition
+        #partition_offset = (comm_idx * world_size * self.sub_partition_sizes[i]) + (local_rank * self.sub_partition_sizes[i])
+        #print(f'[{dist.get_rank()}] partition offset={partition_offset}, partition_size={self.sub_partition_sizes[i]}')
+        #self.fp16_groups_flat[i].narrow(0, partition_offset, self.sub_partition_sizes[i]).copy_(single_comm_all_partitions[local_rank])
+
+        # print(f'[{dist.get_rank()}] comm_idx={comm_idx}, single_comm_all_partitions={single_comm_all_partitions[local_rank]}')
+
+        # for param, updated_grad in zip(self.fp16_groups[i], _unflatten_dense_tensors(self.fp16_groups_flat[i], self.fp16_groups[i])):
+        #     if param in my_params:
+        #         param.grad.copy_(updated_grad)
+
+        # print(f'[{dist.get_rank()}] param_offsets={param_offsets}')
+        # print(f'[{dist.get_rank()}] self.fp16_groups_flat[{i}]={self.fp16_groups_flat[i]}')
+
+        # # stitch together all rank sub partitions for each comm idx
+        # flat_comm_grads = []
+        # for comm_idx, rank_partitions in enumerate(all_comm_partitions):
+        #     flat_comm_grads.append(torch.cat(rank_partitions))
+
+        # flat_all_grads = torch.cat(flat_comm_grads)
+
+        # # copy back reduced gradients but only those needed for this local rank
+        # for param, updated_grad in zip(self.fp16_groups[i], _unflatten_dense_tensors(flat_all_grads, self.fp16_groups[i])):
+        #     if param in my_params:
+        #         param.grad.copy_(updated_grad)
 
     def step(self, closure=None):
         # First compute norm for all group so we know if there is overflow
-        self.overflow = self.overflow_checker.check()
+        # print(f'[STEP] rank={dist.get_rank()}, local_sub_partitions={self.local_sub_partitions}')
+        self.overflow = self.overflow_checker.check(
+            param_groups=self.local_sub_partitions,
+            raw_grad_tensors=True)
 
         prev_scale = self.loss_scale
         self._update_scale(self.overflow)
@@ -645,14 +685,18 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
 
             #TODO RS: can we safely use dtype of the first sub-partition? i think so
             # create flat gradient partitions for parameters updated by this process
-            local_grad_sub_partitions = self.get_flat_sub_partitions(
-                comm_tensor_list=self.params_in_rank_sub_partitions[i][partition_id],
-                comm_param_offsets=self.params_in_rank_sub_partitions_offsets[i]
-                [partition_id],
-                sub_partition_size=self.sub_partition_sizes[i],
-                dtype=self.local_sub_partitions_of_fp32_groups[i][0].dtype,
-                num_comm_intervals=self.num_comm_intervals_per_group[i],
-                default_device=self.local_sub_partitions_of_fp32_groups[i][0].device)
+
+            local_grad_sub_partitions = self.local_sub_partitions[i]
+            assert len(local_grad_sub_partitions) == len(self.local_sub_partitions_of_fp32_groups[i]), f"{len(local_grad_sub_partitions)} !== {len(self.local_sub_partitions_of_fp32_groups[i])}"
+
+            # local_grad_sub_partitions = self.get_flat_sub_partitions(
+            #     comm_tensor_list=self.params_in_rank_sub_partitions[i][partition_id],
+            #     comm_param_offsets=self.params_in_rank_sub_partitions_offsets[i]
+            #     [partition_id],
+            #     sub_partition_size=self.sub_partition_sizes[i],
+            #     dtype=self.local_sub_partitions_of_fp32_groups[i][0].dtype,
+            #     num_comm_intervals=self.num_comm_intervals_per_group[i],
+            #     default_device=self.local_sub_partitions_of_fp32_groups[i][0].device)
 
             #RS: update all our local params with sub-partition grads
             #logger. info("self.local_sub_partitions_of_fp32_groups[i]={}, local_grad_sub_partitions={}".format(len(self.local_sub_partitions_of_fp32_groups[i]), len(local_grad_sub_partitions)))
@@ -666,6 +710,7 @@ class FP16_DeepSpeedZeroOptimizer_Stage1(object):
                 self.params_in_rank_sub_partitions[i][partition_id])
 
             local_sub_partitions_grad_groups.append(local_grad_sub_partitions)
+            # print(f'[rank[{dist.get_rank()}] group={i}, local_grad_sub_partitions={local_grad_sub_partitions}')
 
         #RS: update unscale/clip with sub partitions
         self.unscale_and_clip_grads(local_sub_partitions_grad_groups, norm_groups)

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -41,6 +41,8 @@ def distributed_test(world_size=2, backend='nccl'):
             if torch.cuda.is_available():
                 torch.cuda.set_device(local_rank)
 
+            assert 'args' in func_kwargs, 'must pass args, later consumed for device binding'
+            func_kwargs['args'].local_rank = local_rank
             run_func(*func_args, **func_kwargs)
 
         def dist_launcher(num_procs, *func_args, **func_kwargs):

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -41,8 +41,8 @@ def distributed_test(world_size=2, backend='nccl'):
             if torch.cuda.is_available():
                 torch.cuda.set_device(local_rank)
 
-            assert 'args' in func_kwargs, 'must pass args, later consumed for device binding'
-            func_kwargs['args'].local_rank = local_rank
+            if 'args' in func_kwargs:
+                func_kwargs['args'].local_rank = local_rank
             run_func(*func_args, **func_kwargs)
 
         def dist_launcher(num_procs, *func_args, **func_kwargs):


### PR DESCRIPTION
1) By default ZeRO-1 sets the `max_elements_per_comm` parameter to 500M parameters. We've observed that if the number of parameters in the model are not closely divisible by 500M that zero-1 was adding significant padding that was causing some slow downs and extra memory usage. This PR aims at addressing some of these issues by choosing the the lesser of padding the model or padding the max elements per comm.
2) The reduce-scatter logic in the previous version of zero-1 was overly complex and was using more memory than we had originally thought. We've updated/simplified the logic and reduced the memory overhead to better align with the original paper.
3) (unrelated to zero-1 bug fix) torch 1.7 + nccl 2.7.8 seems to have exposed a bug in our distributed unit test backend, we've now fixed this issue. This PR fixes issue #518. 