### PR TITLE
[Installation] Fix installation on CUDA 11.0

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -36,7 +36,11 @@ def get_default_compute_capatabilities():
     import torch.utils.cpp_extension
     if torch.utils.cpp_extension.CUDA_HOME is not None and installed_cuda_version(
     )[0] >= 11:
-        compute_caps += ";8.0;8.6"
+        if installed_cuda_version()[0] == 11 and installed_cuda_version()[1] == 0:
+            # Special treatment of CUDA 11.0 because compute_86 is not supported.
+            compute_caps += ";8.0"
+        else:
+            compute_caps += ";8.0;8.6"
     return compute_caps
 
 


### PR DESCRIPTION
Fix issue: https://github.com/microsoft/DeepSpeed/issues/607.

The root cause is that the `compute_86` option hasn't been supported in CUDA 11.0 yet. See NVCC doc of cuda 11.0: https://docs.nvidia.com/cuda/archive/11.0/cuda-compiler-driver-nvcc/index.html#ptxas-options-gpu-name