### PR TITLE
Replace timer print rank 0 with logging

### DIFF
--- a/deepspeed/utils/timer.py
+++ b/deepspeed/utils/timer.py
@@ -4,6 +4,7 @@ Copyright 2019 The Microsoft DeepSpeed Team
 
 import time
 import torch
+from deepspeed.utils.logging import log_dist
 
 from deepspeed.utils import logger
 
@@ -13,14 +14,6 @@ try:
 except ImportError:
     PSUTILS_INSTALLED = False
     pass
-
-
-def print_rank_0(message):
-    if torch.distributed.is_initialized():
-        if torch.distributed.get_rank() == 0:
-            print(message)
-    else:
-        print(message)
 
 
 class SynchronizedWallClockTimer:
@@ -98,9 +91,9 @@ class SynchronizedWallClockTimer:
                     reset=reset) * 1000.0 / normalizer
                 string += ' | {}: {:.2f}'.format(name, elapsed_time)
 
-        # TODO: use our logging utilitied to selectively print. Useful for model
-        # parallelism because rank=0 is too restrictive.
-        print_rank_0(string)
+        # TODO: expose ranks as rank=0 is too restrictive
+        # useful for model parallelism
+        log_dist(string, ranks=[0])
 
 
 class ThroughputTimer():

--- a/deepspeed/utils/timer.py
+++ b/deepspeed/utils/timer.py
@@ -81,7 +81,7 @@ class SynchronizedWallClockTimer:
             torch.cuda.max_memory_cached() / (1024 * 1024 * 1024))
         return " | {} | {} | {} | {}".format(alloc, max_alloc, cache, max_cache)
 
-    def log(self, names, normalizer=1.0, reset=True, memory_breakdown=False):
+    def log(self, names, normalizer=1.0, reset=True, memory_breakdown=False, ranks=None):
         """Log a group of timers."""
         assert normalizer > 0.0
         string = f'rank={torch.distributed.get_rank()} time (ms)'
@@ -91,9 +91,7 @@ class SynchronizedWallClockTimer:
                     reset=reset) * 1000.0 / normalizer
                 string += ' | {}: {:.2f}'.format(name, elapsed_time)
 
-        # TODO: expose ranks as rank=0 is too restrictive
-        # useful for model parallelism
-        log_dist(string, ranks=[0])
+        log_dist(string, ranks=ranks or [0])
 
 
 class ThroughputTimer():


### PR DESCRIPTION
Codebase is awesome, thanks for the great work guys :)

To reduce the logging stdout when training it would be nice to swap to using logging rather than print to configure verbosity.

Let me know if theres any thoughts/issues! 