### PR TITLE
[zero3] remove debug prints

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -1418,13 +1418,13 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
                 if torch.is_tensor(output):
                     output = [output]
                 else:
-                    print(f'got UNKNOWN type {type(output)}')
+                    #print(f'got UNKNOWN type {type(output)}')
                     outputs = []
                     for name, val in vars(output).items():
                         if not name.startswith('__') and torch.is_tensor(val):
                             outputs.append(val)
                     output = outputs
-                    print(f'convert output to {output}')
+                    #print(f'convert output to {output}')
 
             for item in filter(lambda item: is_zero_param(item), output):
                 if not any(id(item) in m._external_params for m in FWD_MODULE_STACK):


### PR DESCRIPTION
0.3.15 is afflicted with massive noise through left behind debug prints - this PR removes those. perhaps a patch release could be done unless you plan on making a new release shortly.

```
got UNKNOWN type <class 'transformers.modeling_outputs.BaseModelOutputWithPastAndCrossAttentions'> 
convert output to [tensor([[[        nan,         nan,         nan,  ...,         nan,
                 nan,         nan],
        [        nan,         nan,         nan,  ...,         nan,
                 nan,         nan],
        [        nan,         nan,         nan,  ...,         nan,
                 nan,         nan],
        ...,
        [        nan,         nan,         nan,  ...,         nan,
                 nan,         nan],
        [        nan,         nan,         nan,  ...,         nan,
                 nan,         nan],
        [        nan,         nan,         nan,  ...,         nan,
                 nan,         nan]],
       [[-8.1360e-02, -2.5659e-01,  3.8605e-03,  ..., -1.5259e-01,
         -1.8225e-01, -3.9124e-02],
        [-3.3521e-01, -5.4004e-01, -9.3384e-02,  ...,  7.5623e-02,
         -7.0264e-01, -3.3374e-01],
        [-1.4172e-01, -1.1499e-01, -2.1729e-01,  ...,  4.6783e-02,
          9.8389e-02,  1.1700e-01],
        ...,
        [-2.3584e-01, -0.0000e+00, -2.6318e-01,  ..., -1.3892e-01,
          2.6172e-01, -3.4393e-02],
        [-8.2153e-02,  7.7400e-03, -2.8473e-02,  ..., -1.4290e-02,
         -7.6332e-03,  5.0964e-02],
        [-6.6895e-01, -1.1982e+00,  3.7817e-01,  ..., -5.1910e-02,
          7.6199e-04, -0.0000e+00]],
       [[-3.4131e-01,  2.0050e-02,  3.0380e-02,  ..., -1.7651e-01,
         -4.1675e-01, -4.0332e-01],
        [ 6.1719e-01,  2.9272e-01, -0.0000e+00,  ..., -9.0759e-02,
          4.2822e-01, -0.0000e+00],
        [-3.9014e-01, -1.7310e-01,  2.0557e-01,  ...,  1.6675e-01,
         -5.8008e-01,  1.4233e-01],
        ...,
        [-3.8391e-02, -3.1342e-02,  2.2388e-04,  ...,  2.2507e-03,
          1.5686e-02,  6.7871e-02],
        [ 1.6748e-01, -1.1060e-01,  5.4979e-04,  ..., -0.0000e+00,
         -2.0435e-01, -3.1494e-02],
        [ 1.7920e-01, -1.6882e-01,  8.7463e-02,  ...,  2.5269e-02,
         -2.5098e-01, -0.0000e+00]],
       [[-6.8311e-01, -0.0000e+00, -7.9285e-02,  ...,  3.0908e-01,
         -4.2188e-01, -7.9895e-02],
        [ 3.4863e-01,  4.0479e-01,  1.6870e-01,  ..., -5.4749e-02,
         -6.7285e-01, -1.1884e-01],
        [-4.9951e-01,  1.0229e-01, -1.4905e-01,  ...,  3.9258e-01,
         -3.6087e-03,  4.2139e-01],
        ...,
        [-0.0000e+00, -5.6305e-03, -1.0483e-02,  ..., -8.9035e-03,
          1.1625e-03,  5.0079e-02],
        [-6.4331e-02, -1.8417e-02, -4.9164e-02,  ..., -2.3514e-02,
         -0.0000e+00, -2.3514e-02],
        [-2.0416e-02, -3.6224e-02, -2.8046e-02,  ..., -3.8452e-02,
          0.0000e+00, -2.6367e-02]]], device='cuda:0', dtype=torch.float16,
      grad_fn=<PreBackwardFunctionBackward>)]
```

@jeffra 