### PR TITLE
correct cpu_offload deprecation

### DIFF
--- a/deepspeed/runtime/zero/config.py
+++ b/deepspeed/runtime/zero/config.py
@@ -65,14 +65,12 @@ class DeepSpeedZeroConfig(DeepSpeedConfigObject):
         return zero_config_dict
 
     def _sanity_check(self, zero_config_dict):
-        deprecated_dict = {
-            ZERO_OPTIMIZATION_CPU_OFFLOAD:
-            ZERO_OPTIMIZATION_OFFLOAD_OPTIMIZER,
-            ZERO_OPTIMIZATION_CPU_OFFLOAD_PARAMS:
-            ZERO_OPTIMIZATION_OFFLOAD_PARAM,
-            ZERO_OPTIMIZATION_CPU_OFFLOAD_USE_PIN_MEMORY:
+        deprecated_dict = dict(
+            ZERO_OPTIMIZATION_CPU_OFFLOAD=ZERO_OPTIMIZATION_OFFLOAD_OPTIMIZER,
+            ZERO_OPTIMIZATION_CPU_OFFLOAD_PARAMS=ZERO_OPTIMIZATION_OFFLOAD_PARAM,
+            ZERO_OPTIMIZATION_CPU_OFFLOAD_USE_PIN_MEMORY=
             f'{ZERO_OPTIMIZATION_OFFLOAD_PARAM} or {ZERO_OPTIMIZATION_OFFLOAD_OPTIMIZER}'
-        }
+        )
 
         for old_key, new_key in deprecated_dict.items():
             if old_key in zero_config_dict:

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -356,7 +356,7 @@ Enabling and configuring ZeRO memory optimizations
 
 | Description                                                                                                                                | Default |
 | ------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| For use with ZeRO stage 1, enable backward hooks to reduce gradients during the backward pass or wait until the end of the backward pass.  | `True`  |  
+| For use with ZeRO stage 1, enable backward hooks to reduce gradients during the backward pass or wait until the end of the backward pass.  | `True`  |
 
 ***offload_param***: [dictionary]
 
@@ -368,7 +368,7 @@ Enabling and configuring ZeRO memory optimizations
 
 | Description                                                                                                                                                                                                                    | Default |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| Enable offloading of optimizer state to CPU or NVMe, and optimizer computation to CPU. This frees up GPU memory for larger models or batch sizes. Valid only with stage 3. See [here](#optimizer-offloading) for more details. | `False` |
+| Enable offloading of optimizer state to CPU or NVMe, and optimizer computation to CPU. This frees up GPU memory for larger models or batch sizes. Valid only with stage 2 and 3. See [here](#optimizer-offloading) for more details. | `False` |
 
 ***stage3_max_live_parameters***: [integer]
 
@@ -405,7 +405,7 @@ Enabling and configuring ZeRO memory optimizations
 
 ***cpu_offload***: [boolean]
 
-**Deprecated:** **cpu_offload** is disabled and will be removed in future, please use `offload_optimizer` instead.
+**Deprecated:** **cpu_offload** is deprecated and will be removed in future, please use `offload_optimizer` instead.
 {: .notice--warning}
 
 | Description                                                                                                                                       | Default |


### PR DESCRIPTION
This PR:

1. reformats `deprecated_dict` so that it is more readable after autoformatter done botching the code
2. fixes the docs to indicate that `offload_optimizer` is not just for zero3 but for zero2 too
3. fixes invalid doc that says `cpu_offload` is disabled, whereas it's just deprecated

 