### PR TITLE
Fix all Pipeline Module Parameters being sent to cuda:0

### DIFF
--- a/deepspeed/runtime/pipe/module.py
+++ b/deepspeed/runtime/pipe/module.py
@@ -186,7 +186,7 @@ class PipelineModule(nn.Module):
 
         #with torch.random.fork_rng(devices=[torch.cuda.current_device()]):
         self._build()
-        self.to('cuda')
+        self.to(f'cuda:{self.global_rank}')
 
         self.tied_comms = self._index_tied_modules()
         self._synchronize_tied_weights()

--- a/deepspeed/runtime/pipe/module.py
+++ b/deepspeed/runtime/pipe/module.py
@@ -148,6 +148,8 @@ class PipelineModule(nn.Module):
         self.world_group = dist.new_group(ranks=range(dist.get_world_size()))
         self.global_rank = dist.get_rank(group=self.world_group)
         self.world_size = dist.get_world_size(group=self.world_group)
+        self.local_rank = int(os.environ.get("LOCAL_RANK", None))
+        assert self.local_rank != None
 
         if topology:
             self._topo = topology
@@ -186,7 +188,7 @@ class PipelineModule(nn.Module):
 
         #with torch.random.fork_rng(devices=[torch.cuda.current_device()]):
         self._build()
-        self.to(f'cuda:{self.global_rank}')
+        self.to(f'cuda:{self.local_rank}')
 
         self.tied_comms = self._index_tied_modules()
         self._synchronize_tied_weights()


### PR DESCRIPTION
so, it seems that internally, PipelineModule calls `self.to('cuda')` (L189). 

This appears to send the model parameters to GPU0, for *every visible gpu* running the deepspeed script, and makes scaling up difficult. 

Instead, we can send the parameters to the current device with `self.to(f'cuda:{self.global_rank}')`.

I'm actually unsure as to why the entire model's parameters are getting sent to one single GPU at this stage at all - aren't they meant to be partitioned equally across all GPUs?

Would appreciate anyone clearing this up for me.