### PR TITLE
Triangular mask support for Transformer kernel

### DIFF
--- a/csrc/includes/custom_cuda_layers.h
+++ b/csrc/includes/custom_cuda_layers.h
@@ -255,3 +255,14 @@ void launch_fuse_transpose_bias_kernel(const T* inp,
                                        cudaStream_t stream);
 
 void launch_param_update(const float* input, __half* output, int size, cudaStream_t stream);
+
+template <typename T>
+void launch_attn_softmax_v2(T* vals,
+                            T* mask,
+                            bool triangular,
+                            int batch_size,
+                            int heads,
+                            int num_seq,
+                            int sequence_length,
+                            float scale,
+                            cudaStream_t stream)

--- a/csrc/includes/custom_cuda_layers.h
+++ b/csrc/includes/custom_cuda_layers.h
@@ -258,11 +258,11 @@ void launch_param_update(const float* input, __half* output, int size, cudaStrea
 
 template <typename T>
 void launch_attn_softmax_v2(T* vals,
-                            T* mask,
+                            const T* mask,
                             bool triangular,
                             int batch_size,
                             int heads,
                             int num_seq,
                             int sequence_length,
                             float scale,
-                            cudaStream_t stream)
+                            cudaStream_t stream);

--- a/csrc/includes/ds_transformer_cuda.h
+++ b/csrc/includes/ds_transformer_cuda.h
@@ -134,6 +134,10 @@ public:
     inline int GetIntermediateSize() const { return _intermediate_size; }
 
     void SetSeqLength(int seq_len);
+    inline void SetTriangularMode(unsigned seq, unsigned prob)
+    {
+        _softmax.SetTriangularMode(prob, seq);
+    }
     inline int GetHiddenSize() const { return _hidden_size; }
     void SetTrainingMode(bool training);
     inline bool IsTrainingMode() const { return _training; }

--- a/csrc/includes/softmax.h
+++ b/csrc/includes/softmax.h
@@ -39,17 +39,17 @@ public:
     void Forward(int bsz, T* vals, const T* attn_mask, cudaStream_t& stream)
     {
         if (config_.triangular)
-            launch_attn_softmax<T>(vals, attn_mask, bsz, config_.heads, config_.seq_length, stream);
+            launch_attn_softmax_v2<T>(vals,
+                                      attn_mask,
+                                      (config_.seq_length == config_.prob_depth),
+                                      bsz,
+                                      config_.heads,
+                                      config_.seq_length,
+                                      config_.prob_depth,
+                                      1.0,
+                                      stream);
         else
-            launch_attn_softmax_v2(vals,
-                                   attn_mask,
-                                   (config_.seq_length == config_.prob_length),
-                                   bsz,
-                                   config_.heads,
-                                   config_.seq_length,
-                                   config_.prob_length,
-                                   1.0,
-                                   stream);
+            launch_attn_softmax<T>(vals, attn_mask, bsz, config_.heads, config_.seq_length, stream);
     }
 
     void Backward(int bsz, T* out_grad, const T* soft_out, cudaStream_t stream)

--- a/csrc/transformer/ds_transformer_cuda.cpp
+++ b/csrc/transformer/ds_transformer_cuda.cpp
@@ -713,7 +713,7 @@ std::vector<torch::Tensor> ds_transformer_forward(int layer_id,
     if (mask_size[mask_dim - 2] > 1 ||
         mask_size[mask_dim - 2] ==
             mask_size[mask_dim - 1])  // Detecting triangular mask; TODO: check for other cases
-       layer->SetTriangularMode((mask_size[mask_dim - 2], (mask_size[mask_dim - 1]);
+        layer->SetTriangularMode(mask_size[mask_dim - 2], mask_size[mask_dim - 1]);
 
     auto workspace = torch::empty({get_workspace_size<T>(bsz,
                                                          seq_len,

--- a/csrc/transformer/ds_transformer_cuda.cpp
+++ b/csrc/transformer/ds_transformer_cuda.cpp
@@ -708,6 +708,12 @@ std::vector<torch::Tensor> ds_transformer_forward(int layer_id,
         seq_len = input.size(1);
         layer->SetSeqLength(seq_len);
     }
+    auto mask_size = input_mask.sizes();
+    unsigned mask_dim = mask_size.size();
+    if (mask_size[mask_dim - 2] > 1 ||
+        mask_size[mask_dim - 2] ==
+            mask_size[mask_dim - 1])  // Detecting triangular mask; TODO: check for other cases
+       layer->SetTriangularMode((mask_size[mask_dim - 2], (mask_size[mask_dim - 1]);
 
     auto workspace = torch::empty({get_workspace_size<T>(bsz,
                                                          seq_len,

--- a/csrc/transformer/softmax_kernels.cu
+++ b/csrc/transformer/softmax_kernels.cu
@@ -592,7 +592,7 @@ template void launch_attn_softmax_backward_v2<float>(float* out_grad,
 
 template <int tbSize, int tbSeq>
 __global__ void attn_softmax_v2(__half* vals,
-                                __half* mask,
+                                const __half* mask,
                                 bool triangular,
                                 int total_count,
                                 int heads,
@@ -702,11 +702,11 @@ __global__ void attn_softmax_v2(__half* vals,
 
 template <int tbSize, int tbSeq>
 __global__ void attn_softmax_v2(float* vals,
-                                float* attn_mask,
+                                const float* attn_mask,
                                 bool triangular,
                                 int total_count,
                                 int heads,
-                                int seq_length,
+                                int sequence_length,
                                 int num_seq,
                                 float scale)
 {
@@ -803,7 +803,7 @@ __global__ void attn_softmax_v2(float* vals,
 
 template <typename T>
 void launch_attn_softmax_v2(T* vals,
-                            T* mask,
+                            const T* mask,
                             bool triangular,
                             int batch_size,
                             int heads,
@@ -838,12 +838,10 @@ void launch_attn_softmax_v2(T* vals,
         throw std::runtime_error(
             "Unsupport Seq_Length! Check the restriction of the max_threads and "
             "max_thread_iterations!");
-
-    CUDA_CHECK_ERROR();
 }
 
 template void launch_attn_softmax_v2(float* vals,
-                                     float* mask,
+                                     const float* mask,
                                      bool triangular,
                                      int batch_size,
                                      int heads,
@@ -852,7 +850,7 @@ template void launch_attn_softmax_v2(float* vals,
                                      float scale,
                                      cudaStream_t stream);
 template void launch_attn_softmax_v2(__half* vals,
-                                     __half* mask,
+                                     const __half* mask,
                                      bool triangular,
                                      int batch_size,
                                      int heads,

--- a/csrc/transformer/softmax_kernels.cu
+++ b/csrc/transformer/softmax_kernels.cu
@@ -589,3 +589,274 @@ template void launch_attn_softmax_backward_v2<float>(float* out_grad,
                                                      int heads,
                                                      int seq_length,
                                                      cudaStream_t stream);
+
+template <int tbSize, int tbSeq>
+__global__ void attn_softmax_v2(__half* vals,
+                                __half* mask,
+                                bool triangular,
+                                int total_count,
+                                int heads,
+                                int sequence_length,
+                                int num_seq,
+                                float scale)
+{
+#if __CUDA_ARCH__ >= 700
+
+    cg::thread_block b = cg::this_thread_block();
+    cg::thread_block_tile<tbSize> g = cg::tiled_partition<tbSize>(b);
+
+    float2 low_data[tbSeq];
+    float2 high_data[tbSeq];
+
+    __half2 h_scale = __float2half2_rn(scale);
+
+    int wid = threadIdx.x >> 5;
+    int lane = threadIdx.x & 0x1f;
+
+    int iter_offset = blockIdx.x * (blockDim.x >> 5) + wid;
+
+    if (iter_offset < total_count) {
+        vals += (iter_offset * sequence_length);
+
+        int mask_offset = (iter_offset / (heads * num_seq)) * (sequence_length);
+        int seq_id = iter_offset % num_seq;
+        int seq_id4 = seq_id >> 2;
+        float max_val = minus_infinity;
+
+        for (int i = 0; i < tbSeq; i++) {
+            int data_id = i * (WARP_SIZE << 2) + (lane << 2);
+            if ((!triangular || ((data_id >> 2) <= seq_id4)) && data_id < sequence_length) {
+                if ((sequence_length - data_id) >= 4) {
+                    low_data[i].x = __half2float(vals[data_id]);
+                    low_data[i].y = (!triangular || ((data_id + 1) <= seq_id))
+                                        ? __half2float(vals[data_id + 1])
+                                        : minus_infinity;
+                    high_data[i].x = (!triangular || ((data_id + 2) <= seq_id))
+                                         ? __half2float(vals[data_id + 2])
+                                         : minus_infinity;
+                    high_data[i].y = (!triangular || ((data_id + 3) <= seq_id))
+                                         ? __half2float(vals[data_id + 3])
+                                         : minus_infinity;
+                } else {
+                    low_data[i].x = __half2float(vals[data_id]);
+                    low_data[i].y = (((!triangular || (data_id + 1) <= seq_id)) &&
+                                     (data_id + 1) < sequence_length)
+                                        ? __half2float(vals[data_id + 1])
+                                        : minus_infinity;
+                    high_data[i].x = (((!triangular || (data_id + 2) <= seq_id)) &&
+                                      (data_id + 2) < sequence_length)
+                                         ? __half2float(vals[data_id + 2])
+                                         : minus_infinity;
+                    high_data[i].y = minus_infinity;
+                }
+                max_val = (low_data[i].x > max_val ? low_data[i].x : max_val);
+                max_val = (low_data[i].y > max_val ? low_data[i].y : max_val);
+                max_val = (high_data[i].x > max_val ? high_data[i].x : max_val);
+                max_val = (high_data[i].y > max_val ? high_data[i].y : max_val);
+            } else {
+                low_data[i].x = minus_infinity;
+                low_data[i].y = minus_infinity;
+                high_data[i].x = minus_infinity;
+                high_data[i].y = minus_infinity;
+            }
+        }
+
+        for (int i = 1; i < tbSize; i *= 2) {
+            auto temp = g.shfl_xor(max_val, i);
+            max_val = (temp > max_val ? temp : max_val);
+        }
+
+        float sum = 0;
+        for (int i = 0; i < tbSeq; i++) {
+            low_data[i].x = __expf(low_data[i].x - max_val);
+            low_data[i].y = __expf(low_data[i].y - max_val);
+            high_data[i].x = __expf(high_data[i].x - max_val);
+            high_data[i].y = __expf(high_data[i].y - max_val);
+
+            sum += (low_data[i].x + low_data[i].y + high_data[i].x + high_data[i].y);
+        }
+
+        for (int i = 1; i < tbSize; i *= 2) sum += g.shfl_xor(sum, i);
+
+        sum += 1e-6;
+
+        for (int i = 0; i < tbSeq; i++) {
+            int data_id = i * (WARP_SIZE << 2) + (lane << 2);
+
+            if (data_id < sequence_length) {
+                if ((sequence_length - data_id) >= 4) {
+                    vals[data_id] = low_data[i].x / sum;
+                    vals[data_id + 1] = low_data[i].y / sum;
+                    vals[data_id + 2] = high_data[i].x / sum;
+                    vals[data_id + 3] = high_data[i].y / sum;
+                } else {
+                    vals[data_id] = low_data[i].x / sum;
+                    if ((data_id + 1) < sequence_length) vals[data_id + 1] = low_data[i].y / sum;
+                    if ((data_id + 2) < sequence_length) vals[data_id + 2] = high_data[i].x / sum;
+                }
+            }
+        }
+    }
+#endif
+}
+
+template <int tbSize, int tbSeq>
+__global__ void attn_softmax_v2(float* vals,
+                                float* attn_mask,
+                                bool triangular,
+                                int total_count,
+                                int heads,
+                                int seq_length,
+                                int num_seq,
+                                float scale)
+{
+    cg::thread_block b = cg::this_thread_block();
+    cg::thread_block_tile<tbSize> g = cg::tiled_partition<tbSize>(b);
+
+    float4 data[tbSeq];
+
+    int wid = threadIdx.x >> 5;
+    int lane = threadIdx.x & 0x1f;
+    int warp_num = blockDim.x >> 5;
+
+    int iter_offset = blockIdx.x * warp_num + wid;
+    if (iter_offset < total_count) {
+        vals += (iter_offset * sequence_length);
+
+        // int mask_offset = (iter_offset / (heads * num_seq)) * (sequence_length);
+        int seq_id = iter_offset % num_seq;
+        int seq_id4 = seq_id >> 2;
+        float max_val = minus_infinity;
+
+        for (int i = 0; i < tbSeq; i++) {
+            int data_id = i * (WARP_SIZE << 2) + (lane << 2);
+            if ((!triangular || ((data_id >> 2) <= seq_id4)) && data_id < sequence_length) {
+                if ((sequence_length - data_id) >= 4) {
+                    data[i].x = (vals[data_id]);
+                    data[i].y = (!triangular || ((data_id + 1) <= seq_id)) ? (vals[data_id + 1])
+                                                                           : minus_infinity;
+                    data[i].z = (!triangular || ((data_id + 2) <= seq_id)) ? (vals[data_id + 2])
+                                                                           : minus_infinity;
+                    data[i].w = (!triangular || ((data_id + 3) <= seq_id)) ? (vals[data_id + 3])
+                                                                           : minus_infinity;
+                } else {
+                    data[i].x = (vals[data_id]);
+                    data[i].y = (((!triangular || (data_id + 1) <= seq_id)) &&
+                                 (data_id + 1) < sequence_length)
+                                    ? (vals[data_id + 1])
+                                    : minus_infinity;
+                    data[i].z = (((!triangular || (data_id + 2) <= seq_id)) &&
+                                 (data_id + 2) < sequence_length)
+                                    ? (vals[data_id + 2])
+                                    : minus_infinity;
+                    data[i].w = minus_infinity;
+                }
+                max_val = (data[i].x > max_val ? data[i].x : max_val);
+                max_val = (data[i].y > max_val ? data[i].y : max_val);
+                max_val = (data[i].z > max_val ? data[i].z : max_val);
+                max_val = (data[i].w > max_val ? data[i].w : max_val);
+            } else {
+                data[i].x = minus_infinity;
+                data[i].y = minus_infinity;
+                data[i].z = minus_infinity;
+                data[i].w = minus_infinity;
+            }
+        }
+
+        for (int i = 1; i < tbSize; i *= 2) {
+            auto temp = g.shfl_xor(max_val, i);
+            max_val = (temp > max_val ? temp : max_val);
+        }
+
+        float sum = 0;
+        for (int i = 0; i < tbSeq; i++) {
+            data[i].x = __expf(data[i].x - max_val);
+            data[i].y = __expf(data[i].y - max_val);
+            data[i].z = __expf(data[i].z - max_val);
+            data[i].w = __expf(data[i].w - max_val);
+
+            sum += (data[i].x + data[i].y + data[i].z + data[i].w);
+        }
+
+        for (int i = 1; i < tbSize; i *= 2) sum += g.shfl_xor(sum, i);
+
+        sum += 1e-6;
+
+        for (int i = 0; i < tbSeq; i++) {
+            int data_id = i * (WARP_SIZE << 2) + (lane << 2);
+
+            if (data_id < sequence_length) {
+                if ((sequence_length - data_id) >= 4) {
+                    vals[data_id] = data[i].x / sum;
+                    vals[data_id + 1] = data[i].y / sum;
+                    vals[data_id + 2] = data[i].z / sum;
+                    vals[data_id + 3] = data[i].w / sum;
+                } else {
+                    vals[data_id] = data[i].x / sum;
+                    if ((data_id + 1) < sequence_length) vals[data_id + 1] = data[i].y / sum;
+                    if ((data_id + 2) < sequence_length) vals[data_id + 2] = data[i].z / sum;
+                }
+            }
+        }
+    }
+}
+
+template <typename T>
+void launch_attn_softmax_v2(T* vals,
+                            T* mask,
+                            bool triangular,
+                            int batch_size,
+                            int heads,
+                            int num_seq,
+                            int sequence_length,
+                            float scale,
+                            cudaStream_t stream)
+{
+    int total_count = batch_size * heads * num_seq;
+
+    dim3 grid_dim((total_count - 1) / 32 + 1);
+    dim3 block_dim(1024);
+    if (sequence_length <= 128)
+        attn_softmax_v2<32, 1><<<grid_dim, block_dim, 0, stream>>>(
+            vals, mask, triangular, total_count, heads, sequence_length, num_seq, scale);
+    else if (sequence_length <= 256)
+        attn_softmax_v2<32, 2><<<grid_dim, block_dim, 0, stream>>>(
+            vals, mask, triangular, total_count, heads, sequence_length, num_seq, scale);
+    else if (sequence_length <= 512)
+        attn_softmax_v2<32, 4><<<grid_dim, block_dim, 0, stream>>>(
+            vals, mask, triangular, total_count, heads, sequence_length, num_seq, scale);
+    else if (sequence_length <= 1024)
+        attn_softmax_v2<32, 8><<<grid_dim, block_dim, 0, stream>>>(
+            vals, mask, triangular, total_count, heads, sequence_length, num_seq, scale);
+    else if (sequence_length <= 2048)
+        attn_softmax_v2<32, 16><<<grid_dim, block_dim, 0, stream>>>(
+            vals, mask, triangular, total_count, heads, sequence_length, num_seq, scale);
+    else if (sequence_length <= 4096)
+        attn_softmax_v2<32, 32><<<grid_dim, block_dim, 0, stream>>>(
+            vals, mask, triangular, total_count, heads, sequence_length, num_seq, scale);
+    else
+        throw std::runtime_error(
+            "Unsupport Seq_Length! Check the restriction of the max_threads and "
+            "max_thread_iterations!");
+
+    CUDA_CHECK_ERROR();
+}
+
+template void launch_attn_softmax_v2(float* vals,
+                                     float* mask,
+                                     bool triangular,
+                                     int batch_size,
+                                     int heads,
+                                     int num_seq,
+                                     int sequence_length,
+                                     float scale,
+                                     cudaStream_t stream);
+template void launch_attn_softmax_v2(__half* vals,
+                                     __half* mask,
+                                     bool triangular,
+                                     int batch_size,
+                                     int heads,
+                                     int num_seq,
+                                     int sequence_length,
+                                     float scale,
+                                     cudaStream_t stream);

--- a/deepspeed/ops/transformer/transformer.py
+++ b/deepspeed/ops/transformer/transformer.py
@@ -191,7 +191,7 @@ class DeepSpeedTransformerFunction(Function):
                                            device=input.device,
                                            dtype=input.dtype)),
                               1)
-            input_mask = torch.cat((input_mask, torch.ones((inp_size[0], input_mask.shape[1], input_mask.shape[2], \
+            input_mask = torch.cat((input_mask, torch.ones((input_mask.shape[0], input_mask.shape[1], input_mask.shape[2], \
                                             (16 - (inp_size[1] % 16))), device=input_mask.device, dtype=input_mask.dtype) * -10000), 3)
 
         (output,


### PR DESCRIPTION
Adding the new version of SoftMax for Transformer kernel to support Triangular mask used in GPT-based models.

This addresses https://github.com/microsoft/DeepSpeed/issues/828.

TODO: Add a unit test for guarding against this type of masking.