### PR TITLE
ZeRO3: Gradient norm allreduce for DP

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -2403,7 +2403,7 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
         """ Perform all reduce within model parallel group, if any.
         """
         if self.model_parallel_group is None:
-            torch.distributed.all_reduce(tensor=tensor, op=op)
+            pass
         else:
             torch.distributed.all_reduce(tensor=tensor,
                                          op=op,


### PR DESCRIPTION
Compute gradient norm allreduce for DP training. Fix for #966. 