### PR TITLE
Support initialization with dict configuration

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -435,9 +435,9 @@ class DeepSpeedEngine(Module):
     # Configure based on command line arguments
     def _configure_with_arguments(self, args, mpu):
         self.local_rank = args.local_rank if hasattr(args, 'local_rank') else 0
-        self._config = DeepSpeedConfig(args.deepspeed_config,
-                                       mpu,
-                                       param_dict=self.config_params)
+        config_file = args.deepspeed_config if hasattr(args,
+                                                       'deepspeed_config') else None
+        self._config = DeepSpeedConfig(config_file, mpu, param_dict=self.config_params)
 
     # Validate command line arguments
     def _do_args_sanity_check(self, args):

--- a/tests/unit/simple_model.py
+++ b/tests/unit/simple_model.py
@@ -161,16 +161,21 @@ def create_config_from_dict(tmpdir, config_dict):
     return config_path
 
 
-def args_from_dict(tmpdir, config_dict):
-    config_path = create_config_from_dict(tmpdir, config_dict)
+def create_deepspeed_args():
     parser = argparse.ArgumentParser()
     args = parser.parse_args(args='')
     args.deepspeed = True
-    args.deepspeed_config = config_path
     if torch.distributed.is_initialized():
         # We assume up to one full node executing unit tests
         assert torch.distributed.get_world_size() <= torch.cuda.device_count()
         args.local_rank = torch.distributed.get_rank()
     else:
         args.local_rank = 0
+    return args
+
+
+def args_from_dict(tmpdir, config_dict):
+    args = create_deepspeed_args()
+    config_path = create_config_from_dict(tmpdir, config_dict)
+    args.deepspeed_config = config_path
     return args


### PR DESCRIPTION
Allow client to initialize DeepSpeed engine with a python `dict` (as config_params) and without `args.deepspeed_config`. 
Should unblock HF trainer integration issue #610 