### PR TITLE
implement missing get_last_lr

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,3 +197,4 @@ Conduct](https://opensource.microsoft.com/codeofconduct/). For more information 
 2. Microsoft Research Webinar
     * Registration is free and all videos are available on-demand.
     * [ZeRO & Fastest BERT: Increasing the scale and speed of deep learning training in DeepSpeed](https://note.microsoft.com/MSR-Webinar-DeepSpeed-Registration-On-Demand.html).
+3. [DeepSpeed on AzureML](https://youtu.be/yBVXR8G8Bg8)

--- a/deepspeed/runtime/lr_schedules.py
+++ b/deepspeed/runtime/lr_schedules.py
@@ -381,6 +381,11 @@ class LRRangeTest(object):
             lr_range_test_min_lr * lr_increase for lr_range_test_min_lr in self.min_lr
         ]
 
+    def get_last_lr(self):
+        """ Return last computed learning rate by current scheduler.
+        """
+        return self._last_lr
+
     def _update_optimizer(self, group_lrs):
         for param_group, lr in zip(self.optimizer.param_groups, group_lrs):
             param_group['lr'] = lr
@@ -390,6 +395,7 @@ class LRRangeTest(object):
             batch_iteration = self.last_batch_iteration + 1
         self.last_batch_iteration = batch_iteration
         self._update_optimizer(self.get_lr())
+        self._last_lr = [group['lr'] for group in self.optimizer.param_groups]
 
     def state_dict(self):
         return {'last_batch_iteration': self.last_batch_iteration}
@@ -628,12 +634,18 @@ class OneCycle(object):
             return self._get_cycle_lr()
         return self._get_decay_lr(self.last_batch_iteration - self.total_size)
 
+    def get_last_lr(self):
+        """ Return last computed learning rate by current scheduler.
+        """
+        return self._last_lr
+
     def step(self, batch_iteration=None):
         if batch_iteration is None:
             batch_iteration = self.last_batch_iteration + 1
         self.last_batch_iteration = batch_iteration
         for param_group, lr in zip(self.optimizer.param_groups, self.get_lr()):
             param_group['lr'] = lr
+        self._last_lr = [group['lr'] for group in self.optimizer.param_groups]
 
     def state_dict(self):
         return {'last_batch_iteration': self.last_batch_iteration}
@@ -690,12 +702,18 @@ class WarmupLR(object):
                             self.delta_lrs)
         ]
 
+    def get_last_lr(self):
+        """ Return last computed learning rate by current scheduler.
+        """
+        return self._last_lr
+
     def step(self, last_batch_iteration=None):
         if last_batch_iteration is None:
             last_batch_iteration = self.last_batch_iteration + 1
         self.last_batch_iteration = last_batch_iteration
         for param_group, lr in zip(self.optimizer.param_groups, self.get_lr()):
             param_group['lr'] = lr
+        self._last_lr = [group['lr'] for group in self.optimizer.param_groups]
 
     def state_dict(self):
         return {'last_batch_iteration': self.last_batch_iteration}

--- a/deepspeed/runtime/lr_schedules.py
+++ b/deepspeed/runtime/lr_schedules.py
@@ -384,7 +384,7 @@ class LRRangeTest(object):
     def get_last_lr(self):
         """ Return last computed learning rate by current scheduler.
         """
-        assert getattr(self, '_last_lr', False), "need to call step() first"
+        assert getattr(self, '_last_lr', None) is not None, "need to call step() first"
         return self._last_lr
 
     def _update_optimizer(self, group_lrs):
@@ -638,7 +638,7 @@ class OneCycle(object):
     def get_last_lr(self):
         """ Return last computed learning rate by current scheduler.
         """
-        assert getattr(self, '_last_lr', False), "need to call step() first"
+        assert getattr(self, '_last_lr', None) is not None, "need to call step() first"
         return self._last_lr
 
     def step(self, batch_iteration=None):
@@ -707,7 +707,7 @@ class WarmupLR(object):
     def get_last_lr(self):
         """ Return last computed learning rate by current scheduler.
         """
-        assert getattr(self, '_last_lr', False), "need to call step() first"
+        assert getattr(self, '_last_lr', None) is not None, "need to call step() first"
         return self._last_lr
 
     def step(self, last_batch_iteration=None):

--- a/deepspeed/runtime/lr_schedules.py
+++ b/deepspeed/runtime/lr_schedules.py
@@ -384,7 +384,7 @@ class LRRangeTest(object):
     def get_last_lr(self):
         """ Return last computed learning rate by current scheduler.
         """
-        assert getattr(self, '_last_lr', None), "need to call step() first"
+        assert getattr(self, '_last_lr', False), "need to call step() first"
         return self._last_lr
 
     def _update_optimizer(self, group_lrs):
@@ -638,7 +638,7 @@ class OneCycle(object):
     def get_last_lr(self):
         """ Return last computed learning rate by current scheduler.
         """
-        assert getattr(self, '_last_lr', None), "need to call step() first"
+        assert getattr(self, '_last_lr', False), "need to call step() first"
         return self._last_lr
 
     def step(self, batch_iteration=None):
@@ -707,7 +707,7 @@ class WarmupLR(object):
     def get_last_lr(self):
         """ Return last computed learning rate by current scheduler.
         """
-        assert getattr(self, '_last_lr', None), "need to call step() first"
+        assert getattr(self, '_last_lr', False), "need to call step() first"
         return self._last_lr
 
     def step(self, last_batch_iteration=None):

--- a/deepspeed/runtime/lr_schedules.py
+++ b/deepspeed/runtime/lr_schedules.py
@@ -384,6 +384,7 @@ class LRRangeTest(object):
     def get_last_lr(self):
         """ Return last computed learning rate by current scheduler.
         """
+        assert getattr(self, '_last_lr', None), "need to call step() first"
         return self._last_lr
 
     def _update_optimizer(self, group_lrs):
@@ -637,6 +638,7 @@ class OneCycle(object):
     def get_last_lr(self):
         """ Return last computed learning rate by current scheduler.
         """
+        assert getattr(self, '_last_lr', None), "need to call step() first"
         return self._last_lr
 
     def step(self, batch_iteration=None):
@@ -705,6 +707,7 @@ class WarmupLR(object):
     def get_last_lr(self):
         """ Return last computed learning rate by current scheduler.
         """
+        assert getattr(self, '_last_lr', None), "need to call step() first"
         return self._last_lr
 
     def step(self, last_batch_iteration=None):


### PR DESCRIPTION
This PR fixes:
```
AttributeError: 'WarmupLR' object has no attribute 'get_last_lr'
```
by adding `get_last_lr` as it is implemented in [pytorch](https://github.com/pytorch/pytorch/blob/159f258415364f73a20ecd2b15b9f2e52ef1b922/torch/optim/lr_scheduler.py#L96)
I think it was added around pytorch-1.4.

I added `get_last_lr` to the rest of lr classes in that file, not sure if there are others.