### PR TITLE
[build] make builder smarter and configurable wrt compute capabilities + docs

### DIFF
--- a/docs/_tutorials/advanced-install.md
+++ b/docs/_tutorials/advanced-install.md
@@ -84,6 +84,29 @@ the nodes listed in your hostfile (either given via --hostfile, or defaults to
 /job/hostfile).
 
 
+## Building for the correct architectures
+
+If you're getting the following error:
+
+```python
+RuntimeError: CUDA error: no kernel image is available for execution on the device
+```
+when running deepspeed that means that the cuda extensions weren't built for the card you're trying to use it for.
+
+When building from source deepspeed will try to support a wide range of architectures, but under jit-mode it'll only support the archs visible at the time of building.
+
+You can build specifically for a desired range of architectures by setting a `TORCH_CUDA_ARCH_LIST` env variable, like so:
+
+```bash
+TORCH_CUDA_ARCH_LIST="6.1;7.5;8.6" pip install ...
+```
+
+It will also make the build faster when you only build for a few architectures.
+
+This is also recommended to do to ensure your exact architecture is used. Due to a variety of technical reasons a distributed pytorch binary isn't built to fully support all architectures, skipping binary compatible ones, at a potential cost of underutilizing your full card's compute capabilities. To see which archs get included during the deepspeed build from source - save the log and grep for `-gencode` arguments.
+
+The full list of nvidia gpus and their compute capabilities can be found [here](https://developer.nvidia.com/cuda-gpus).
+
 ## Feature specific dependencies
 
 Some DeepSpeed features require specific dependencies outside of the general

--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -216,25 +216,53 @@ class OpBuilder(ABC):
 
 class CUDAOpBuilder(OpBuilder):
     def compute_capability_args(self, cross_compile_archs=None):
-        if cross_compile_archs is None:
-            cross_compile_archs = get_default_compute_capatabilities()
+        """
+        Returns nvcc compute capability compile flags.
 
-        args = []
+        1. `TORCH_CUDA_ARCH_LIST` takes priority over `cross_compile_archs`.
+        2. If neither is set default compute capabilities will be used
+        3. Under `jit_mode` compute capabilities of all visible cards will be used.
+
+        Format:
+
+        - `TORCH_CUDA_ARCH_LIST` may use ; or whitespace separators. Examples:
+
+        TORCH_CUDA_ARCH_LIST="6.1;7.5;8.6" pip install ...
+        TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5 8.0 8.6+PTX" pip install ...
+
+        - `cross_compile_archs` uses ; separator.
+
+        """
+
+        ccs = []
         if self.jit_mode:
-            # Compile for underlying architecture since we know it at runtime
-            CC_MAJOR, CC_MINOR = torch.cuda.get_device_capability()
-            compute_capability = f"{CC_MAJOR}{CC_MINOR}"
-            args.append('-gencode')
-            args.append(
-                f'arch=compute_{compute_capability},code=compute_{compute_capability}')
+            # Compile for underlying architectures since we know those at runtime
+            for i in range(torch.cuda.device_count()):
+                CC_MAJOR, CC_MINOR = torch.cuda.get_device_capability(i)
+                cc = f"{CC_MAJOR}.{CC_MINOR}"
+                if cc not in ccs:
+                    ccs.append(cc)
+            ccs = sorted(ccs)
         else:
             # Cross-compile mode, compile for various architectures
-            for compute_capability in cross_compile_archs.split(';'):
-                compute_capability = compute_capability.replace('.', '')
-                args.append('-gencode')
-                args.append(
-                    f'arch=compute_{compute_capability},code=compute_{compute_capability}'
-                )
+            # env override takes priority
+            cross_compile_archs_env = os.environ.get('TORCH_CUDA_ARCH_LIST', None)
+            if cross_compile_archs_env is not None:
+                if cross_compile_archs is not None:
+                    print(
+                        f"{WARNING} env var `TORCH_CUDA_ARCH_LIST={cross_compile_archs_env}` overrides `cross_compile_archs={cross_compile_archs}`"
+                    )
+                cross_compile_archs = cross_compile_archs_env.replace(' ', ';')
+            else:
+                if cross_compile_archs is None:
+                    cross_compile_archs = get_default_compute_capatabilities()
+            ccs = cross_compile_archs.split(';')
+
+        args = []
+        for cc in ccs:
+            cc = cc.replace('.', '')
+            args.append(f'-gencode arch=compute_{cc},code=compute_{cc}')
+
         return args
 
     def version_dependent_macros(self):

--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -261,7 +261,7 @@ class CUDAOpBuilder(OpBuilder):
         args = []
         for cc in ccs:
             cc = cc.replace('.', '')
-            args.append(f'-gencode arch=compute_{cc},code=compute_{cc}')
+            args.append(f'-gencode=arch=compute_{cc},code=compute_{cc}')
 
         return args
 

--- a/op_builder/fused_adam.py
+++ b/op_builder/fused_adam.py
@@ -22,4 +22,7 @@ class FusedAdamBuilder(CUDAOpBuilder):
         return ['-O3'] + self.version_dependent_macros()
 
     def nvcc_args(self):
-        return ['-lineinfo', '-O3', '--use_fast_math'] + self.version_dependent_macros() + self.compute_capability_args()
+        return ['-lineinfo',
+                '-O3',
+                '--use_fast_math'
+                ] + self.version_dependent_macros() + self.compute_capability_args()

--- a/op_builder/fused_adam.py
+++ b/op_builder/fused_adam.py
@@ -22,4 +22,4 @@ class FusedAdamBuilder(CUDAOpBuilder):
         return ['-O3'] + self.version_dependent_macros()
 
     def nvcc_args(self):
-        return ['-lineinfo', '-O3', '--use_fast_math'] + self.version_dependent_macros()
+        return ['-lineinfo', '-O3', '--use_fast_math'] + self.version_dependent_macros() + self.compute_capability_args()

--- a/op_builder/fused_lamb.py
+++ b/op_builder/fused_lamb.py
@@ -22,4 +22,4 @@ class FusedLambBuilder(CUDAOpBuilder):
         return ['-O3'] + self.version_dependent_macros()
 
     def nvcc_args(self):
-        return ['-lineinfo', '-O3', '--use_fast_math'] + self.version_dependent_macros()
+        return ['-lineinfo', '-O3', '--use_fast_math'] + self.version_dependent_macros() + self.compute_capability_args()

--- a/op_builder/fused_lamb.py
+++ b/op_builder/fused_lamb.py
@@ -22,4 +22,7 @@ class FusedLambBuilder(CUDAOpBuilder):
         return ['-O3'] + self.version_dependent_macros()
 
     def nvcc_args(self):
-        return ['-lineinfo', '-O3', '--use_fast_math'] + self.version_dependent_macros() + self.compute_capability_args()
+        return ['-lineinfo',
+                '-O3',
+                '--use_fast_math'
+                ] + self.version_dependent_macros() + self.compute_capability_args()


### PR DESCRIPTION
This PR fixes:

```
RuntimeError: cuda runtime error (209) : no kernel image is available for execution on the device at ...
```
error, resulting from this build:
```
DS_BUILD_OPS=1 pip install --no-clean --no-cache -v --disable-pip-version-check -e . 
```

`multi_tensor_adam.cu` and `fused_lamb_cuda_kernel.cu` were getting only `-gencode=arch=compute_80,code=sm_80` flags and missing all the rest `-gencode arch=compute_60,code=compute_60 -gencode arch=compute_61,code=compute_61 -gencode arch=compute_70,code=compute_70 -gencode arch=compute_80,code=compute_80 -gencode arch=compute_86,code=compute_86`

The lone `-gencode=arch=compute_80,code=sm_80` comes from `CUDAExtension` - which currently checks the capacity of the 1st card only and assumes that the other cards and the same. Moreover it clamps down the number to the minimum of the same first digit in:
```
python -c "import torch; print(torch.cuda.get_arch_list())" 
['sm_37', 'sm_50', 'sm_60', 'sm_70', 'sm_75', 'sm_80']
```
so, for example, `sm_86` becomes `sm_80`.

I'm pretty sure it's wrong though since it's the card with `compute_61` that was getting this error, so these 2 libs weren't built to support `compute_61`. This is with pytorch-nightly.

The 2 cards I have right now are:
```
$ CUDA_VISIBLE_DEVICES=0 python -c "import torch; print(torch.cuda.get_device_capability())"
(8, 6)
$ CUDA_VISIBLE_DEVICES=1 python -c "import torch; print(torch.cuda.get_device_capability())"
(6, 1)
```

Note: A PR has been proposed to fix this problem transparently to `CUDAExtension` users, but it won't be available until future versions of pytorch if it's accepted. https://github.com/pytorch/pytorch/pull/48891

The cost of this deepspeed PR is that the build process is now slightly slower as it now has to build 4-5 kernels x 2 instead of just 2 (assuming all features are enabled to be compiled). So perhaps down the road we can fix that by conditioning on pytorch version and build less kernels. Alternatively you could copy the loop to get just the required archs: https://github.com/pytorch/pytorch/blob/b8f90d778d4c0739c7c07fe2b2fb0aef5e7c77e7/torch/utils/cpp_extension.py#L1531-L1545

------------------

**edit**: After understanding how `CUDAExtension`  sorts out its archs I have made further improvements to this PR

* [x] by default build the cuda extension for all supported archs (discussion above)
* [x] changed jit_mode to check archs of all visible cards and not just the first one (similar to the PR I submitted to pytorch)
* [x] add support for `TORCH_CUDA_ARCH_LIST`, in exact same manner as `CUDAExtension` does it. So now I can build deepspeed much faster by specifying only the archs that I need: `TORCH_CUDA_ARCH_LIST="6.1;7.5;8.6" DS_BUILD_OPS=1 pip install --no-clean --no-cache -v --disable-pip-version-check -e .`
   `TORCH_CUDA_ARCH_LIST` overrides the `CUDAOpBuilder`'s `cross_compile_archs` arg
* [x] refactor the code
* [x] document `CUDAOpBuilder` nuances
* [x] extend the advanced installation tutorial to document the arch mismatch error, its cause and how to build the most efficient version of deepspeed for the exact desired archs.

A related PR: proposed support for compute_86 in https://github.com/microsoft/DeepSpeed/pull/577 to include the full capabilities of the rtx-30* cards.

This might be related to https://github.com/microsoft/DeepSpeed/issues/95
