### PR TITLE
[config] turn exponential notation back on for config dump

### DIFF
--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -9,7 +9,7 @@ import copy
 
 from .constants import *
 from .fp16.loss_scaler import INITIAL_LOSS_SCALE, SCALE_WINDOW, DELAYED_SHIFT, MIN_LOSS_SCALE
-from .config_utils import get_scalar_param, dict_raise_error_on_duplicate_keys
+from .config_utils import get_scalar_param, dict_raise_error_on_duplicate_keys, ScientificNotationEncoder
 from .zero.config import DeepSpeedZeroConfig
 from .zero.constants import *
 from .activation_checkpointing.config import DeepSpeedActivationCheckpointingConfig
@@ -744,6 +744,7 @@ class DeepSpeedConfig(object):
             json.dumps(self._param_dict,
                        sort_keys=True,
                        indent=4,
+                       cls=ScientificNotationEncoder,
                        separators=(',',
                                    ':'))))
 

--- a/deepspeed/runtime/config_utils.py
+++ b/deepspeed/runtime/config_utils.py
@@ -34,7 +34,7 @@ class ScientificNotationEncoder(json.JSONEncoder):
                 f'\n{prefix}"{k}": {self.iterencode(v, level=level)}' for k,
                 v in o.items()
             ]
-            return "{" + ', '.join(x) + f"\n{prefix_close}}}"
+            return "{" + ', '.join(x) + f"\n{prefix_close}" + "}"
         elif isinstance(o, Sequence) and not isinstance(o, str):
             return f"[{ f', '.join(map(self.iterencode, o)) }]"
         return "\n, ".join(super().iterencode(o, _one_shot))

--- a/deepspeed/runtime/config_utils.py
+++ b/deepspeed/runtime/config_utils.py
@@ -14,7 +14,7 @@ class ScientificNotationEncoder(json.JSONEncoder):
     """
     This class overrides ``json.dumps`` default formatter.
 
-    This version keeps everything as normal except formats floats bigger than 1e3 using scientific notation.
+    This version keeps everything as normal except formats numbers bigger than 1e3 using scientific notation.
 
     Just pass ``cls=ScientificNotationEncoder`` to ``json.dumps`` to activate it
 
@@ -24,7 +24,7 @@ class ScientificNotationEncoder(json.JSONEncoder):
         prefix_close = " " * level * indent
         level += 1
         prefix = " " * level * indent
-        if isinstance(o, float):
+        if isinstance(o, float) or isinstance(o, int):
             if o > 1e3:
                 return f"{o:e}"
             else:

--- a/deepspeed/runtime/config_utils.py
+++ b/deepspeed/runtime/config_utils.py
@@ -24,7 +24,9 @@ class ScientificNotationEncoder(json.JSONEncoder):
         prefix_close = " " * level * indent
         level += 1
         prefix = " " * level * indent
-        if isinstance(o, float) or isinstance(o, int):
+        if isinstance(o, bool):
+            return "true" if o else "false"
+        elif isinstance(o, float) or isinstance(o, int):
             if o > 1e3:
                 return f"{o:e}"
             else:


### PR DESCRIPTION
As suggested in https://github.com/microsoft/DeepSpeed/issues/929 this PR dumps json objects with a custom formatter that represents huge numbers in scientific notation, so instead of getting
```
"sub_group_size":100000000000000.0
```
we now get:
```
"sub_group_size": 1.000000e+14,
```
You can of course further tweak it to format even better.

I changed it to leave small numbers `< 1e3` alone. 

Here is an example of a new dump:

```
    "zero_optimization": {
        "stage": 3, 
        "cpu_offload": true, 
        "cpu_offload_params": true, 
        "cpu_offload_use_pin_memory": true, 
        "overlap_comm": true, 
        "contiguous_gradients": true, 
        "sub_group_size": 1.000000e+14, 
        "reduce_bucket_size": 2.621440e+05, 
        "stage3_prefetch_bucket_size": 2.359296e+05, 
        "stage3_param_persistence_threshold": 5.120000e+03, 
        "stage3_max_live_parameters": 1.000000e+09, 
        "stage3_max_reuse_distance": 1.000000e+09, 
        "stage3_gather_fp16_weights_on_model_save": true
    }, 
```

@tjruwase 

Fixes: https://github.com/microsoft/DeepSpeed/issues/929