### PR TITLE
disable pipe cifar test

### DIFF
--- a/tests/unit/test_pipe.py
+++ b/tests/unit/test_pipe.py
@@ -169,6 +169,7 @@ def train_cifar(model, args, num_steps=400, average_dp_losses=True, fp16=True, s
     return losses
 
 
+@pytest.mark.skip(reason="been seeing nondeterministic failures, skipping for now")
 @pytest.mark.parametrize('topo',
                          [
                              PipeTopo(num_pp=1,


### PR DESCRIPTION
This test has been giving us trouble for a bit, seeing nondeterministic failures, skipping for now to not break out CI. Need to revisit soon though.