### PR TITLE
Change methods to be static

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -826,9 +826,11 @@ class DeepSpeedEngine(Module):
 
         return pld
 
+    @staticmethod
     def is_map_style_dataset(obj):
         return hasattr(obj, "__getitem__") and hasattr(obj, "__len__")
 
+    @staticmethod
     def is_iterable_style_dataset(obj):
         return isinstance(obj,
                           torch.utils.data.IterableDataset


### PR DESCRIPTION
Fix #1032 which forgot to change the methods it calls. Without this change, those calls will throw an argument error.
Fix #1029, the reporting issue, as well.