### PR TITLE
Fix OneBitAdam / Pipeline Parallel with nccl backend

### DIFF
--- a/deepspeed/runtime/comm/nccl.py
+++ b/deepspeed/runtime/comm/nccl.py
@@ -12,8 +12,12 @@ from deepspeed.runtime.compression.cupy import CupyBackend
 
 
 class NcclBackend(object):
-    def __init__(self):
-        self.world_group = dist.new_group(ranks=range(dist.get_world_size()))
+    def __init__(self, mpu=None):
+        if mpu is None:
+            self.world_group = dist.new_group(ranks=range(dist.get_world_size()))
+        else:
+            self.mpu = mpu
+            self.world_group = self.mpu.get_data_parallel_group()
         self.rank = dist.get_rank(group=self.world_group)
         self.size = dist.get_world_size(group=self.world_group)
         self.compression_backend = CupyBackend()
@@ -82,7 +86,7 @@ class NcclBackend(object):
 
         # worker_scale = self.compression_backend.cupy2torch(cupy_worker_scale)
         recvbuf_sign = self.compression_backend.cupy2torch(cupy_recvbuf_sign)
-        #recvbuf_scale = self.compression_backend.cupy2torch(cupy_recvbuf_scale)
+        # recvbuf_scale = self.compression_backend.cupy2torch(cupy_recvbuf_scale)
         recvbuf_scale = [
             torch.zeros(1,
                         dtype=worker_scale.dtype,
@@ -92,9 +96,9 @@ class NcclBackend(object):
         # communication phase 1
         # gather_start = time.time()
         # Alltoall for sign
-        dist.all_to_all_single(recvbuf_sign, torch.stack(sign_list_packed))
+        dist.all_to_all_single(recvbuf_sign, torch.stack(sign_list_packed), group=self.world_group)
         # Allgather for scale
-        dist.all_gather(recvbuf_scale, worker_scale)
+        dist.all_gather(recvbuf_scale, worker_scale, group=self.world_group)
 
         # gather_end = time.time()
 
@@ -102,13 +106,13 @@ class NcclBackend(object):
         cupy_sign_list_packed = None
 
         cupy_recvbuf_sign = self.compression_backend.torch2cupy(recvbuf_sign)
-        #cupy_recvbuf_scale = self.compression_backend.torch2cupy(torch.stack(recvbuf_scale))
+        # cupy_recvbuf_scale = self.compression_backend.torch2cupy(torch.stack(recvbuf_scale))
 
         compensated_server_m = self.compression_backend.cupy2torch(
             (cupy.unpackbits(cupy_recvbuf_sign.flatten())).reshape(
                 self.size,
                 -1)).float().add_(-0.5).mul_(2.0).mul_(
-                    torch.stack(recvbuf_scale).mul_(1 / self.size)).sum(0)
+            torch.stack(recvbuf_scale).mul_(1 / self.size)).sum(0)
         compensated_server_m.add_(server_error)
         server_scale = torch.norm(compensated_server_m) / np.sqrt(
             compensated_server_m.numel())
@@ -151,8 +155,8 @@ class NcclBackend(object):
         ]
 
         # Communication Phase 2
-        dist.all_gather(recvbuf_sign_server, server_sign_packed[0])
-        dist.all_gather(recvbuf_scale_server, server_scale)
+        dist.all_gather(recvbuf_sign_server, server_sign_packed[0], group=self.world_group)
+        dist.all_gather(recvbuf_scale_server, server_scale, group=self.world_group)
 
         cupy_server_sign_packed = None
 
@@ -168,8 +172,8 @@ class NcclBackend(object):
                 (cupy.unpackbits(cupy_recvbuf_sign_server.flatten())).reshape(
                     self.size,
                     -1)).float().add_(-0.5).mul_(2.0).mul_(
-                        self.compression_backend.cupy2torch(
-                            cupy_recvbuf_scale_server)).flatten().data)
+                self.compression_backend.cupy2torch(
+                    cupy_recvbuf_scale_server)).flatten().data)
         if original_size != worker_error_size:
             buffer_m = buffer_m[0:original_size]
         if len(original_shape) > 1:

--- a/deepspeed/runtime/fp16/onebit/onebitadam.py
+++ b/deepspeed/runtime/fp16/onebit/onebitadam.py
@@ -94,7 +94,7 @@ class OnebitAdam(torch.optim.Optimizer):
             assert TORCH_MAJOR >= 1 and TORCH_MINOR >= 8, "Please use torch 1.8 or greater to enable NCCL backend in 1-bit Adam. Alternatively, please specify 'mpi' as the 'comm_backend_name' in config file to proceed with the MPI backend"
             assert dist.is_initialized() == True, "Please initialize the torch distributed backend."
             from deepspeed.runtime.comm.nccl import NcclBackend
-            self.comm_backend_handle = NcclBackend()
+            self.comm_backend_handle = NcclBackend(self.deepspeed.mpu)
 
         elif self.comm_backend_name == 'mpi':
             from deepspeed.runtime.comm.mpi import MpiBackend
@@ -247,6 +247,7 @@ class OnebitAdam(torch.optim.Optimizer):
 
         if self.adam_freeze_key is False:
             if state['step'] >= self.freeze_step:
+                print('Starting compressed communication')
                 self.adam_freeze_key = True
                 self.deepspeed.enable_backward_allreduce = False
 

--- a/deepspeed/runtime/fp16/onebit/onebitadam.py
+++ b/deepspeed/runtime/fp16/onebit/onebitadam.py
@@ -250,6 +250,7 @@ class OnebitAdam(torch.optim.Optimizer):
                 print('Starting compressed communication')
                 self.adam_freeze_key = True
                 self.deepspeed.enable_backward_allreduce = False
+                self.deepspeed.pipeline_enable_backward_allreduce = False
 
         return loss
 
@@ -276,6 +277,8 @@ class OnebitAdam(torch.optim.Optimizer):
             if self.adam_freeze_key is True:
                 self.adam_freeze_key = False
                 self.deepspeed.enable_backward_allreduce = True
+                self.deepspeed.pipeline_enable_backward_allreduce = True
+
             for group in self.param_groups:
                 for p in group['params']:
                     self.state[p].pop('worker_error')

--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -42,30 +42,24 @@ def _tensor_bytes(tensor):
     return tensor.numel() * tensor.element_size()
 
 
-def print_rank_0(message):
-    if torch.distributed.is_initialized():
-        if torch.distributed.get_rank() == 0:
-            print(message)
-    else:
-        print(message)
-
-
 class PipelineEngine(DeepSpeedEngine):
     """ A training engine hybrid pipeline, data, and model parallel training.
 
     This engine is created by ``deepspeed.initialize()`` when a :class:`PipelineModule`
     is provided.
     """
-
     def __init__(self, *super_args, **super_kwargs):
         super().__init__(*super_args, **super_kwargs)
         assert isinstance(self.module, PipelineModule), "model must base PipelineModule"
 
         # We schedule the all-reduces, so disable it in super().backward()
         self.enable_backward_allreduce = False
+        
+        # used to disable the pipeline all-reduce when used with 1-bit adam
         self.pipeline_enable_backward_allreduce = True
+        
         assert not self.elasticity_enabled(), "Elasticity is not currently supported" \
-                                              " with pipeline parallelism."
+            " with pipeline parallelism."
 
         # pipeline step for logging
         self.log_batch_step_id = -1
@@ -83,7 +77,7 @@ class PipelineEngine(DeepSpeedEngine):
 
         assert self.dp_world_size == self.grid.data_parallel_size
         assert self.train_batch_size() == \
-               self.micro_batch_size * self.micro_batches * self.grid.data_parallel_size
+            self.micro_batch_size * self.micro_batches * self.grid.data_parallel_size
 
         #  Set Stage Inf
         self.num_stages = self.grid.pipe_parallel_size
@@ -97,7 +91,7 @@ class PipelineEngine(DeepSpeedEngine):
         self._force_grad_boundary = False
 
         self.batch_timer = ThroughputTimer(batch_size=self.micro_batch_size *
-                                                      self.micro_batches,
+                                           self.micro_batches,
                                            num_workers=self.dp_world_size,
                                            logging_fn=self.tput_log,
                                            monitor_memory=False,
@@ -137,21 +131,21 @@ class PipelineEngine(DeepSpeedEngine):
                         f'STAGE={self.stage_id} '
                         f'LAYERS={self.module._local_stop - self.module._local_start} '
                         f'[{self.module._local_start}, {self.module._local_stop}) '
-                        f'STAGE_PARAMS={num_params} ({num_params / 1e6:0.3f}M) '
-                        f'TOTAL_PARAMS={total_params} ({total_params / 1e6:0.3f}M) '
-                        f'UNIQUE_PARAMS={unique_params} ({unique_params / 1e6:0.3f}M)')
+                        f'STAGE_PARAMS={num_params} ({num_params/1e6:0.3f}M) '
+                        f'TOTAL_PARAMS={total_params} ({total_params/1e6:0.3f}M) '
+                        f'UNIQUE_PARAMS={unique_params} ({unique_params/1e6:0.3f}M)')
 
-        # intialize peer-2-peer communication and allreduce groups
+        #intialize peer-2-peer communication and allreduce groups
         if self.is_pipe_parallel:
             p2p.init_process_groups(self.grid)
 
         # Pipeline buffers
         self.num_pipe_buffers = 0
         self.pipe_buffers = {
-            'inputs': [],  # batch input and received activations
-            'labels': [],  # labels from batch input
-            'outputs': [],  # activations
-            'output_tensors': [],  # tensor object to preserve backward graph
+            'inputs' : [],   # batch input and received activations
+            'labels' : [],   # labels from batch input
+            'outputs' : [],  # activations
+            'output_tensors' : [], # tensor object to preserve backward graph
         }
         self.pipe_recv_buf = None
         self.grad_layer = None
@@ -161,10 +155,10 @@ class PipelineEngine(DeepSpeedEngine):
         self.first_output_send = True
         self.first_gradient_send = True
 
-        # stores the loss for the current micro batch being processed
+        #stores the loss for the current micro batch being processed
         self.loss = torch.tensor(0.0).to(self.device)
 
-        # stores the loss for the entire batch
+        #stores the loss for the entire batch
         self.total_loss = None
         self.agg_loss = torch.tensor(0.0, requires_grad=False).to(self.device)
         self.dp_group_loss = torch.tensor(0.0, requires_grad=False).to(self.device)
@@ -188,6 +182,22 @@ class PipelineEngine(DeepSpeedEngine):
             if not self.is_last_stage():
                 p2p.send(self.loss, self.next_stage)
 
+        # XXX look into timer reporting timing
+        # Initialize some timers because of early weirdness.
+        if self.wall_clock_breakdown():
+            self.timers('forward_microstep').start()
+            self.timers('forward_microstep').stop()
+            self.timers('backward_microstep').start()
+            self.timers('backward_microstep').stop()
+            self.timers('backward_inner_microstep').start()
+            self.timers('backward_inner_microstep').stop()
+            self.timers('backward_allreduce_microstep').start()
+            self.timers('backward_allreduce_microstep').stop()
+            self.timers('backward_allreduce').start()
+            self.timers('backward_allreduce').stop()
+            self.timers('step_microstep').start()
+            self.timers('step_microstep').stop()
+
     def _build_data_iter(self, dataset):
         sampler = torch.utils.data.distributed.DistributedSampler(
             dataset,
@@ -200,10 +210,6 @@ class PipelineEngine(DeepSpeedEngine):
         self.set_dataloader(pipe_dataloader)
 
     def _exec_reduce_tied_grads(self):
-        if self.wall_clock_breakdown():
-            self.timers('reduce_tied_grads').start()
-            self.timers('comms').start()
-
         # We need to run this first to write to self.averaged_gradients;
         # since this class turns `enable_backward_allreduce` off,
         # `self.overlapping_partition_gradients_reduce_epilogue()` defined in the DeepSpeedEngine
@@ -215,23 +221,13 @@ class PipelineEngine(DeepSpeedEngine):
         if self.zero_optimization_partition_gradients():
             self.optimizer.overlapping_partition_gradients_reduce_epilogue()
         self.module.allreduce_tied_weight_gradients()
-        if self.wall_clock_breakdown():
-            self.timers('reduce_tied_grads').stop()
-            self.timers('comms').stop()
 
     def _exec_reduce_grads(self):
-        if self.wall_clock_breakdown():
-            self.timers('reduce_grads').start()
-            self.timers('comms').start()
-
         self._force_grad_boundary = True
         if self.is_data_parallel and self.pipeline_enable_backward_allreduce:
             self.buffered_allreduce_fallback(
                 elements_per_buffer=MEMORY_OPT_ALLREDUCE_SIZE)
         self._force_grad_boundary = False
-        if self.wall_clock_breakdown():
-            self.timers('reduce_grads').stop()
-            self.timers('comms').stop()
 
     def _reserve_pipe_buffers(self, num_buffers):
         """Ensure that each pipeline buffer has at least ``num_buffers`` slots.
@@ -293,8 +289,8 @@ class PipelineEngine(DeepSpeedEngine):
         self.timers('train_batch').stop()
 
         if self.global_steps % self.steps_per_print() == 0:
-            elapsed = self.timers('train_batch').elapsed(reset=True)
             if self.global_rank == 0:
+                elapsed = self.timers('train_batch').elapsed(reset=True)
                 iter_time = elapsed / self.steps_per_print()
                 tput = self.train_batch_size() / iter_time
                 print(f'steps: {self.global_steps} '
@@ -315,14 +311,12 @@ class PipelineEngine(DeepSpeedEngine):
 
         if self.wall_clock_breakdown(
         ) and self.global_steps % self.steps_per_print() == 0:
-                pct_comms = self.timers('comms').elapsed(reset=False) / elapsed * 100
-                pct_optimizer_step = self.timers('step').elapsed(reset=False) / elapsed * 100
-                pct_fwd = self.timers('forward').elapsed(reset=False) / elapsed * 100
-                pct_backward = self.timers('backward').elapsed(reset=False) / elapsed * 100
-                print_rank_0(
-                    f'%comms: {pct_comms} \n %optimizer_step {pct_optimizer_step} \n %forward: {pct_fwd} \n %backward: {pct_backward}')
-                names = list(self.timers.timers.keys())
-                self.timers.log(names)
+            self.timers.log([
+                'pipe_send_output',
+                'pipe_send_grad',
+                'pipe_recv_input',
+                'pipe_recv_grad'
+            ])
 
         # TODO: should return precisely what loss returned and allow others to be queried?
         return self.agg_train_loss
@@ -383,7 +377,7 @@ class PipelineEngine(DeepSpeedEngine):
         self.set_dataiterator(train_iterator)
 
         # Reset any buffers that may have been populated during the forward passes.
-        # ds_checkpointing.reset()
+        #ds_checkpointing.reset()
 
         return self.agg_eval_loss
 
@@ -403,7 +397,7 @@ class PipelineEngine(DeepSpeedEngine):
 
             ## Average loss across all data-parallel groups
             agg_loss = self.dp_group_loss.clone().detach()
-            # print(f'RANK={self.global_rank} bcast SENDER src={self.global_rank} group={self.grid.pp_group}', flush=True)
+            #print(f'RANK={self.global_rank} bcast SENDER src={self.global_rank} group={self.grid.pp_group}', flush=True)
             if self.is_data_parallel:
                 dist.all_reduce(agg_loss, group=self.mpu.get_data_parallel_group())
                 agg_loss /= self.dp_world_size
@@ -509,7 +503,7 @@ class PipelineEngine(DeepSpeedEngine):
             inputs = tuple([part_input.full(), inputs[2]])
             inputs[0].requires_grad = True
             # skip mask
-            # inputs[1].requires_grad = True
+            #inputs[1].requires_grad = True
             part_input = None
             self.pipe_buffers['inputs'][buffer_id] = inputs
 
@@ -567,7 +561,10 @@ class PipelineEngine(DeepSpeedEngine):
         outputs = self.pipe_buffers['outputs'][buffer_id]
 
         if self.wall_clock_breakdown():
+            self.timers('backward_microstep').start()
             self.timers('backward').start()
+            self.timers('backward_inner_microstep').start()
+            self.timers('backward_inner').start()
 
         # Reconstruct if we previously partitioned the output. We must be
         # careful to also restore the computational graph of the tensors we partitioned.
@@ -590,14 +587,14 @@ class PipelineEngine(DeepSpeedEngine):
 
         grad_tensors = self.grad_layer
         if self.is_grad_partitioned:
-            # print(f'RANK={self.global_rank} BEFORE-BWD restoring grad={self.grad_layer[0].size()} {self.grad_layer[1].size()}')
+            #print(f'RANK={self.global_rank} BEFORE-BWD restoring grad={self.grad_layer[0].size()} {self.grad_layer[1].size()}')
             part_grad = PartitionedTensor.from_meta(
                 meta=self.grad_layer[0],
                 local_part=self.grad_layer[1],
                 group=self.grid.get_slice_parallel_group())
             grad_tensors = tuple([part_grad.full(), self.grad_layer[2]])
             part_grad = None
-            # print(f'RANK={self.global_rank} BEFORE-BWD restored grad={self.grad_layer[0].size()} {self.grad_layer[1].size()}')
+            #print(f'RANK={self.global_rank} BEFORE-BWD restored grad={self.grad_layer[0].size()} {self.grad_layer[1].size()}')
 
         # This handles either a single tensor or tuple of tensors.
         if isinstance(outputs, tuple):
@@ -605,7 +602,7 @@ class PipelineEngine(DeepSpeedEngine):
             assert len(out_tensors) == len(grad_tensors)
             torch.autograd.backward(tensors=out_tensors, grad_tensors=grad_tensors)
         else:
-            torch.autograd.backward(tensors=(outputs,), grad_tensors=(grad_tensors,))
+            torch.autograd.backward(tensors=(outputs, ), grad_tensors=(grad_tensors, ))
 
         # Free up the memory from the output of forward()
         self.pipe_buffers['output_tensors'][buffer_id] = None
@@ -613,7 +610,10 @@ class PipelineEngine(DeepSpeedEngine):
         grad_tensors = None
 
         if self.wall_clock_breakdown():
+            self.timers('backward_inner').stop()
+            self.timers('backward_inner_microstep').stop()
             self.timers('backward').stop()
+            self.timers('backward_microstep').stop()
 
         self.mem_status('AFTER BWD')
 
@@ -774,7 +774,6 @@ class PipelineEngine(DeepSpeedEngine):
     def _exec_send_activations(self, buffer_id):
         if self.wall_clock_breakdown():
             self.timers('pipe_send_output').start()
-            self.timers('comms').start()
 
         outputs = self.pipe_buffers['outputs'][buffer_id]
 
@@ -807,7 +806,6 @@ class PipelineEngine(DeepSpeedEngine):
 
         if self.wall_clock_breakdown():
             self.timers('pipe_send_output').stop()
-            self.timers('comms').stop()
 
     def _exec_send_grads(self, buffer_id):
         if self.wall_clock_breakdown():
@@ -845,7 +843,7 @@ class PipelineEngine(DeepSpeedEngine):
                 p2p.send(inputs[0], self.prev_stage)
                 p2p.send(inputs[1], self.prev_stage)
                 # XXX hack hack hack
-                # p2p.send(inputs[2].grad, self.prev_stage)
+                #p2p.send(inputs[2].grad, self.prev_stage)
             else:
                 for idx, buffer in enumerate(inputs):
                     # Skip tensors that will not produce a grad
@@ -909,7 +907,6 @@ class PipelineEngine(DeepSpeedEngine):
     def _exec_recv_grads(self, buffer_id):
         if self.wall_clock_breakdown():
             self.timers('pipe_recv_grad').start()
-            self.timers('comms').start()
 
         outputs = self.pipe_buffers['outputs'][buffer_id]
         # XXX these shapes are hardcoded for Megatron
@@ -947,10 +944,10 @@ class PipelineEngine(DeepSpeedEngine):
 
         if self.wall_clock_breakdown():
             self.timers('pipe_recv_grad').stop()
-            self.timers('comms').stop()
 
     def _exec_optimizer_step(self, lr_kwargs=None):
         if self.wall_clock_breakdown():
+            self.timers('step_microstep').start()
             self.timers('step').start()
         self.mem_status('BEFORE STEP', reset_max=True)
 
@@ -973,7 +970,26 @@ class PipelineEngine(DeepSpeedEngine):
                     self.summary_writer.add_scalar(event[0], event[1], event[2])
 
         if self.wall_clock_breakdown():
+            self.timers('step_microstep').stop()
             self.timers('step').stop()
+            if self.global_steps % self.steps_per_print() == 0:
+                self.timers.log([
+                    'batch_input',
+                    'forward_microstep',
+                    'backward_microstep',
+                    'backward_inner_microstep',
+                    'backward_allreduce_microstep',
+                    'backward_tied_allreduce_microstep',
+                    'step_microstep'
+                ])
+            if self.global_steps % self.steps_per_print() == 0:
+                self.timers.log([
+                    'forward',
+                    'backward',
+                    'backward_inner',
+                    'backward_allreduce',
+                    'step'
+                ])
 
     def _zero_grads(self, inputs):
         if isinstance(inputs, torch.Tensor):
@@ -1039,7 +1055,7 @@ class PipelineEngine(DeepSpeedEngine):
         return
         global mem_alloced, mem_cached
         if not self.global_steps == 0 or not self.global_steps == 9:
-            # return
+            #return
             pass
         if self.mpu.get_data_parallel_rank() != 0:
             return
@@ -1070,12 +1086,12 @@ class PipelineEngine(DeepSpeedEngine):
         max_cached = torch.cuda.max_memory_cached()
 
         # convert to GB for printing
-        new_alloced /= 1024 ** 3
-        new_cached /= 1024 ** 3
-        delta_alloced /= 1024 ** 3
-        delta_cached /= 1024 ** 3
-        max_alloced /= 1024 ** 3
-        max_cached /= 1024 ** 3
+        new_alloced /= 1024**3
+        new_cached /= 1024**3
+        delta_alloced /= 1024**3
+        delta_cached /= 1024**3
+        max_alloced /= 1024**3
+        max_cached /= 1024**3
 
         print(
             f'RANK={rank} STAGE={self.stage_id} STEP={self.global_steps} MEMSTATS',


### PR DESCRIPTION
Following on from https://github.com/microsoft/DeepSpeed/issues/818 , onebitadam is not compatible with Pipeline Parallel training.

This is because there is no logic built in to 1-bitadam to detect pp groups, and so the allreduce will hang or fail as it will try to wait for other stages.

This PR gets it *running* with pipeline parallelism and nccl backend only, although in the (limited) testing i've done so far i've observed only minimal speedup.

I'm also not sure how this will interact with reducing tied gradients, so that's something left open to discussion.

TODO:

- [ ] Verify approach is correct (i'm looking at you deepspeed devs :smile: )
- [ ] Add fix for mpi backend (I guess you would have to get the data parallel group from dist and pass the nodes in manually to mpi? I'm not too familiar with mpi so any advice here would be appreciated)
- [ ] Add fix for tied gradients