### PR TITLE
Save ZeRO3 (partitioned) fp16 weights

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -2832,6 +2832,17 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
     def save_checkpoint_epilogue(self):
         self.persistent_parameters[0].all_gather(self.persistent_parameters)
 
+    def save_partitioned_weights(self, state_dict):
+        for name, param in self.module.named_parameters():
+            if name in state_dict.keys():
+                state_dict[name] = param.ds_tensor
+        return state_dict
+
+    def load_partitioned_weights(self, state_dict):
+        for name, param in self.module.named_parameters():
+            if name in state_dict.keys():
+                param.ds_tensor.copy_(state_dict[name])
+
 
 def _handle_overflow(cpu_sum, x, i):
     import math

--- a/docs/_tutorials/getting-started.md
+++ b/docs/_tutorials/getting-started.md
@@ -265,8 +265,8 @@ local machine to discover the number of slots available. The `--include` and
 `--exclude` arguments work as normal, but the user should specify 'localhost'
 as the hostname.
 
-Also note that `CUDA_VISIBLE_DEVICES` can't be used with DeepSpeed to control 
-which devices should be used. For example, to use only gpu1 of the current 
+Also note that `CUDA_VISIBLE_DEVICES` can't be used with DeepSpeed to control
+which devices should be used. For example, to use only gpu1 of the current
 node, do:
 ```bash
 deepspeed --include localhost:1 ...

--- a/tests/unit/test_checkpointing.py
+++ b/tests/unit/test_checkpointing.py
@@ -47,7 +47,7 @@ def compare_model_states(saved_model, loaded_model, compare_optimizer=True):
         p1_has_ds_tensor = hasattr(p1, 'ds_tensor')
         assert p0_has_ds_tensor == p1_has_ds_tensor, f'Mismatch has ds_tensor attribute p0:{p0_has_ds_tensor}, p1:{p1_has_ds_tensor}'
         if p0_has_ds_tensor:
-            assert torch.allclose(p0, p1, atol=1e-07), f'FP16 model state {p0} is not equal to {p1}'
+            assert torch.allclose(p0.ds_tensor, p1.ds_tensor, atol=1e-07), f'FP16 model state {p0} is not equal to {p1}'
 
     if not compare_optimizer:
         return

--- a/tests/unit/test_checkpointing.py
+++ b/tests/unit/test_checkpointing.py
@@ -41,6 +41,14 @@ def compare_model_states(saved_model, loaded_model, compare_optimizer=True):
         assert id(p0) != id(p1), f'Comparing fp16 model state tensor against itself : {id(p0)} <====> {id(p1)}'
         assert torch.allclose(p0, p1, atol=1e-07), f"FP16 model state {p0} is not equal to {p1}"
 
+    # Compare ds_tensor values for ZeRO stage3
+    for p0, p1 in zip(saved_model.module.parameters(), loaded_model.module.parameters()):
+        p0_has_ds_tensor = hasattr(p0, 'ds_tensor')
+        p1_has_ds_tensor = hasattr(p1, 'ds_tensor')
+        assert p0_has_ds_tensor == p1_has_ds_tensor, f'Mismatch has ds_tensor attribute p0:{p0_has_ds_tensor}, p1:{p1_has_ds_tensor}'
+        if p0_has_ds_tensor:
+            assert torch.allclose(p0, p1, atol=1e-07), f'FP16 model state {p0} is not equal to {p1}'
+
     if not compare_optimizer:
         return
 


### PR DESCRIPTION
Save ZeRO3 (partitioned) fp16 weights. This is a first step to using ZeRO3 weights outside DeepSpeed, #872.