### PR TITLE
[Stage][Fix] Add additional conditions when checking types of output from the model

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -1415,14 +1415,16 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
         def _post_forward_module_hook(module, input, output):
             global FWD_MODULE_STACK
             FWD_MODULE_STACK.pop()
-
-            if not isinstance(output, (list, tuple)):
+            if output is None:
+                output = []
+            elif not isinstance(output, (list, tuple)):
                 if torch.is_tensor(output):
                     output = [output]
                 else:
                     #print(f'got UNKNOWN type {type(output)}')
                     outputs = []
-                    for name, val in vars(output).items():
+                    output = output if isinstance(output, dict) else vars(output)
+                    for name, val in output.items():
                         if not name.startswith('__') and torch.is_tensor(val):
                             outputs.append(val)
                     output = outputs

--- a/tests/unit/test_zero_context.py
+++ b/tests/unit/test_zero_context.py
@@ -243,3 +243,42 @@ def test_ext_param_returnobj():
         assert len(net.dangler._external_params) == 0
         engine.backward(loss)
         engine.step()
+
+
+class ModelContainerVariableOutputType(ModelContainer):
+    def __init__(self, dim=16, output_type=dict):
+        super().__init__()
+        self.output_type = output_type
+        self.dim = dim
+        self.linear1 = torch.nn.Linear(dim, dim)
+
+    def forward(self, input):
+        act1 = self.linear1(input)
+        if self.output_type is None:
+            return None
+        if self.output_type is dict:
+            return {'loss': act1.sum()}
+        return act1.sum()
+
+
+@pytest.mark.parametrize('output_type', [None, dict])
+def test_stage_3_output_type(output_type):
+    setup_serial_env()
+    print()
+
+    net = ModelContainerVariableOutputType(output_type=output_type)
+
+    args = SimpleNamespace(local_rank=0)
+    engine, optim, _, _ = deepspeed.initialize(args=args,
+                                               model=net,
+                                               model_parameters=net.parameters(),
+                                               config=config)
+
+    for _ in range(1):
+        input = torch.rand(net.dim).to(engine.device).half()
+        loss = engine(input)
+        if loss is not None:
+            if isinstance(loss, dict):
+                loss = loss['loss']
+            engine.backward(loss)
+            engine.step()

--- a/tests/unit/test_zero_context.py
+++ b/tests/unit/test_zero_context.py
@@ -254,14 +254,13 @@ class ModelContainerVariableOutputType(ModelContainer):
 
     def forward(self, input):
         act1 = self.linear1(input)
-        if self.output_type is None:
-            return None
         if self.output_type is dict:
             return {'loss': act1.sum()}
-        return act1.sum()
+        if self.output_type is torch.tensor:
+            return act1.sum()
 
 
-@pytest.mark.parametrize('output_type', [None, dict])
+@pytest.mark.parametrize('output_type', [torch.tensor, dict, None])
 def test_stage_3_output_type(output_type):
     setup_serial_env()
     print()


### PR DESCRIPTION
Fixes an upstream issue in Lightning that I found when testing the latest DeepSpeed version on our CI.

From the forward pass in Lightning, we offer a few different potential output types. Due to the additional type checking of the output, some of these failed (`None` and `Dict`). This adds additional checks to ensure we handle those cases within the hook.

If possible I'd like to add a test (even though Lightning CI caught this), any guidance on where would be the right place?