### PR TITLE
remove session_params key from docstrings

### DIFF
--- a/deepspeed/runtime/activation_checkpointing/config.py
+++ b/deepspeed/runtime/activation_checkpointing/config.py
@@ -12,7 +12,6 @@ from deepspeed.runtime.config_utils import get_scalar_param
 #activations for the backpropagation.
 ACTIVATION_CHKPT_FORMAT = '''
 Activation Checkpointing should be configured as:
-"session_params": {
   "activation_checkpointing": {
     "partitioned_activations": [true|false],
     "number_checkpoints": 100,
@@ -21,7 +20,6 @@ Activation Checkpointing should be configured as:
     "profile": [true|false],
     "synchronize_checkpoint_boundary": [true|false],
     }
-}
 '''
 
 ACT_CHKPT_PARTITION_ACTIVATIONS = 'partition_activations'

--- a/deepspeed/runtime/zero/constants.py
+++ b/deepspeed/runtime/zero/constants.py
@@ -10,7 +10,6 @@ Licensed under the MIT license.
 # Users have to configure the desired optimization (0 means disabled) in params.json as below example:
 ZERO_FORMAT = '''
 ZeRO optimization should be enabled as:
-"session_params": {
   "zero_optimization": {
     "stage": [0|1|2],
     "allgather_partitions": [true|false],
@@ -22,7 +21,6 @@ ZeRO optimization should be enabled as:
     "load_from_fp32_weights": [true|false]
     "cpu_offload": [true|false]
     }
-}
 '''
 
 ZERO_OPTIMIZATION = 'zero_optimization'


### PR DESCRIPTION
As in https://github.com/microsoft/DeepSpeed/pull/162, removing `"session_params"` from two docstrings since it's an outdated relic that can cause confusion.