### PR TITLE
Pipeline warnings and checkpoint portability

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -1103,31 +1103,31 @@ class PipelineEngine(DeepSpeedEngine):
         is ``save_state_dict()``.
 
         Returns:
-            str: The directory path where the checkpoint was saved.
+            None
         """
         assert isinstance(self.module, PipelineModule)
-        assert self._curr_save_path is not None, \
+        assert self._curr_ckpt_path is not None, \
             "PipelineEngine expects module_state_dict() to be called from save_checkpoint()"
 
-        self.module.save_state_dict(self._curr_save_path)
-        return self._curr_save_path
+        self.module.save_state_dict(self._curr_ckpt_path)
+        return None
 
     def load_module_state_dict(self, state_dict, strict=True):
         """Override hack to instead use a directory path.
 
         This is important because pipeline models checkpoint by layer instead of rank.
 
-        If ``state_dict`` is not a ``str``, we revert to ``super()`` expecting a ``dict``.
+        If ``state_dict`` is not ``None`` or a ``str``, we revert to ``super()`` expecting a ``dict``.
 
         Args:
-            state_dict (str): Path to the directory for checkpoint.
+            state_dict (str, None): unused
             strict (bool, optional): Strict state loading. Defaults to True.
         """
-        if not isinstance(state_dict, str):
+        if (state_dict is not None) and (not isinstance(state_dict, str)):
             super().load_module_state_dict(state_dict, strict)
             return
 
-        self.module.load_state_dir(state_dict, strict=strict)
+        self.module.load_state_dir(load_dir=self._curr_ckpt_path, strict=strict)
 
     # A map of PipeInstruction types to methods. Each method will be executed with the
     # kwargs provided to the PipeInstruction from the scheduler.

--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -52,6 +52,9 @@ class PipelineEngine(DeepSpeedEngine):
         super().__init__(*super_args, **super_kwargs)
         assert isinstance(self.module, PipelineModule), "model must base PipelineModule"
 
+        # We schedule the all-reduces, so disable it in super().backward()
+        self.enable_backward_allreduce = False
+
         # pipeline step for logging
         self.log_batch_step_id = -1
 
@@ -546,7 +549,7 @@ class PipelineEngine(DeepSpeedEngine):
         # The last stage just runs backward on the loss using DeepSpeed's typical
         # mechanisms.
         if self.is_last_stage():
-            super().backward(self.loss, allreduce_gradients=False)
+            super().backward(self.loss)
             self.mem_status('AFTER BWD')
             return
 


### PR DESCRIPTION
This PR does two things:

1. Drops deprecated `allreduce_gradients` argument to `backward()`
2. Fixes a portability bug in pipeline checkpointing. Previously, checkpoints could not be renamed due to this.