### PR TITLE
[debug utils] see_memory_usage fixes

### DIFF
--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -567,7 +567,8 @@ def see_memory_usage(message, force=False):
 
     # reset for the next call
     # 1. get the peak memory to report correct data
-    torch.cuda.reset_peak_memory_stats()
+    if hasattr(torch.cuda, "reset_peak_memory_stats"):  # pytorch 1.4+
+        torch.cuda.reset_peak_memory_stats()
     # 2. python doesn't do real-time garbage collection so do it explicitly
     gc.collect()
 

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -560,17 +560,17 @@ def see_memory_usage(message, force=False):
         CA {round(torch.cuda.memory_cached() / (1024 * 1024 * 1024),2)} GB \
         Max_CA {round(torch.cuda.max_memory_cached() / (1024 * 1024 * 1024))} GB ")
 
+    # python doesn't do real-time garbage collection so do it explicitly to get the correct RAM reports
+    gc.collect()
+
     vm_stats = psutil.virtual_memory()
     used_GB = round(((vm_stats.total - vm_stats.available) / (1024**3)), 2)
     logger.info(
         f'CPU Virtual Memory:  used = {used_GB} GB, percent = {vm_stats.percent}%')
 
-    # reset for the next call
-    # 1. get the peak memory to report correct data
+    # get the peak memory to report correct data, so reset the counter for the next call
     if hasattr(torch.cuda, "reset_peak_memory_stats"):  # pytorch 1.4+
         torch.cuda.reset_peak_memory_stats()
-    # 2. python doesn't do real-time garbage collection so do it explicitly
-    gc.collect()
 
 
 def call_to_str(base, *args, **kwargs):

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -8,6 +8,7 @@ Helper functions and classes from multiple sources.
 
 import os
 import psutil
+import gc
 from math import ceil
 from math import floor
 from bisect import bisect_left, bisect_right
@@ -563,6 +564,12 @@ def see_memory_usage(message, force=False):
     used_GB = round(((vm_stats.total - vm_stats.available) / (1024**3)), 2)
     logger.info(
         f'CPU Virtual Memory:  used = {used_GB} GB, percent = {vm_stats.percent}%')
+
+    # reset for the next call
+    # 1. get the peak memory to report correct data
+    torch.cuda.reset_peak_memory_stats()
+    # 2. python doesn't do real-time garbage collection so do it explicitly
+    gc.collect()
 
 
 def call_to_str(base, *args, **kwargs):

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -552,6 +552,9 @@ def see_memory_usage(message, force=False):
     if torch.distributed.is_initialized() and not torch.distributed.get_rank() == 0:
         return
 
+    # python doesn't do real-time garbage collection so do it explicitly to get the correct RAM reports
+    gc.collect()
+
     # Print message except when distributed but not rank 0
     logger.info(message)
     logger.info(
@@ -559,9 +562,6 @@ def see_memory_usage(message, force=False):
         Max_MA {round(torch.cuda.max_memory_allocated() / (1024 * 1024 * 1024),2)} GB \
         CA {round(torch.cuda.memory_cached() / (1024 * 1024 * 1024),2)} GB \
         Max_CA {round(torch.cuda.max_memory_cached() / (1024 * 1024 * 1024))} GB ")
-
-    # python doesn't do real-time garbage collection so do it explicitly to get the correct RAM reports
-    gc.collect()
 
     vm_stats = psutil.virtual_memory()
     used_GB = round(((vm_stats.total - vm_stats.available) / (1024**3)), 2)

--- a/docs/_tutorials/getting-started.md
+++ b/docs/_tutorials/getting-started.md
@@ -265,8 +265,8 @@ local machine to discover the number of slots available. The `--include` and
 `--exclude` arguments work as normal, but the user should specify 'localhost'
 as the hostname.
 
-Also note that `CUDA_VISIBLE_DEVICES` can't be used with DeepSpeed to control 
-which devices should be used. For example, to use only gpu1 of the current 
+Also note that `CUDA_VISIBLE_DEVICES` can't be used with DeepSpeed to control
+which devices should be used. For example, to use only gpu1 of the current
 node, do:
 ```bash
 deepspeed --include localhost:1 ...

--- a/docs/_tutorials/pipeline.md
+++ b/docs/_tutorials/pipeline.md
@@ -277,7 +277,7 @@ For example, a machine with 16 GPUs must have as much local CPU memory as 16 tim
 DeepSpeed provides a `LayerSpec` class that delays the construction of
 modules until the model layers have been partitioned across workers.
 Then each worker will allocate only the layers it's assigned to. So, comparing to the
-example from the previous paragraph, using `LayerSpec` a machine with 16 GPUs will need to 
+example from the previous paragraph, using `LayerSpec` a machine with 16 GPUs will need to
 allocate a total of 1x model size on its CPU memory and not 16x.
 
 Here is an example of the abbreviated AlexNet model, but expressed only


### PR DESCRIPTION
This PR improves `see_memory_usage` as currently it's hiding real information at times.
 
There are 2 proposed adjustments:
 
1. peak memory is not telling

e.g.:
```
[2021-03-24 15:15:37,640] [INFO] [utils.py:555:see_memory_usage] before get_layer_state_dict 
[2021-03-24 15:15:37,641] [INFO] [utils.py:556:see_memory_usage] MA 0.14 GB         Max_MA 0.26 GB         CA 0.39 GB         Max_CA 1 GB
[2021-03-24 15:15:37,641] [INFO] [utils.py:564:see_memory_usage] CPU Virtual Memory:  used = 47.48 GB, percent = 37.8%
[2021-03-24 15:15:37,643] [INFO] [utils.py:555:see_memory_usage] after get_layer_state_dict
[2021-03-24 15:15:37,643] [INFO] [utils.py:556:see_memory_usage] MA 0.14 GB         Max_MA 0.26 GB         CA 0.39 GB         Max_CA 1 GB
[2021-03-24 15:15:37,643] [INFO] [utils.py:564:see_memory_usage] CPU Virtual Memory:  used = 47.48 GB, percent = 37.8%
```
this tells me absolutely nothing about the peak memory usage of the code I'm profiling, other than that it didn't take more peak memory usage than the last time it peaked to this number.
 
To get the real understanding you have to call:
```
self.torch.cuda.reset_peak_memory_stats()
```
at the end of the report.

So after this PR applied I now get:
```
[2021-03-24 16:14:42,919] [INFO] [utils.py:556:see_memory_usage] before get_layer_state_dict
[2021-03-24 16:14:42,920] [INFO] [utils.py:557:see_memory_usage] MA 0.14 GB         Max_MA 0.26 GB         CA 0.35 GB         Max_CA 1 GB
[2021-03-24 16:14:42,920] [INFO] [utils.py:565:see_memory_usage] CPU Virtual Memory:  used = 47.87 GB, percent = 38.1%
[2021-03-24 16:14:42,985] [INFO] [utils.py:556:see_memory_usage] after get_layer_state_dict
[2021-03-24 16:14:42,986] [INFO] [utils.py:557:see_memory_usage] MA 0.14 GB         Max_MA 0.14 GB         CA 0.35 GB         Max_CA 0 GB
[2021-03-24 16:14:42,986] [INFO] [utils.py:565:see_memory_usage] CPU Virtual Memory:  used = 47.88 GB, percent = 38.1%
```
So I know the code I'm profiling peaked 0.14GB - And I had no idea this happened before this PR. 

**edit:** I had no idea you were still supporting pt-1.2 - which doesn't have this function, so had to tweak the PR to check if it's there.

2. general RAM isn't necessarily correct either.
 
In my similar profiling functions I also like to add:
```
gc.collect()
```
since python doesn't do real-time garbage collection, so again you don't always get the correct picture of the memory usage if a variable was deleted but not gc'ed yet. I think you always get the correct cuda report since it's managed by pytorch directly, but not so for general RAM since it is not.

I don't have an example at this moment, but I can come up with one if needed.

--------

Another useful thing is to also add:
```
self.torch.cuda.empty_cache()
``` 
after `gc.collect()`

But `empty_cache()` only helps if one uses pynvml/nvidia-smi for monitoring memory usage. I use `pynvml` in tools like https://github.com/stas00/ipyexperiments to profile the full gpu memory and not just the parts accessible to pytorch. and which also tries to overcome the problem of only a single peak memory counter. This is a long outstanding [feature request](https://github.com/pytorch/pytorch/issues/16266) - please vote if you want to have multiple counters.

I left this part out of this PR since you don't use `pynvml`.

Thanks.