### PR TITLE
[engine] train should be able to get `mode` arg

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -800,12 +800,12 @@ class DeepSpeedEngine(Module):
                                    data_parallel_world_size=data_parallel_world_size,
                                    data_parallel_rank=data_parallel_rank)
 
-    def train(self):
+    def train(self, mode=True):
         r"""
         """
 
         self.warn_unscaled_loss = True
-        self.module.train()
+        self.module.train(mode)
 
     def eval(self):
         r"""


### PR DESCRIPTION
Currently, calling `train()` on DDP wrapping `deepspeed` module fails:
```
  File "/home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/torch/nn/parallel/distributed.py", line 753, in train
    super(DistributedDataParallel, self).train(mode)
  File "/home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1296, in train
    module.train(mode)
TypeError: train() takes 1 positional argument but 2 were given
```
this PR makes `deepspeed`'s `train` - like all other `nn.Modules` - that is accept an optional `mode` arg with default `True`.

nn.Module does:
```
    def train(self: T, mode: bool = True) -> T:
        self.training = mode
        for module in self.children():
            module.train(mode)
        return self
```


(I'm trying to integrate deepspeed into a large program so perhaps there is another way around it, but my feeling is that this is the right signature regardless)

I think `eval` needs to have the same change, unless you think the `train` change is not right.

Thanks.