### PR TITLE
ZeRO-Infinity: support swapping misaligned sized fp16 tensors

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -771,9 +771,6 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
         #defragmented pinned memory
         self.param_groups_fp16_flat_cpu_memory = []
 
-        #fp16 buffer for swapping out nvme params
-        self.param_group_fp16_flat_reuse_buffer = None
-
         #a single 32-bit partition of the parallel partitioned parameters
         #that this process will update
         self.fp32_partitioned_groups_flat = []
@@ -1076,6 +1073,8 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
         dist.barrier()
         partition_id = dist.get_rank(group=self.dp_process_group)
         create_fp16_flat_reuse_buffer = False
+        largest_partition_numel = []
+        max_partition_numel = 0
 
         #create a flat CPU memory allocation for each param group
         if self.offload_param:
@@ -1102,6 +1101,12 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
                 total_elements = sum(
                     [t.ds_numel for t in self.fp16_partitioned_groups[i]])
                 self.fp16_partitioned_groups_flat_numel.append(total_elements)
+
+                if total_elements > max_partition_numel:
+                    largest_partition_numel = [
+                        t.ds_numel for t in self.fp16_partitioned_groups[i]
+                    ]
+                    max_partition_numel = total_elements
 
                 print_rank_0(
                     f"fp16 group {i} partitioned_param norms : {[param.ds_tensor.norm().item() for param in self.fp16_groups[i]]}"
@@ -1175,14 +1180,9 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
                 see_memory_usage(f"After Flattening param subgroup {i}", force=False)
 
         if create_fp16_flat_reuse_buffer:
-            assert self.param_group_fp16_flat_reuse_buffer is None, \
-            f'Unexpected that pinned memory for swapping params out to NVMe is already created'
-
-            self.param_group_fp16_flat_reuse_buffer = torch.empty(max(
-                self.fp16_partitioned_groups_flat_numel),
-                                                                  dtype=self.dtype,
-                                                                  device='cpu',
-                                                                  pin_memory=True)
+            assert len(largest_partition_numel) > 0, f'Unexpected that largest partition is empty'
+            self.fp16_groups[0][0].nvme_swapper.reserve_partitioned_swap_space(
+                largest_partition_numel)
 
     def _swap_in_sub_group_to_flat_buffer(self, flat_buffer, sub_group_id):
         offset = 0
@@ -1576,7 +1576,6 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
 
             self.grads_in_partition_offset = 0
 
-
     def _optimizer_step(self, sub_group_id):
         param_group_id = self.sub_group_to_group_id[sub_group_id]
         fp32_param = self.fp32_partitioned_groups_flat[sub_group_id]
@@ -1586,17 +1585,6 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
         self.optimizer.step()
         self.optimizer.param_groups[param_group_id]['params'] = []
 
-        if fp16_param is not None:
-            fp16_param.data.copy_(fp32_param.data)
-        else:
-            #synchronize incase there is a previous write going on the reuse buffer
-            self.fp16_groups[sub_group_id][0].nvme_swapper.synchronize_writes()
-            self.param_group_fp16_flat_reuse_buffer.narrow(
-                0,
-                0,
-                fp32_param.numel()).data.copy_(fp32_param.data)
-
-
     def _swappable_optimizer_subgroup(self, sub_group_id):
         if not self.swap_optimizer:
             return False
@@ -1605,60 +1593,27 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
             None,
             numel=self.fp16_partitioned_groups_flat_numel[sub_group_id])
 
-
-
-    def _partitioned_params_swap_out_2(self, i):
+    def _partitioned_params_swap_out(self, i):
         offset = 0
         fp32_param = self.fp32_partitioned_groups_flat[i]
         assert fp32_param is not None, \
         f'fp32 parameters of sub_group {i} is None'
 
-        swap_out_params = []
+        swap_fp16_params = []
+        swap_fp32_params = []
         for param, partitioned_param in zip(self.fp16_groups[i], self.fp16_partitioned_groups[i]):
             src = fp32_param.narrow(0, offset, partitioned_param.ds_numel)
             if partitioned_param.status == PartitionedParamStatus.AVAILABLE:
                 partitioned_param.data.copy_(src.data)
             else:
-                fp16_buffer = self.fp16_groups[i][0].nvme_swapper.get_buffer(param, partitioned_param.ds_numel)
-                fp16_buffer.data.copy_(src.data)
-                partitioned_param.status = PartitionedParamStatus.AVAILABLE
-                swap_out_params.append(param)
+                swap_fp32_params.append(src)
+                swap_fp16_params.append(param)
             offset += partitioned_param.ds_numel
 
-        if len(swap_out_params):
-            swap_out_params[0].nvme_swapper.synchronize_writes()
-            swap_out_params[0].nvme_swapper.swap_out_and_release(
-                swap_out_params,
-                async_op=True,
-                force_buffer_release=True)
-
-
-
-    def _partitioned_params_swap_out(self, i):
-        swap_out_params = []
-        offset = 0
-        for param, partitioned_param in zip(self.fp16_groups[i], self.fp16_partitioned_groups[i]):
-            src = self.param_group_fp16_flat_reuse_buffer.narrow(
-                0,
-                offset,
-                partitioned_param.ds_numel)
-            if partitioned_param.status == PartitionedParamStatus.AVAILABLE:
-                partitioned_param.data.copy_(src.data)
-            else:
-                partitioned_param.data = src.data
-                #Setting it to available just for good practice. It will be released at the end of the call
-                #by swap out and release
-                partitioned_param.status = PartitionedParamStatus.AVAILABLE
-                swap_out_params.append(param)
-            offset += partitioned_param.ds_numel
-
-        if len(swap_out_params) > 0:
-            #The write synchronize will happen before the buffer is reused in _optimizer_step so the buffer can be released
-            swap_out_params[0].nvme_swapper.swap_out_and_release(
-                swap_out_params,
-                async_op=True,
-                force_buffer_release=True)
-
+        if len(swap_fp16_params):
+            swap_fp16_params[0].nvme_swapper.swap_out_partitioned_params(
+                dst_fp16_params=swap_fp16_params,
+                src_fp32_params=swap_fp32_params)
 
     def initialize_optimizer_states(self):
         num_subgroups = len(self.fp16_groups)
@@ -1699,6 +1654,7 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
                                                        device=self.device)
                 if self.offload_optimizer_pin_memory:
                     subgroup_gradient_buffer = subgroup_gradient_buffer.pin_memory()
+
                 self.fp32_partitioned_groups_flat[i].grad = subgroup_gradient_buffer
             else:
                 self.fp32_partitioned_groups_flat[i].grad = gradient_buffer.narrow(
@@ -1708,11 +1664,11 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
 
             self._optimizer_step(i)
 
-            if swappable_optimizer_subgroup:
-                self._optimizer_states_and_gradient_swap_out(i, timer_names)
-
             if swappable_param_subgroup:
                 self._partitioned_params_swap_out(i)
+
+            if swappable_optimizer_subgroup:
+                self._optimizer_states_and_gradient_swap_out(i, timer_names)
 
             see_memory_usage(
                 f'[End] Initialize optimizer states {i} / {num_subgroups} subgroups, num_elems: {num_elements}, swappable opt/param:{swappable_optimizer_subgroup}/{swappable_param_subgroup}',
@@ -2718,14 +2674,12 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
         # get rid of the fp32 gradients. Not needed anymore
         self.fp32_partitioned_groups_flat[sub_group_id].grad = None
 
-
     def _unflatten_partitioned_parameters(self, sub_group_id):
         updated_params = self.unflatten(self.fp16_partitioned_groups_flat[sub_group_id],
                                         self.fp16_partitioned_groups[sub_group_id])
 
         for partitioned_param, q in zip(self.fp16_partitioned_groups[sub_group_id], updated_params):
             partitioned_param.data = q.data
-
 
     def _overflow_clean_up(self, prev_scale):
         see_memory_usage('After overflow before clearing gradients', force=False)
@@ -2777,6 +2731,9 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
 
     def _reassign_or_swap_out_partitioned_parameters(self, sub_group_id):
         if self.fp16_partitioned_groups_flat[sub_group_id] is not None:
+            self.fp16_partitioned_groups_flat[sub_group_id].data.copy_(
+                self.fp32_partitioned_groups_flat[sub_group_id].data)
+
             #unflatten fp16 parameter subgroup
             self._unflatten_partitioned_parameters(sub_group_id)
         else:
@@ -2813,11 +2770,11 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
             #apply the optimizer step on the sub group and copy fp32 parameters to fp16
             self._optimizer_step(sub_group_id)
 
-            #release memory or swap out optimizer states of fp32 parameters
-            self._release_sub_group(sub_group_id, timer_names)
-
             #put fp16 parameters in appropriate location
             self._reassign_or_swap_out_partitioned_parameters(sub_group_id)
+
+            #release memory or swap out optimizer states of fp32 parameters
+            self._release_sub_group(sub_group_id, timer_names)
 
         self.stop_timers(['optimizer_step'])
 


### PR DESCRIPTION
Support swapping fp16 tensors of lengths that are not aligned to nvme constraints.
Fix for #1070. 