### PR TITLE
Seeded unit tests

### DIFF
--- a/deepspeed/runtime/pipe/module.py
+++ b/deepspeed/runtime/pipe/module.py
@@ -533,7 +533,7 @@ class PipelineModule(nn.Module):
         idx = local_layer_idx + self._local_start
         layer_ckpt_path = os.path.join(ckpt_dir, f'layer_{idx:02d}')
         rank_repr = self._grid._topo.get_rank_repr(rank=self.global_rank)
-        if rank_repr is not '':
+        if rank_repr != '':
             layer_ckpt_path += f'-{rank_repr}'
         layer_ckpt_path += '-model_states.pt'
         return layer_ckpt_path

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -37,6 +37,11 @@ def ensure_directory_exists(filename):
 
 
 def set_random_seed(seed):
+    """Set the random seed for common PRNGs used during training: random, numpy, and torch.
+
+    Args:
+        seed (int): the seed to use
+    """
     import numpy
     import random
     random.seed(seed)

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-forked
+pytest-randomly
 pre-commit
 clang-format
 sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[options.entry_points]
+pytest_randomly.random_seeder =
+    deepspeed = deepspeed.runtime.utils:set_random_seed
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,3 @@
 [options.entry_points]
 pytest_randomly.random_seeder =
     deepspeed = deepspeed.runtime.utils:set_random_seed
-


### PR DESCRIPTION
Use `pytest-randomly` to seed our unit tests in a deterministic way. By default we'll use the system time and the seed is included in each testing log. We can use a fixed seed by supplying `--randomly-seed=SEED` to `pytest`