### PR TITLE
Fix wrong idx bug in invertible LayerNormBackward1

### DIFF
--- a/csrc/transformer/normalize_kernels.cu
+++ b/csrc/transformer/normalize_kernels.cu
@@ -624,9 +624,8 @@ __global__ void LayerNormBackward1(const T* __restrict__ out_grad,
     int offset = threadIdx.y * width + idx;
     int y_stride = width * TILE_DIM;
 
-    int pos = blockIdx.x * TILE_DIM + threadIdx.y;
-    float betta_reg = (invertible ? (float)betta[pos] : 0.0f);
-    float gamma_reg = (float)gamma[pos];
+    float betta_reg = (invertible ? (float)betta[idx] : 0.0f);
+    float gamma_reg = (float)gamma[idx];
 
     // Loop across matrix height
     float betta_tmp = 0;

--- a/csrc/transformer/normalize_kernels.cu
+++ b/csrc/transformer/normalize_kernels.cu
@@ -624,6 +624,7 @@ __global__ void LayerNormBackward1(const T* __restrict__ out_grad,
     int offset = threadIdx.y * width + idx;
     int y_stride = width * TILE_DIM;
 
+    int pos = blockIdx.x * TILE_DIM + threadIdx.y;
     float betta_reg = (invertible ? (float)betta[idx] : 0.0f);
     float gamma_reg = (float)gamma[idx];
 

--- a/csrc/transformer/normalize_kernels.cu
+++ b/csrc/transformer/normalize_kernels.cu
@@ -624,7 +624,6 @@ __global__ void LayerNormBackward1(const T* __restrict__ out_grad,
     int offset = threadIdx.y * width + idx;
     int y_stride = width * TILE_DIM;
 
-    int pos = blockIdx.x * TILE_DIM + threadIdx.y;
     float betta_reg = (invertible ? (float)betta[idx] : 0.0f);
     float gamma_reg = (float)gamma[idx];
 
@@ -660,6 +659,7 @@ __global__ void LayerNormBackward1(const T* __restrict__ out_grad,
     }
 
     if (threadIdx.x == 0) {
+        int pos = blockIdx.x * TILE_DIM + threadIdx.y;    
         betta_grad[pos] = s1;
         gamma_grad[pos] = s2;
     }
@@ -1368,7 +1368,6 @@ __global__ void LayerNormBackward1_fused_add(const T* __restrict__ out_grad1,
     int offset = threadIdx.y * width + idx;
     int y_stride = width * TILE_DIM;
 
-    int pos = blockIdx.x * TILE_DIM + threadIdx.y;
     float betta_reg = (invertible ? (float)betta[idx] : 0.0f);
     float gamma_reg = (float)gamma[idx];
 
@@ -1404,6 +1403,7 @@ __global__ void LayerNormBackward1_fused_add(const T* __restrict__ out_grad1,
     }
 
     if (threadIdx.x == 0) {
+        int pos = blockIdx.x * TILE_DIM + threadIdx.y;
         betta_grad[pos] = s1;
         gamma_grad[pos] = s2;
     }

--- a/csrc/transformer/normalize_kernels.cu
+++ b/csrc/transformer/normalize_kernels.cu
@@ -659,7 +659,7 @@ __global__ void LayerNormBackward1(const T* __restrict__ out_grad,
     }
 
     if (threadIdx.x == 0) {
-        int pos = blockIdx.x * TILE_DIM + threadIdx.y;    
+        int pos = blockIdx.x * TILE_DIM + threadIdx.y;
         betta_grad[pos] = s1;
         gamma_grad[pos] = s2;
     }

--- a/csrc/transformer/normalize_kernels.cu
+++ b/csrc/transformer/normalize_kernels.cu
@@ -1369,8 +1369,8 @@ __global__ void LayerNormBackward1_fused_add(const T* __restrict__ out_grad1,
     int y_stride = width * TILE_DIM;
 
     int pos = blockIdx.x * TILE_DIM + threadIdx.y;
-    float betta_reg = (invertible ? (float)betta[pos] : 0.0f);
-    float gamma_reg = (float)gamma[pos];
+    float betta_reg = (invertible ? (float)betta[idx] : 0.0f);
+    float gamma_reg = (float)gamma[idx];
 
     // Loop across matrix height
     float betta_tmp = 0;


### PR DESCRIPTION
Thanks for your great work. I'm migrating the DeepSpeed Transformer kernel to our in-house Tensorflow codebase. 

In this function, gradients of gamma and beta are to be computed, we need to get `val = (output-beta) / gamma`. The bug is that the index of gamma and beta didn't match the offset on the hidden size dim of output which is `idx`. 

This will result in incorrect gamma gradients, tested on our Tensorflow op implementation.