### PR TITLE
doc borked table fix

### DIFF
--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -54,6 +54,7 @@ title: "DeepSpeed Configuration JSON"
   }
 ```
 The Adam optimizer also supports the following two params keys/values in addition to the standard parameters from [torch.optim.Adam](https://pytorch.org/docs/stable/_modules/torch/optim/adam.html#Adam):
+
 | "params" key  | Description                                                                 | Default |
 | ------------- | --------------------------------------------------------------------------- | --------|
 | torch\_adam   | Use torch's implementation of adam instead of our fused adam implementation | false   |
@@ -97,7 +98,7 @@ Example of ***scheduler***
           "warmup_max_lr": 0.001,
           "warmup_num_steps": 1000
       }
-  }  
+  }
 ```
 
 ### Communication options


### PR DESCRIPTION
At https://www.deepspeed.ai/docs/config-json/#optimizer-parameters there is a borked table:

![snapshot_3](https://user-images.githubusercontent.com/10676103/104110220-62b62200-528a-11eb-8405-a806fe86d8a0.png)

It looks like a valid MD, and renders fine with my own tools, but if I look at the source it's different from all other tables in that file by not having a leading new line. So this PR attempts to fix that. I'm not sure how to validate I actually fixed it.