### PR TITLE
Fix issue where gradient_predivide_factor was called as a func.

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -1931,8 +1931,8 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
 
             dist.all_reduce(tensor_to_allreduce, group=self.dp_process_group)
 
-            if self.gradient_predivide_factor() != dp_world_size:
-                tensor_to_allreduce.mul_(self.gradient_predivide_factor() /
+            if self.gradient_predivide_factor != dp_world_size:
+                tensor_to_allreduce.mul_(self.gradient_predivide_factor /
                                          dp_world_size)
         else:
             tensor_to_allreduce.div_(dp_world_size)

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -1932,8 +1932,7 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
             dist.all_reduce(tensor_to_allreduce, group=self.dp_process_group)
 
             if self.gradient_predivide_factor != dp_world_size:
-                tensor_to_allreduce.mul_(self.gradient_predivide_factor /
-                                         dp_world_size)
+                tensor_to_allreduce.mul_(self.gradient_predivide_factor / dp_world_size)
         else:
             tensor_to_allreduce.div_(dp_world_size)
             dist.all_reduce(tensor_to_allreduce, group=self.dp_process_group)


### PR DESCRIPTION
`gradient_predivide_factor` is a `float`, hence shouldn't be called as func.
This crashes when `reduce_scatter` flag is set to `False`.