### PR TITLE
Use odd shape tensor to represent parameter data in partitioned state

### DIFF
--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -23,6 +23,7 @@ from ..swap_tensor.partitioned_param_swapper import AsyncPartitionedParameterSwa
 from ..config import DeepSpeedConfig
 
 param_count = 0
+partitioned_param_data_shape = [1]
 
 
 def print_rank_0(message, debug=False, force=False):
@@ -631,7 +632,8 @@ class Init(InsertPostInitMethodToModuleSubClasses):
                     f'Before partitioning param {param.ds_id} {param.shape}',
                     force=False)
                 #param.data does not store anything meaningful in partitioned state
-                param.data = torch.ones(1).half().to(param.device)
+                param.data = torch.ones(partitioned_param_data_shape).half().to(
+                    param.device)
                 see_memory_usage(f'After partitioning param {param.ds_id} {param.shape}',
                                  force=False)
 
@@ -712,7 +714,7 @@ class Init(InsertPostInitMethodToModuleSubClasses):
 
             see_memory_usage(f'Before partitioning param {param.ds_id} {param.shape}',
                              force=False)
-            param.data = torch.ones(1).half().to(param.device)
+            param.data = torch.ones(partitioned_param_data_shape).half().to(param.device)
             see_memory_usage(f'After partitioning param {param.ds_id} {param.shape}',
                              force=False)
 

--- a/tests/unit/test_zero_context.py
+++ b/tests/unit/test_zero_context.py
@@ -32,7 +32,7 @@ def test_scatter_gather():
     with deepspeed.zero.Init():
         l = torch.nn.Linear(6, 3)
     assert l.weight.ds_status == ZeroParamStatus.NOT_AVAILABLE
-    assert l.weight.numel() == torch.size(partitioned_param_data_shape)
+    assert l.weight.shape == torch.Size(partitioned_param_data_shape)
 
     # Ensure there is no impact outside the context
     l2 = torch.nn.Linear(6, 3)

--- a/tests/unit/test_zero_context.py
+++ b/tests/unit/test_zero_context.py
@@ -6,7 +6,7 @@ import torch
 import pytest
 
 import deepspeed
-from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
+from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus, partitioned_param_data_shape
 
 from common import distributed_test
 
@@ -32,7 +32,7 @@ def test_scatter_gather():
     with deepspeed.zero.Init():
         l = torch.nn.Linear(6, 3)
     assert l.weight.ds_status == ZeroParamStatus.NOT_AVAILABLE
-    assert l.weight.numel() == 1
+    assert l.weight.numel() == torch.size(partitioned_param_data_shape)
 
     # Ensure there is no impact outside the context
     l2 = torch.nn.Linear(6, 3)


### PR DESCRIPTION
Currently, partitioned parameters in ZeRO-3 are represented by a scalar value (a tensor of shape [1]). If an external  parameter is used in element-wise operations but not registered with deepspeed, it can fail silently (no crash due to mismatch in shape). Refer to https://github.com/microsoft/DeepSpeed/issues/930.

This fix uses an odd-shaped tensor to represent partitioned parameters so that it will reduce the chances of silent failures.