### PR TITLE
Add space in help string

### DIFF
--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -95,7 +95,7 @@ def parse_args(args=None):
     parser.add_argument("--launcher",
                         default=PDSH_LAUNCHER,
                         type=str,
-                        help="(optional) choose launcher backend for multi-node"
+                        help="(optional) choose launcher backend for multi-node "
                         "training. Options currently include PDSH, OpenMPI, MVAPICH.")
 
     parser.add_argument("--launcher_args",


### PR DESCRIPTION
This PR adds a space in `--launcher`.

Before:
```
  --launcher LAUNCHER   (optional) choose launcher backend for multi-
                        nodetraining. Options currently include PDSH, OpenMPI,
                        MVAPICH.
```

After:
```
  --launcher LAUNCHER   (optional) choose launcher backend for multi-
                        node training. Options currently include PDSH, OpenMPI,
                        MVAPICH.
```