### PR TITLE
[checkpointing] Ensure tag is a string

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1482,6 +1482,9 @@ class DeepSpeedEngine(Module):
         if tag is None:
             tag = f"global_step{self.global_steps}"
 
+        # Ensure tag is a string
+        tag = str(tag)
+
         # Ensure checkpoint tag is consistent across ranks
         self._checkpoint_tag_validation(tag)
 


### PR DESCRIPTION
Our megatron example uses an integer as the tag, this forces whatever tag is given to be a string since it will ultimately be used as a path.