### PR TITLE
improve assert message

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -588,7 +588,7 @@ class DeepSpeedEngine(Module):
                 assert all([param.dtype == torch.half for param in self.module.parameters()]), f"Model must initialized in fp16 mode for ZeRO Stage 3."
             self.module.half()
         else:
-            assert all([param.dtype == torch.float for param in self.module.parameters()]), f"The fp16 is not enabled but dtype on parameters not fp16"
+            assert all([param.dtype == torch.float for param in self.module.parameters()]), f"fp16 is not enabled but one or several model parameters have dtype of fp16"
 
         if not self.dont_change_device:
             self.module.to(self.device)


### PR DESCRIPTION
I was having a hard time making sense of the assert: 
``` 
AssertionError: The fp16 is not enabled but dtype on parameters not fp16
```
This PR tries:
```
fp16 is not enabled but one or several model parameters have dtype of fp16
```