### PR TITLE
[build] build against installed cuda-11.1 while torch built w/ cuda-11.0

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -29,6 +29,9 @@ def assert_no_cuda_mismatch():
     torch_cuda_version = ".".join(torch.version.cuda.split('.')[:2])
     # This is a show-stopping error, should probably not proceed past this
     if installed_cuda_version != torch_cuda_version:
+        if installed_cuda_version == "11.1" and torch_cuda_version == "11.0":
+            # it works to build against installed cuda-11.1 while torch was built with cuda-11.0
+            return
         raise Exception(
             f"Installed CUDA version {installed_cuda_version} does not match the "
             f"version torch was compiled with {torch.version.cuda}, unable to compile "

--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -43,8 +43,8 @@ def assert_no_cuda_mismatch():
     sys_cuda_version = f'{cuda_major}.{cuda_minor}'
     torch_cuda_version = ".".join(torch.version.cuda.split('.')[:2])
     # This is a show-stopping error, should probably not proceed past this
-    if installed_cuda_version != torch_cuda_version:
-        if installed_cuda_version == "11.1" and torch_cuda_version == "11.0":
+    if sys_cuda_version != torch_cuda_version:
+        if sys_cuda_version == "11.1" and torch_cuda_version == "11.0":
             # it works to build against installed cuda-11.1 while torch was built with cuda-11.0
             return
         raise Exception(


### PR DESCRIPTION
I learned this from nvidia apex, it works to build against installed cuda-11.1 while torch was built with cuda-11.0 - as the API is similar (identical?). Note that tensorflow requires cuda-11.1 to work with rtx-30*. So while I do have 11.0 and 11.1 installed, the builder can't find 11.0 automatically.

Can probably remove this when cuda-11.2 comes out and we get pytorch fully supporting Ampere - until then pytorch can't be built with cuda-11.1. 

I verified that I was able to build all options with:

```
DS_BUILD_OPS=1 pip install deepspeed -v .
```
```
ds_report
--------------------------------------------------
DeepSpeed C++/CUDA extension op report
--------------------------------------------------
NOTE: Ops not installed will be just-in-time (JIT) compiled at
      runtime if needed. Op compatibility means that your system
      meet the required dependencies to JIT install the op.
--------------------------------------------------
JIT compiled ops requires ninja
ninja .................. [OKAY]
--------------------------------------------------
op name ................ installed .. compatible
--------------------------------------------------
cpu_adam ............... [YES] ...... [OKAY]
fused_adam ............. [YES] ...... [OKAY]
fused_lamb ............. [YES] ...... [OKAY]
sparse_attn ............ [YES] ...... [OKAY]
transformer ............ [YES] ...... [OKAY]
stochastic_transformer . [YES] ...... [OKAY]
utils .................. [YES] ...... [OKAY]
--------------------------------------------------
DeepSpeed general environment info:
torch install path ............... ['/home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/torch']
torch version .................... 1.8.0.dev20201202+cu110
torch cuda version ............... 11.0
nvcc version ..................... 11.1
deepspeed install path ........... ['/home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/deepspeed']
deepspeed info ................... 0.3.7+7a75f8b, 7a75f8b, master
deepspeed wheel compiled w. ...... torch 1.8, cuda 11.0
```

Otherwise with rtx-3090 I was getting:
`RuntimeError: NCCL error in: /pytorch/torch/lib/c10d/ProcessGroupNCCL.cpp:31, unhandled cuda error, NCCL version 2.7.8`