### PR TITLE
[website] add missing config menu entries

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -37,12 +37,18 @@ lnav:
         url: /docs/config-json/#communication-options
       - title: "FP16"
         url: /docs/config-json/#fp16-training-options
+      - title: "AMP"
+        url: /docs/config-json/#automatic-mixed-precision-amp-training-options
+      - title: "Gradient Clipping"
+        url: /docs/config-json/#gradient-clipping
       - title: "ZeRO optimizations"
         url: /docs/config-json/#zero-optimizations-for-fp16-training
       - title: "Logging"
         url: /docs/config-json/#logging
       - title: "Activation checkpointing"
         url: /docs/config-json/#activation-checkpointing
+      - title: "Sparse Attention"
+        url: /docs/config-json/#sparse-attention
   - title: "Tutorials"
     url: /tutorials/
     children:


### PR DESCRIPTION
3 entries are missing from the navigation menu - this PR adds those.

If and when you merge this could you please re-generate the website? Thank you!