### PR TITLE
Fix checkpoint loading when zero optimizer states are not given

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1346,6 +1346,8 @@ class DeepSpeedEngine(Module):
                     load_optimizer_states=load_optimizer_states)
             elif load_optimizer_states:
                 self.optimizer.load_state_dict(checkpoint['optimizer'])
+        elif self.optimizer is not None and self.fp16_enabled():
+            self.optimizer._restore_from_fp16_weights()
 
         if load_lr_scheduler_states and self.lr_scheduler is not None:
             self.lr_scheduler.load_state_dict(checkpoint['lr_scheduler'])


### PR DESCRIPTION
When I use DeepSpeed for the finetuning without giving the zero state checkpoints, the FP32 master parameter is not initialized properly. This PR fixes this issue.