### PR TITLE
fix pipeline engine allreduce bug supporting zero optimizer

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -221,8 +221,7 @@ class PipelineEngine(DeepSpeedEngine):
     def _exec_reduce_grads(self):
         self._force_grad_boundary = True
         if self.is_data_parallel:
-            self.buffered_allreduce_fallback(
-                elements_per_buffer=MEMORY_OPT_ALLREDUCE_SIZE)
+            self.allreduce_gradients(bucket_size=MEMORY_OPT_ALLREDUCE_SIZE)
         self._force_grad_boundary = False
 
     def _reserve_pipe_buffers(self, num_buffers):


### PR DESCRIPTION
Hello, I found that when the pipeline engine synchronizes the gradient, the communication function in the zero stage will not be called when the zero optimizer is setted.
I think this should be a bug, thanks
