### PR TITLE
fix assert message

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -566,10 +566,10 @@ class DeepSpeedEngine(Module):
             if self.zero_optimization_partition_weights() and any(
                 [hasattr(param,
                          'ds_id') for param in self.module.parameters()]):
-                assert all([param.dtype == torch.half for param in self.module.parameters()]), f"fp16 is enabled but one or several model parameters have dtype that is not fp16"
+                assert all([param.dtype == torch.half for param in self.module.parameters()]), "fp16 is enabled but one or several model parameters have dtype that is not fp16"
             self.module.half()
         else:
-            assert all([param.dtype == torch.float for param in self.module.parameters()]), f"fp16 is not enabled but one or several model parameters have dtype of fp16"
+            assert all([param.dtype == torch.float for param in self.module.parameters()]), "fp16 is not enabled but one or several model parameters have dtype of fp16"
 
         if not self.dont_change_device:
             self.module.to(self.device)

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -566,7 +566,7 @@ class DeepSpeedEngine(Module):
             if self.zero_optimization_partition_weights() and any(
                 [hasattr(param,
                          'ds_id') for param in self.module.parameters()]):
-                assert all([param.dtype == torch.half for param in self.module.parameters()]), f"Model must initialized in fp16 mode for ZeRO Stage 3."
+                assert all([param.dtype == torch.half for param in self.module.parameters()]), f"fp16 is enabled but one or several model parameters have dtype that is not fp16"
             self.module.half()
         else:
             assert all([param.dtype == torch.float for param in self.module.parameters()]), f"fp16 is not enabled but one or several model parameters have dtype of fp16"


### PR DESCRIPTION
The current assert "Model must initialized in fp16 mode for ZeRO Stage 3." needs grammatical TLC - I rewrote it completely to match its cousin assert, so now we have 2 consistent matching asserts:

- "fp16 is enabled but one or several model parameters have dtype that is not fp16"
- "fp16 is not enabled but one or several model parameters have dtype of fp16"

This PR also removes the `f""` as it's not needed.