### PR TITLE
[build] add compute_86 capability

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -34,7 +34,7 @@ def installed_cuda_version():
 def get_default_compute_capatabilities():
     compute_caps = DEFAULT_COMPUTE_CAPABILITIES
     if installed_cuda_version()[0] >= 11:
-        compute_caps += ";8.0"
+        compute_caps += ";8.0;8.6"
     return compute_caps
 
 


### PR DESCRIPTION
RTX-30 series are compute_86
```
python -c "import torch; print(torch.cuda.get_device_capability())"
(8, 6)
```
This PR adds support for this compute capability.

I verified that it works.

Reference: https://developer.nvidia.com/cuda-gpus