### PR TITLE
Delete check of pdsh

### DIFF
--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -306,9 +306,6 @@ def main(args=None):
 
     multi_node_exec = len(active_resources) > 1
 
-    if multi_node_exec and not shutil.which('pdsh'):
-        raise RuntimeError("pdsh is not installed, unable to proceed")
-
     if not multi_node_exec:
         deepspeed_launch = [
             sys.executable,


### PR DESCRIPTION
Checking whether or not `pdsh` exists seems to be redundant because it is checked by `runner.backend_exists()` when `args.launcher` is `pdsh`. Furthermore, this check is always done regardless of `args.launcher`. If I understand correctly, it is not necessary for `openmpi` and `mvapich`.

Sorry if I misunderstand. Thanks.