### PR TITLE
remove torchvision dependency

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,4 @@
 torch>=1.2
-torchvision>=0.4.0
 tqdm
 tensorboardX==1.8
 ninja


### PR DESCRIPTION
DeepSpeed itself does not require `torchvision`, I think we originally added it to support our cifar example. However we should just have this requirement in the example code itself and not in base deepspeed. We ran into strange issues with torchvision and compiled versions of torch not being compatible, and thus made deepspeed trigger version mismatch errors.