### PR TITLE
[builder] allow minor cuda version differences

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -48,14 +48,32 @@ def get_default_compute_capatabilities():
     return compute_caps
 
 
+# list compatible minor CUDA versions - so that for example pytorch built with cuda-11.0 can be used
+# to build deepsped and system-wide installed cuda 11.2
+cuda_minor_mismatch_ok = {
+    10: ["10.0",
+         "10.1",
+         "10.2"],
+    11: ["11.0",
+         "11.1",
+         "11.2",
+         "11.3"],
+}
+
+
 def assert_no_cuda_mismatch():
     cuda_major, cuda_minor = installed_cuda_version()
     sys_cuda_version = f'{cuda_major}.{cuda_minor}'
     torch_cuda_version = ".".join(torch.version.cuda.split('.')[:2])
     # This is a show-stopping error, should probably not proceed past this
+
     if sys_cuda_version != torch_cuda_version:
-        if sys_cuda_version == "11.1" and torch_cuda_version == "11.0":
-            # it works to build against installed cuda-11.1 while torch was built with cuda-11.0
+        if (cuda_major in cuda_minor_mismatch_ok
+                and sys_cuda_version in cuda_minor_mismatch_ok[cuda_major]
+                and torch_cuda_version in cuda_minor_mismatch_ok[cuda_major]):
+            print(f"Installed CUDA version {sys_cuda_version} does not match the "
+                  f"version torch was compiled with {torch.version.cuda} "
+                  "but since the APIs are compatible, accepting this combination")
             return
         raise Exception(
             f"Installed CUDA version {sys_cuda_version} does not match the "

--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -49,7 +49,7 @@ def get_default_compute_capatabilities():
 
 
 # list compatible minor CUDA versions - so that for example pytorch built with cuda-11.0 can be used
-# to build deepsped and system-wide installed cuda 11.2
+# to build deepspeed and system-wide installed cuda 11.2
 cuda_minor_mismatch_ok = {
     10: ["10.0",
          "10.1",

--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -66,7 +66,6 @@ def assert_no_cuda_mismatch():
     sys_cuda_version = f'{cuda_major}.{cuda_minor}'
     torch_cuda_version = ".".join(torch.version.cuda.split('.')[:2])
     # This is a show-stopping error, should probably not proceed past this
-
     if sys_cuda_version != torch_cuda_version:
         if (cuda_major in cuda_minor_mismatch_ok
                 and sys_cuda_version in cuda_minor_mismatch_ok[cuda_major]


### PR DESCRIPTION
I've been manually skipping this must match check for a long time now, and so far all the minor versions of cuda 10 or 11 seem to work when mismatched. So instead of manually mapping out each one of them this PR just creates a table of all the mismatching versions that are still OK.

Mind you, I have only been testing with transformers, so it is possible that there are some incompatible APIs that I don't know off. But this is all minor cuda releases, I'm not sure why the requirement for the exact match was introduced in the first place. Perhaps just matching the major version is plenty...

@jeffra  