### PR TITLE
[zero.Init] post_init partitining is to be run only by a child module

### DIFF
--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -241,17 +241,17 @@ class InsertPostInitMethodToModuleSubClasses(object):
                              force=False)
 
                 is_child_module = False
-                if not hasattr(module, "child_entered"):
+                if not hasattr(module, "_ds_child_entered"):
                     # child's __init__ was called, since parents all see the same object they can now skip post_init
                     is_child_module = True
-                    setattr(module, "child_entered", True)
+                    setattr(module, "_ds_child_entered", True)
 
                 f(module, *args, **kwargs)
 
                 if is_child_module:
                     # child's __init__ is done, now we can run a single post_init on the child and release
                     # parents from being parents, so that they can be children too.
-                    delattr(module, "child_entered")
+                    delattr(module, "_ds_child_entered")
 
                     print_rank_0(f'Running post_init for {module.__class__.__name__}',
                                  force=False)

--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -241,21 +241,17 @@ class InsertPostInitMethodToModuleSubClasses(object):
                              force=False)
 
                 is_child_module = False
-                if not hasattr(module, "is_parent_module"):
-                    # child's __init__ was called, flag parents not call post_init
+                if not hasattr(module, "child_entered"):
+                    # child's __init__ was called, since parents all see the same object they can now skip post_init
                     is_child_module = True
-                    for parent_class in module.__class__.__mro__:
-                        if not parent_class == object:
-                            setattr(parent_class, "is_parent_module", True)
+                    setattr(module, "child_entered", True)
 
                 f(module, *args, **kwargs)
 
                 if is_child_module:
                     # child's __init__ is done, now we can run a single post_init on the child and release
                     # parents from being parents, so that they can be children too.
-                    for parent_class in module.__class__.__mro__:
-                        if not parent_class == object:
-                            delattr(parent_class, "is_parent_module")
+                    delattr(module, "child_entered")
 
                     print_rank_0(f'Running post_init for {module.__class__.__name__}',
                                  force=False)

--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -234,8 +234,8 @@ class InsertPostInitMethodToModuleSubClasses(object):
                 # the inheritance ancestry. This way the partitioning will need to happen only once
                 # when the whole object is ready to be partitioned and not before. This is because
                 # often the child module will need to tweak the weights - for example running a
-                # custom weights init function. So if a parent created the weights, the child won't
-                # need to gather them in order to tweak the weights.
+                # custom weights init function. So if a parent created the weights param, the child
+                # won't need to gather it in order to tweak it
 
                 print_rank_0(f'Before initializing {module.__class__.__name__}',
                              force=False)
@@ -249,8 +249,7 @@ class InsertPostInitMethodToModuleSubClasses(object):
                 f(module, *args, **kwargs)
 
                 if is_child_module:
-                    # child's __init__ is done, now we can run a single post_init on the child and release
-                    # parents from being parents, so that they can be children too.
+                    # child's __init__ is done, now we can run a single post_init on the child object
                     delattr(module, "_ds_child_entered")
 
                     print_rank_0(f'Running post_init for {module.__class__.__name__}',

--- a/tests/unit/test_zero_context.py
+++ b/tests/unit/test_zero_context.py
@@ -355,7 +355,7 @@ def test_subclass_param_init():
     assert model.param.ds_status == ZeroParamStatus.NOT_AVAILABLE
 
     # test that the weights manipulation during each __init__ worked in all w/o needing gathering
-    ones = torch.ones(5).cuda()
+    ones = torch.ones(5).half().cuda()
     with deepspeed.zero.GatheredParameters(list(model.parameters(recurse=False))):
         assert torch.equal(model.param, ones + 1)
         assert torch.equal(model.param_pa, ones + 2)

--- a/tests/unit/test_zero_context.py
+++ b/tests/unit/test_zero_context.py
@@ -283,6 +283,7 @@ def test_stage_3_output_type(output_type):
             engine.step()
 
 
+# test that no sub-class or super-class is missed
 class ConvX(torch.nn.Conv1d):
     def __init__(self, *args):
         super().__init__(*args)
@@ -310,3 +311,52 @@ def test_subclass_param():
 
     assert model.param.ds_status == ZeroParamStatus.NOT_AVAILABLE
     assert model.conv1.param_in.ds_status == ZeroParamStatus.NOT_AVAILABLE
+
+
+# test that sub-classes get params that aren't prematurely partitioned and thus requiring gathering
+# fixed by https://github.com/microsoft/DeepSpeed/pull/1202
+class GrandPa(torch.nn.Module):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.param_grandpa = torch.nn.Parameter(torch.ones(5))
+        self.param_grandpa.data = (self.param_grandpa.data +
+                                   1).data  # test param is not yet partitioned
+
+
+class Pa(GrandPa):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.param_pa = torch.nn.Parameter(torch.ones(5))
+        self.param_pa.data = (self.param_pa.data +
+                              1).data  # test param is not yet partitioned
+        self.param_grandpa.data = (self.param_grandpa.data +
+                                   1).data  # test param is not yet partitioned
+
+
+class Son(Pa):
+    def __init__(self):
+        super().__init__()
+        self.param = torch.nn.Parameter(torch.ones(5))
+        self.param.data = (self.param.data + 1).data  # test param is not yet partitioned
+        self.param_pa.data = (self.param_pa.data +
+                              1).data  # test param is not yet partitioned
+        self.param_grandpa.data = (self.param_grandpa.data +
+                                   1).data  # test param is not yet partitioned
+
+
+def test_subclass_param_init():
+    setup_serial_env()
+    with deepspeed.zero.Init(config=config):
+        model = Son().cpu()
+
+    # test that all params have been partitioned
+    assert model.param_grandpa.ds_status == ZeroParamStatus.NOT_AVAILABLE
+    assert model.param_pa.ds_status == ZeroParamStatus.NOT_AVAILABLE
+    assert model.param.ds_status == ZeroParamStatus.NOT_AVAILABLE
+
+    # test that the weights manipulation during each __init__ worked in all w/o needing gathering
+    ones = torch.ones(5).cuda()
+    with deepspeed.zero.GatheredParameters(list(model.parameters(recurse=False))):
+        assert torch.equal(model.param, ones + 1)
+        assert torch.equal(model.param_pa, ones + 2)
+        assert torch.equal(model.param_grandpa, ones + 3)


### PR DESCRIPTION
Originally the zero partitioning `post_init` was run only by the top `super` class, missing out on the children. Then we fixed it to run on all classes. Which was still insufficient. A parent creating weights, and child wanting to modify these weights now had to gather the weights. Moreover `post_init` was run multiple times on the same object.

This PR changes the wrapper logic to run `post_init` only once per object and do it only when child's `__init__` has finished. Thus no longer requiring the child to do any gathering.

Thanks to @samyam for suggesting how to tell the child from its parents.