### PR TITLE
[build] fix empty entry in gcc cmd leading to build failure.

### DIFF
--- a/op_builder/async_io.py
+++ b/op_builder/async_io.py
@@ -30,7 +30,7 @@ class AsyncIOBuilder(OpBuilder):
         return ['csrc/aio/py_lib', 'csrc/aio/common']
 
     def cxx_args(self):
-        return [
+        args = [
             '-g',
             '-Wall',
             '-O0',
@@ -41,8 +41,13 @@ class AsyncIOBuilder(OpBuilder):
             '-march=native',
             '-fopenmp',
             '-laio',
-            self.simd_width()
         ]
+
+        simd_width = self.simd_width()
+        if len(simd_width) > 0:
+            args.append(simd_width)
+
+        return args
 
     def extra_ldflags(self):
         return ['-laio']


### PR DESCRIPTION
In https://github.com/microsoft/DeepSpeed/issues/1126#issuecomment-853289728 it took quite a chase to figure out this: on 2 systems building async_io 
```
DS_BUILD_AIO=1 python setup.py build_ext develop
```
was failing with:
```
gcc: error: : No such file or directory
```
After a lot of digging it proved to be `op_builder/async_io.py` inserting an empty arg into gcc options on systems where `simd_width()` returns `""`, and hence the impossible chase after the invisible problem ensued.

If others need to debug similar things in the future, you want to work/debug inside `lib/python3.8/distutils/spawn.py` (with the desired python version) inside `_spawn_posix` at the point where a child is doing:
```
 exec_fn(executable, cmd)
```
and print each cmd entry separately and look for an empty one.

Whooph.

@tjruwase 