### PR TITLE
more fine-grained manifest file for includes/excludes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
-global-include *.cpp *.h *.cu *.tr *.cuh *.cc *.txt
+include version.txt build.txt
+graft deepspeed/ops/csrc
+graft deepspeed/ops/sparse_attention/trsrc


### PR DESCRIPTION
We recently ran into an issue where the previous manifest file was causing build hangs if DeepSpeedExamples (DSE) was checked out and had lots of training data included. We think it was trying to scan through the DSE directories looking for matches and ran into some issues with a symlink. Either way, this more explicit listing of files to include fixes this issue.