### PR TITLE
skip empty lines in hostfile

### DIFF
--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -120,9 +120,12 @@ def fetch_hostfile(hostfile_path):
 
     # e.g., worker-0 slots=16
     with open(hostfile_path, 'r') as fd:
-
         resource_pool = collections.OrderedDict()
         for line in fd.readlines():
+            line = line.strip()
+            if line == '':
+                # skip empty lines
+                continue
             try:
                 hostname, slots = line.split()
                 _, slot_count = slots.split("=")


### PR DESCRIPTION
If the user gives our launcher a hostfile with any empty lines we currently crash saying it's malformed, this should fix that.