### PR TITLE
Add 'latest' checkpoint save/load support

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1473,7 +1473,9 @@ class DeepSpeedEngine(Module):
         # This is to make sure the checkpoint names are created without collision
         # There seems to be issue creating them in parallel
 
+        save_latest = False
         if tag is None:
+            save_latest = True
             tag = f"global_step{self.global_steps}"
 
         if self.save_non_zero_checkpoint:
@@ -1485,8 +1487,9 @@ class DeepSpeedEngine(Module):
             self._save_zero_checkpoint(save_dir, tag)
 
         # Save latest checkpoint tag
-        with open(os.path.join(save_dir, 'latest'), 'w') as fd:
-            fd.write(tag)
+        if save_latest:
+            with open(os.path.join(save_dir, 'latest'), 'w') as fd:
+                fd.write(tag)
 
         return True
 

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1319,8 +1319,8 @@ class DeepSpeedEngine(Module):
 
         if tag is None:
             latest_path = os.path.join(load_dir, 'latest')
-            assert os.path.isfile(latest_path), f"Unable to find latest file at {latest_path}, if trying to load latest " \
-                "checkpoint please ensure this file exists or pass an explicit checkpoint tag when loading a checkpoint."
+            #assert os.path.isfile(latest_path), f"Unable to find latest file at {latest_path}, if trying to load latest " \
+            #    "checkpoint please ensure this file exists or pass an explicit checkpoint tag when loading a checkpoint."
             with open(latest_path, 'r') as fd:
                 tag = fd.read().strip()
 
@@ -1461,21 +1461,23 @@ class DeepSpeedEngine(Module):
         )
         return zero_optimizer_sd
 
-    def save_checkpoint(self, save_dir, tag=None, client_state={}):
+    def save_checkpoint(self, save_dir, tag=None, client_state={}, save_latest=True):
         r"""Save training checkpoint
 
         Arguments:
             save_dir: Required. Directory for saving the checkpoint
-            tag: Checkpoint tag used as a unique identifier for the checkpoint, global step is used if not provided.
+            tag: Optional. Checkpoint tag used as a unique identifier for the checkpoint, global step is used if not provided.
             client_state: Optional. State dictionary used for saving required training states in the client code.
+            save_latest: Optional. Save a file 'latest' pointing to the latest saved checkpoint.
         """
 
         # This is to make sure the checkpoint names are created without collision
         # There seems to be issue creating them in parallel
 
-        save_latest = False
+        # Ensure save_dir directory exists
+        os.makedirs(save_dir, exist_ok=True)
+
         if tag is None:
-            save_latest = True
             tag = f"global_step{self.global_steps}"
 
         if self.save_non_zero_checkpoint:

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1304,7 +1304,7 @@ class DeepSpeedEngine(Module):
                         load_module_strict=True,
                         load_optimizer_states=True,
                         load_lr_scheduler_states=True):
-        r"""Load training checkpoint
+        """Load training checkpoint
 
         Arguments:
             load_dir: Required. Directory to load the checkpoint from
@@ -1319,8 +1319,8 @@ class DeepSpeedEngine(Module):
 
         if tag is None:
             latest_path = os.path.join(load_dir, 'latest')
-            #assert os.path.isfile(latest_path), f"Unable to find latest file at {latest_path}, if trying to load latest " \
-            #    "checkpoint please ensure this file exists or pass an explicit checkpoint tag when loading a checkpoint."
+            assert os.path.isfile(latest_path), f"Unable to find latest file at {latest_path}, if trying to load latest " \
+                "checkpoint please ensure this file exists or pass an explicit checkpoint tag when loading a checkpoint."
             with open(latest_path, 'r') as fd:
                 tag = fd.read().strip()
 

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1300,7 +1300,7 @@ class DeepSpeedEngine(Module):
 
     def load_checkpoint(self,
                         load_dir,
-                        tag,
+                        tag=None,
                         load_module_strict=True,
                         load_optimizer_states=True,
                         load_lr_scheduler_states=True):
@@ -1308,7 +1308,7 @@ class DeepSpeedEngine(Module):
 
         Arguments:
             load_dir: Required. Directory to load the checkpoint from
-            tag: Required. Checkpoint tag used as a unique identifier for the checkpoint. Ex. Global Step.
+            tag: Checkpoint tag used as a unique identifier for checkpoint, if not provided will attempt to load tag in 'latest' file
             load_module_strict: Optional. Boolean to strictly enforce that the keys in state_dict of module and checkpoint match.
             load_optimizer_states: Optional. Boolean to load the training optimizer states from Checkpoint. Ex. ADAM's momentum and variance
             load_lr_scheduler_states: Optional. Boolean to add the learning rate scheduler states from Checkpoint.
@@ -1316,6 +1316,13 @@ class DeepSpeedEngine(Module):
             load_path: Path of the loaded checkpoint. None if loading the checkpoint failed
             client_state: State dictionary used for loading required training states in the client code.
         """
+
+        if tag is None:
+            latest_path = os.path.join(load_dir, 'latest')
+            assert os.path.isfile(latest_path), f"Unable to find latest file at {latest_path}, if trying to load latest " \
+                "checkpoint please ensure this file exists or pass an explicit checkpoint tag when loading a checkpoint."
+            with open(latest_path, 'r') as fd:
+                tag = fd.read().strip()
 
         load_path, client_states = self._load_checkpoint(load_dir,
                                                          tag,
@@ -1454,17 +1461,20 @@ class DeepSpeedEngine(Module):
         )
         return zero_optimizer_sd
 
-    def save_checkpoint(self, save_dir, tag, client_state={}):
+    def save_checkpoint(self, save_dir, tag=None, client_state={}):
         r"""Save training checkpoint
 
         Arguments:
             save_dir: Required. Directory for saving the checkpoint
-            tag: Required. Checkpoint tag used as a unique identifier for the checkpoint. Ex. Global Step.
+            tag: Checkpoint tag used as a unique identifier for the checkpoint, global step is used if not provided.
             client_state: Optional. State dictionary used for saving required training states in the client code.
         """
 
         # This is to make sure the checkpoint names are created without collision
         # There seems to be issue creating them in parallel
+
+        if tag is None:
+            tag = f"global_step{self.global_steps}"
 
         if self.save_non_zero_checkpoint:
             self._create_checkpoint_file(save_dir, tag, False)
@@ -1473,6 +1483,10 @@ class DeepSpeedEngine(Module):
         if self.save_zero_checkpoint:
             self._create_zero_checkpoint_files(save_dir, tag)
             self._save_zero_checkpoint(save_dir, tag)
+
+        # Save latest checkpoint tag
+        with open(os.path.join(save_dir, 'latest'), 'w') as fd:
+            fd.write(tag)
 
         return True
 

--- a/tests/unit/test_checkpointing.py
+++ b/tests/unit/test_checkpointing.py
@@ -723,7 +723,7 @@ def test_checkpoint_latest(tmpdir):
     models = [SimpleModel(hidden_dim=hidden_dim) for _ in range(2)]
 
     @distributed_test(world_size=[1])
-    def helper(args, models):
+    def _helper(args, models):
         checkpoint_correctness_verification(args,
                                             models=models,
                                             hidden_dim=hidden_dim,
@@ -733,7 +733,7 @@ def test_checkpoint_latest(tmpdir):
                                             fp16=False,
                                             empty_tag=True)
 
-    helper(args, models)
+    _helper(args, models)
 
 
 def test_checkpoint_missing_latest(tmpdir):

--- a/tests/unit/test_checkpointing.py
+++ b/tests/unit/test_checkpointing.py
@@ -729,7 +729,8 @@ def test_checkpoint_latest(tmpdir):
                                             hidden_dim=hidden_dim,
                                             tmpdir=tmpdir,
                                             load_optimizer_states=True,
-                                            load_lr_scheduler_states=True,
+                                            load_lr_scheduler_states=False,
+                                            fp16=False,
                                             empty_tag=True)
 
     helper(args, models)

--- a/tests/unit/test_checkpointing.py
+++ b/tests/unit/test_checkpointing.py
@@ -735,6 +735,7 @@ def test_checkpoint_latest(tmpdir):
 
     helper(args, models)
 
+
 def test_checkpoint_missing_latest(tmpdir):
     config_dict = {
         "train_batch_size": 2,


### PR DESCRIPTION
* Makes the `tag` parameter optional to save/load checkpoints. 
* Saves an additional file called `latest` which stores the latest saved checkpoint tag.
* If omitted on save we will use deepspeed's global step as the tag.
* If omitted on load we assume the `latest` file exists and set the tag to the contents of the file.

This is required for deepspeed elastic training support. The user will set a `model_engine.load_checkpoint(save_dir=<save_path>)` at the start of their training. This will attempt to restore from the latest checkpoint if a job is elastically scaled or restarted due to failure.