### PR TITLE
Use pure Python to determine IP address instead of nonportable `hostname -I`

### DIFF
--- a/deepspeed/utils/distributed.py
+++ b/deepspeed/utils/distributed.py
@@ -55,7 +55,8 @@ def mpi_discovery(distributed_port=TORCH_DISTRIBUTED_DEFAULT_PORT, verbose=True)
     master_addr = None
     if rank == 0:
         ips = [
-            addrinfo[4][0] for addrinfo in socket.getaddrinfo(socket.gethostname(), None)
+            addrinfo[4][0] for addrinfo in socket.getaddrinfo(socket.gethostname(),
+                                                              None)
             if addrinfo[0] == socket.AF_INET and addrinfo[1] == socket.SOCK_STREAM
         ]
         master_addr = ips[0]

--- a/deepspeed/utils/distributed.py
+++ b/deepspeed/utils/distributed.py
@@ -2,6 +2,7 @@
 Copyright 2020 The Microsoft DeepSpeed Team
 '''
 import os
+import socket
 import torch
 from datetime import timedelta
 
@@ -54,9 +55,9 @@ def mpi_discovery(distributed_port=TORCH_DISTRIBUTED_DEFAULT_PORT, verbose=True)
 
     master_addr = None
     if rank == 0:
-        hostname_cmd = ["hostname -I"]
-        result = subprocess.check_output(hostname_cmd, shell=True)
-        master_addr = result.decode('utf-8').split()[0]
+        ips = [addrinfo[4][0] for addrinfo in socket.getaddrinfo(socket.gethostname(), None)
+                              if addrinfo[0] == socket.AF_INET and addrinfo[1] == socket.SOCK_STREAM]
+        master_addr = ips[0]
     master_addr = comm.bcast(master_addr, root=0)
 
     # Determine local rank by assuming hostnames are unique

--- a/deepspeed/utils/distributed.py
+++ b/deepspeed/utils/distributed.py
@@ -48,15 +48,16 @@ def mpi_discovery(distributed_port=TORCH_DISTRIBUTED_DEFAULT_PORT, verbose=True)
     Discovery MPI environment via mpi4py and map to relevant torch.distributed state
     """
     from mpi4py import MPI
-    import subprocess
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     world_size = comm.Get_size()
 
     master_addr = None
     if rank == 0:
-        ips = [addrinfo[4][0] for addrinfo in socket.getaddrinfo(socket.gethostname(), None)
-                              if addrinfo[0] == socket.AF_INET and addrinfo[1] == socket.SOCK_STREAM]
+        ips = [
+            addrinfo[4][0] for addrinfo in socket.getaddrinfo(socket.gethostname(), None)
+            if addrinfo[0] == socket.AF_INET and addrinfo[1] == socket.SOCK_STREAM
+        ]
         master_addr = ips[0]
     master_addr = comm.bcast(master_addr, root=0)
 


### PR DESCRIPTION
The main moviation behind this change is that [coreutils][1] states, for
`hostname`, "portable scripts should not rely on its existence". In fact, the
[inetutils][2] version of `hostname` does not support the `-I` flag. The
[man page][3] from the expected version of `hostname` says to "not make any
assumptions about the order of the output".

This change uses pure Python to grab the first IP address that will work with
MPI. This was the location that caused problems for me, I haven't checked if
`hostname` appears anywhere else in the code. I used the first IPv4 address
that supported streams, since order should not matter.

[1]: https://www.gnu.org/software/coreutils/manual/html_node/hostname-invocation.html
[2]: https://www.gnu.org/software/inetutils/manual/html_node/hostname-invocation.html
[3]: https://linux.die.net/man/1/hostname