### PR TITLE
add DeepSpeedZeroConfig __repr__ method

### DIFF
--- a/deepspeed/runtime/zero/config.py
+++ b/deepspeed/runtime/zero/config.py
@@ -6,6 +6,7 @@ Licensed under the MIT license.
 from deepspeed.runtime.config_utils import get_scalar_param
 from deepspeed.utils import logger
 from deepspeed.runtime.zero.constants import *
+import json
 
 
 class DeepSpeedZeroConfig(object):
@@ -53,6 +54,9 @@ class DeepSpeedZeroConfig(object):
 
     def repr(self):
         return self.__dict__
+
+    def __repr__(self):
+        return json.dumps(self.__dict__, sort_keys=True, indent=4)
 
     def _initialize(self, zero_config_dict):
         self.stage = get_scalar_param(zero_config_dict,


### PR DESCRIPTION
DeepSpeedZeroConfig object isn't being shown during startup

before:

```
[2020-12-10 21:24:11,820] [INFO] [config.py:648:print]   zero_config .................. 
<deepspeed.runtime.zero.config.DeepSpeedZeroConfig object at 0x7f32d4c0dbb0>
```

after this PR:

```
[2020-12-10 21:59:46,612] [INFO] [config.py:648:print]   zero_config .................. {
    "allgather_bucket_size": 500000000,
    "allgather_partitions": true,
    "contiguous_gradients": false,
    "cpu_offload": false,
    "elastic_checkpoint": true,
    "load_from_fp32_weights": true,
    "overlap_comm": false,
    "reduce_bucket_size": 500000000,
    "reduce_scatter": true,
    "stage": 0
}
```

Also I'm not sure about other files, but this file is in DOS format (`\r\n/^M `line ending)... is this by design?
