### PR TITLE
[install] fixes/improvements/docs

### DIFF
--- a/docs/_tutorials/advanced-install.md
+++ b/docs/_tutorials/advanced-install.md
@@ -65,6 +65,14 @@ Available `DS_BUILD` options include:
 * `DS_BUILD_STOCHASTIC_TRANSFORMER` builds the stochastic transformer op
 * `DS_BUILD_UTILS` builds various optimized utilities
 
+To speed up the build-all process, you can parallelize the compilation process with:
+
+```bash
+DS_BUILD_OPS=1 pip install deepspeed --global-option="build_ext" --global-option="-j8"
+```
+
+This should complete the full build 2-3 times faster. You can adjust `-j` to specify how many cpu-cores to be used during the build. In the example 8 cores will be used.
+
 
 ## Install DeepSpeed from source
 

--- a/docs/_tutorials/advanced-install.md
+++ b/docs/_tutorials/advanced-install.md
@@ -71,7 +71,7 @@ To speed up the build-all process, you can parallelize the compilation process w
 DS_BUILD_OPS=1 pip install deepspeed --global-option="build_ext" --global-option="-j8"
 ```
 
-This should complete the full build 2-3 times faster. You can adjust `-j` to specify how many cpu-cores to be used during the build. In the example 8 cores will be used.
+This should complete the full build 2-3 times faster. You can adjust `-j` to specify how many cpu-cores are to be used during the build. In the example it is set to 8 cores.
 
 
 ## Install DeepSpeed from source

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ usage() {
   echo """
 Usage: install.sh [options...]
 
-By default will install deepspeed and all third party dependecies accross all machines listed in
+By default will install deepspeed and all third party dependencies across all machines listed in
 hostfile (hostfile: /job/hostfile). If no hostfile exists, will only install locally
 
 [optional]
@@ -45,6 +45,10 @@ while [[ $# -gt 0 ]]
 do
 key="$1"
 case $key in
+    -l|--local_only)
+    local_only=1;
+    shift
+    ;;
     -s|--pip_sudo)
     pip_sudo=1;
     shift
@@ -69,7 +73,7 @@ case $key in
     -H|--hostfile)
     hostfile=$2
     if [ ! -f $2 ]; then
-        echo "User provided hostfile does not exist at $hostfile, exiting"
+        echo "User-provided hostfile does not exist at $hostfile, exiting"
         exit 1
     fi
     shift
@@ -80,7 +84,7 @@ case $key in
     exit 0
     ;;
     *)
-    echo "Unkown argument(s)"
+    echo "Unknown argument(s)"
     usage
     exit 1
     shift
@@ -98,7 +102,7 @@ if [ "$allow_sudo" == "0" ]; then
 fi
 
 if [ "$ds_only" == "1" ] && [ "$tp_only" == "1" ]; then
-    echo "-d and -t are mutually exclusive, only choose one or none"
+    echo "-d and -t are mutually exclusive, only choose one of the two"
     usage
     exit 1
 fi


### PR DESCRIPTION
This PR:

* fixes typos in `install.sh`
* adds the missing `-l` flag (`install.sh -l` fails)
* adds instructions on how to parallelize the full build to get 2-3x speedups (advanced install doc)

Demo of the speedup:
```
rm -rf build
time TORCH_CUDA_ARCH_LIST="6.1;8.6" DS_BUILD_OPS=1 pip install --no-cache -v --disable-pip-version-check -e . 2>&1 | tee build.log
real    1m58.428s
user    1m46.989s
sys     0m12.085s


rm -rf build
time TORCH_CUDA_ARCH_LIST="6.1;8.6" DS_BUILD_OPS=1 pip install --editable . --global-option="build_ext" --global-option="-j8" --no-cache -v --disable-pip-version-check 2>&1 | tee build.log
real    0m48.744s
user    1m52.540s
sys     0m12.522s
```

from 2 min to 50 secs

Another thing that might be useful is to help the user see what's happening, since it's better not to hide the compilation process, in which case adding:  `-v --disable-pip-version-check` is a useful addition. (the last flag prevents a very noisy flurry of pointless pip version check logs)

My `build.sh` is:
```
#!/bin/bash
rm -rf build
time TORCH_CUDA_ARCH_LIST="6.1;8.6" DS_BUILD_OPS=1 pip install -e . --global-option="build_ext" --global-option="-j8" --no-cache -v --disable-pip-version-check 2>&1 | tee build.log
```
