### PR TITLE
delay imports for replace policies and fix missing req

### DIFF
--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -387,6 +387,9 @@ def replace_module(model, orig_class, replace_fn, _replace_policy):
         policy.update({orig_class: (replace_fn, _replace_policy)})
     else:
         for plcy in replace_policies:
+            # instantiate a throw-away policy in order to populate the _orig_layer_class
+            _ = plcy(None)
+            assert plcy._orig_layer_class != None
             policy.update({plcy._orig_layer_class: (replace_fn, plcy)})
 
     replaced_module, _ = _replace_module(model, policy)

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -6,3 +6,5 @@ clang-format
 sphinx
 recommonmark
 sphinx-rtd-theme
+megatron-lm==1.1.5
+importlib-metadata>=4


### PR DESCRIPTION
- [x] Add requirement for dev on importlib-metadata > 4, we were seeing pytest issues with importlib-metadata 2.0
- [x] Delay import of static class variables, this was causing our unit test framework to crash since importing megatron seems to initialize cuda which causes us python/pytorch multi-process issues :(
- [x] fix incorrect import path for ParallelTransformerLayer