### PR TITLE
Fix NameError: name 'dist' is not defined

### DIFF
--- a/deepspeed/utils/distributed.py
+++ b/deepspeed/utils/distributed.py
@@ -89,7 +89,8 @@ def mpi_discovery(distributed_port=TORCH_DISTRIBUTED_DEFAULT_PORT, verbose=True)
                     os.environ['MASTER_PORT']))
 
     if torch.distributed.is_initialized():
-        assert torch.distributed.get_rank() == rank, "MPI rank {} does not match torch rank {}".format(rank, dist.get_rank())
+        assert torch.distributed.get_rank() == rank, "MPI rank {} does not match torch rank {}".format(
+            rank, torch.distributed.get_rank())
         assert torch.distributed.get_world_size() == world_size, "MPI world size {} does not match torch world size {}".format(
             world_size, torch.distributed.get_world_size())
 


### PR DESCRIPTION
Thanks for the great work. I found that `NameError` raises in `mpi_discovery` at `deepspeed/utils/distributed.py`.
This PR fixes the following error:

```
  File "/opt/work/train_engine.py", line 273, in set_model
    self.criterion, self.optimizer, _, self.scheduler = deepspeed.initialize(
  File "/home/makino/.local/lib/python3.8/site-packages/deepspeed/__init__.py", line 110, in initialize
    engine = DeepSpeedEngine(args=args,
  File "/home/makino/.local/lib/python3.8/site-packages/deepspeed/runtime/engine.py", line 134, in __init__
    init_distributed(dist_backend=self.dist_backend)
  File "/home/makino/.local/lib/python3.8/site-packages/deepspeed/utils/distributed.py", line 35, in init_distributed
    mpi_discovery(distributed_port=distributed_port, verbose=verbose)
  File "/home/makino/.local/lib/python3.8/site-packages/deepspeed/utils/distributed.py", line 82, in mpi_discovery
    assert torch.distributed.get_rank() == rank, "MPI rank {} does not match torch rank {}".format(rank, dist.get_rank())
NameError: name 'dist' is not defined
```