### PR TITLE
[transformer-kernel] turn off unit test printing

### DIFF
--- a/.github/workflows/torch16.yml
+++ b/.github/workflows/torch16.yml
@@ -9,7 +9,7 @@ on:
   #  - 'docs/**'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"

--- a/tests/unit/test_cuda_backward.py
+++ b/tests/unit/test_cuda_backward.py
@@ -24,8 +24,9 @@ def check_equal(first, second, atol=1e-2, verbose=False):
     diction_x = {}
     diction_y = {}
 
-    for i, (x, y) in enumerate(zip(first, second)):
-        print(x[1], y[1])
+    if verbose:
+        for i, (x, y) in enumerate(zip(first, second)):
+            print(x[1], y[1])
 
     for i, (x, y) in enumerate(zip(first, second)):
         k = 0
@@ -38,18 +39,20 @@ def check_equal(first, second, atol=1e-2, verbose=False):
         diction_y[k, y[1]] = y[0]
     if verbose:
         print()
-    for i, (x, y) in enumerate(zip(diction_x, diction_y)):
-        print(x, y)
+        for i, (x, y) in enumerate(zip(diction_x, diction_y)):
+            print(x, y)
 
     for i, (x, y) in enumerate(zip(diction_x, diction_y)):
         if (x[0] == 1): continue
-        print("checking ", x[1], ":")
+        if verbose:
+            print("checking ", x[1], ":")
         y = diction_y[x[0], x[1]]
         x = diction_x[x[0], x[1]]
         x = x.cpu().detach().numpy()
         y = y.cpu().detach().numpy()
-        print(x)
-        print(y)
+        if verbose:
+            print(x)
+            print(y)
 
         avgx = np.sum(abs(x), dtype=float)
         countx = x.shape[0]
@@ -60,8 +63,8 @@ def check_equal(first, second, atol=1e-2, verbose=False):
         if avgx != float('inf') and avgx != -float('inf'):
             avgx = avgx / countx
             tollerance = avgx * atol
-        print("tollerance is ", tollerance)
         if verbose:
+            print("tollerance is ", tollerance)
             print("x = {}".format(x.flatten()))
             print("y = {}".format(y.flatten()))
             print('-' * 80)


### PR DESCRIPTION
Default turn off printing in transformer kernel tests, results in significant speed-up in test completion.