### PR TITLE
Fixing the CPU-Adam compile issue for the AMD architecture

### DIFF
--- a/op_builder/cpu_adam.py
+++ b/op_builder/cpu_adam.py
@@ -36,7 +36,7 @@ class CPUAdamBuilder(CUDAOpBuilder):
                 return '-D__AVX512__'
             elif 'avx2' in result:
                 return '-D__AVX256__'
-        return ''
+        return '-D__SCALAR__'
 
     def cxx_args(self):
         CUDA_LIB64 = os.path.join(torch.utils.cpp_extension.CUDA_HOME, "lib64")


### PR DESCRIPTION
It seems like adding empty string in the CPU-ADAM op_builder make gcc crash with this error: "gcc: error: : No such file or directory". I did a simple modification and returned -D__SCALAR__ instead of empty string. This won't make any difference in the cpp code since we already have conditions for both AVX2 and AVX512.
This fixes this [issue](https://github.com/microsoft/DeepSpeed/issues/788).