### PR TITLE
enable apex.optimizers.FusedAdam and deepspeed fused fp16 optimizer

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -16,7 +16,7 @@ from deepspeed.runtime.zero.stage2 import FP16_DeepSpeedZeroOptimizer
 from deepspeed.runtime.zero.stage1 import FP16_DeepSpeedZeroOptimizer_Stage1
 from deepspeed.runtime.zero.utils import is_zero_supported_optimizer
 from deepspeed.runtime.activation_checkpointing import checkpointing as activation_checkpointing
-from deepspeed.runtime.fp16.fused_optimizer import FP16_Optimizer
+from deepspeed.runtime.fp16.fused_optimizer import FP16_Optimizer, FP16_FUSED_SUPPORTED_OPTIMIZERS, is_fp16_fused_supported_optimizer
 from deepspeed.runtime.fp16.unfused_optimizer import FP16_UnfusedOptimizer
 from deepspeed.runtime.config import DeepSpeedConfig, DEEPSPEED_OPTIMIZERS, \
     ADAM_OPTIMIZER, ADAMW_OPTIMIZER, LAMB_OPTIMIZER, ONEBIT_ADAM_OPTIMIZER, \
@@ -631,11 +631,7 @@ class DeepSpeedEngine(Module):
         initial_dynamic_scale = self.initial_dynamic_scale()
         dynamic_loss_args = self.dynamic_loss_scale_args()
         clip_grad = self.gradient_clipping()
-        if isinstance(optimizer,
-                      FusedAdam) or self.optimizer_name() in [
-                          'FusedAdam',
-                          ONEBIT_ADAM_OPTIMIZER
-                      ]:
+        if is_fp16_fused_supported_optimizer(optimizer):
             if self.dynamic_loss_scale():
                 logger.info('Creating fp16 optimizer with dynamic loss scale')
                 timers = self.timers if self.wall_clock_breakdown() else None

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -632,7 +632,10 @@ class DeepSpeedEngine(Module):
         dynamic_loss_args = self.dynamic_loss_scale_args()
         clip_grad = self.gradient_clipping()
         if isinstance(optimizer,
-                      FusedAdam) or self.optimizer_name() == ONEBIT_ADAM_OPTIMIZER:
+                      FusedAdam) or self.optimizer_name() in [
+                          'FusedAdam',
+                          ONEBIT_ADAM_OPTIMIZER
+                      ]:
             if self.dynamic_loss_scale():
                 logger.info('Creating fp16 optimizer with dynamic loss scale')
                 timers = self.timers if self.wall_clock_breakdown() else None


### PR DESCRIPTION
If a client provides an optimizer of type `apex.optimizers.FusedAdam`, it won't be given a fused FP16 optimizer. The `isinstance()` query here only checks for DeepSpeed's `FusedAdam`.

The implementation here was just hacked together to test the logic. We could also test for `apex.optimizers.FusedAdam` specifically, and just be careful not handle missing `apex`?

Would also love to put together a list of requirements for compatibility!

Major question: can we merge this without breaking existing checkpoints? We may need to handle loading from an unfused fp16 optimizer checkpoint.