### PR TITLE
Only call Init Distributed if required

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -131,10 +131,10 @@ class DeepSpeedEngine(Module):
             dist_init_required = not dist.is_initialized()
 
         if dist_init_required is False:
-            assert (dist.is_initialized()==True), "Torch distributed not initialized. Please set dist_init_required to True or initialize before calling deepspeed.initialize()"
-
-        # Initialize torch distributed if needed
-        init_distributed(dist_backend=self.dist_backend)
+            assert dist.is_initialized() is True, "Torch distributed not initialized. Please set dist_init_required to True or initialize before calling deepspeed.initialize()"
+        else:
+            # Initialize torch distributed if needed
+            init_distributed(dist_backend=self.dist_backend)
 
         self._do_args_sanity_check(args)
         self._configure_with_arguments(args, mpu)


### PR DESCRIPTION
Adds an else statement to make sure we only call `init_distributed` if required. 

I added this due to running into an `mpi4py` missing requirement issue, since we do not expose the `auto_mpi_discovery` flag within the `init_distributed` function. As a result by ensuring we use the check first to see if distributed has already been initialized, we can omit calling this check.