### PR TITLE
[zero3] params_to_reduce isn't always there

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -1962,14 +1962,15 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
             for tensor in tensors:
                 tensor.div_(dist.get_world_size(group=self.dp_process_group))
 
-            # reduction resulting with each rank only holding the gradient partition it owns
-            # This could either be a reduce scatter or a reduce op depending on how
-            # parameters are partitionied. The method is impelemnted by the
-            # DeepSpeed param extensions to the pytroch parameter, so its up to
-            # the extension to define what happens here
-            params_to_reduce[0].reduce_gradients_at_owner(
-                param_list=params_to_reduce,
-                hierarchy=self.param_coordinator.hierarchy)
+            if len(params_to_reduce) > 0:
+                # reduction resulting with each rank only holding the gradient partition it owns
+                # This could either be a reduce scatter or a reduce op depending on how
+                # parameters are partitionied. The method is implemented by the
+                # DeepSpeed param extensions to the pytorch parameter, so its up to
+                # the extension to define what happens here
+                params_to_reduce[0].reduce_gradients_at_owner(
+                    param_list=params_to_reduce,
+                    hierarchy=self.param_coordinator.hierarchy)
 
     def set_grad_positions(self):
         for i, group in enumerate(self.fp16_groups):

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -1889,8 +1889,14 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
 
     ###############Idependent Partition Gradient ########################
     def reduce_independent_p_g_buckets_and_remove_grads(self, param, i):
-        #print_rank_0(f"Inside reduce ipg buckets. Param ID {param.ds_id}, ipg elements {self.elements_in_ipg_bucket}, reduce bucket size {self.reduce_bucket_size}", force=True)
-        if self.elements_in_ipg_bucket + param.ds_numel > self.reduce_bucket_size:
+        #print_rank_0(f"Inside reduce ipg buckets. {debug_param2name_id_shape(param)}, ipg elements {self.elements_in_ipg_bucket}, reduce bucket size {self.reduce_bucket_size}", force=True)
+
+        # Because the ipg bucket is initialized with a random place holder tensor, we must
+        # explicitly check that the bucket has any real data in it (self.elements_in_ipg_bucket >
+        # 0). Otherwise if the incoming param.ds_numel is large, this branch may get triggered on a
+        # garbage data and `self.average_tensor()` will crash because its params_to_reduce will be
+        # empty, while reduction_list will have that garbage data.
+        if self.elements_in_ipg_bucket > 0 and self.elements_in_ipg_bucket + param.ds_numel > self.reduce_bucket_size:
             self.report_ipg_memory_usage("In ipg_remove_grads before reduce_ipg_grads",
                                          param.ds_numel)
 
@@ -1962,15 +1968,14 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
             for tensor in tensors:
                 tensor.div_(dist.get_world_size(group=self.dp_process_group))
 
-            if len(params_to_reduce) > 0:
-                # reduction resulting with each rank only holding the gradient partition it owns
-                # This could either be a reduce scatter or a reduce op depending on how
-                # parameters are partitionied. The method is implemented by the
-                # DeepSpeed param extensions to the pytorch parameter, so its up to
-                # the extension to define what happens here
-                params_to_reduce[0].reduce_gradients_at_owner(
-                    param_list=params_to_reduce,
-                    hierarchy=self.param_coordinator.hierarchy)
+            # reduction resulting with each rank only holding the gradient partition it owns
+            # This could either be a reduce scatter or a reduce op depending on how
+            # parameters are partitionied. The method is implemented by the
+            # DeepSpeed param extensions to the pytorch parameter, so its up to
+            # the extension to define what happens here
+            params_to_reduce[0].reduce_gradients_at_owner(
+                param_list=params_to_reduce,
+                hierarchy=self.param_coordinator.hierarchy)
 
     def set_grad_positions(self):
         for i, group in enumerate(self.fp16_groups):
@@ -2202,7 +2207,7 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
         #####################################################################
 
     def reduce_ready_partitions_and_remove_grads(self, param, i):
-        #print(f"Backward {param.ds_id}")
+        #print_rank_0(f"Backward {debug_param2name_id_shape(param)}", force=True)
         self.reduce_independent_p_g_buckets_and_remove_grads(param, i)
 
     def zero_reduced_gradients(self, partition_id, i):


### PR DESCRIPTION
**update**: so the bug was earlier upstream in `reduce_independent_p_g_buckets_and_remove_grads`, and this PR has been now updated to the correct fix. Thank you, @tjruwase, for solving this (I just coded and verified that it works).

--------------------

Trying to port HF's Electra model's to Deepspeed I'm getting this on the very first backward step (with some extra debug):

```
Incrementing with parameter id 42
------ Before allocating allgather param name=generator_lm_head.weight id=41 shape=torch.Size([1]) status=ZeroParamStatus.NOT_AVAILABLE partition size=327680
------allgather param with name=generator_lm_head.weight id=41 shape=torch.Size([1]) status=ZeroParamStatus.NOT_AVAILABLE partition size=327680
------ Before allocating allgather param name=generator_lm_head.bias id=42 shape=torch.Size([1]) status=ZeroParamStatus.NOT_AVAILABLE partition size=5120
------allgather param with name=generator_lm_head.bias id=42 shape=torch.Size([1]) status=ZeroParamStatus.NOT_AVAILABLE partition size=5120
Backward name=generator_lm_head.weight id=41 shape=torch.Size([5120, 64])
Inside reduce ipg buckets. name=generator_lm_head.weight id=41 shape=torch.Size([5120, 64]), ipg elements 0, reduce bucket size 4096
Params in ipg bucket []
Reducing []
GOT 1
torch.Size([4096])
Traceback (most recent call last):
  File "examples/pytorch/language-modeling/run_mlm.py", line 533, in <module>
    main()
  File "examples/pytorch/language-modeling/run_mlm.py", line 484, in main
    train_result = trainer.train(resume_from_checkpoint=checkpoint)
  File "/mnt/nvme1/code/huggingface/transformers-ds-zero_to_fp32-tests/src/transformers/trainer.py", line 1269, in train
    tr_loss += self.training_step(model, inputs)
  File "/mnt/nvme1/code/huggingface/transformers-ds-zero_to_fp32-tests/src/transformers/trainer.py", line 1778, in training_step
    loss = self.deepspeed.backward(loss)
  File "/mnt/nvme1/code/github/00optimize/DeepSpeed-zero-init-child-only-post_init/deepspeed/runtime/engine.py", line 1188, in backward
    self.optimizer.backward(loss)
  File "/mnt/nvme1/code/github/00optimize/DeepSpeed-zero-init-child-only-post_init/deepspeed/runtime/zero/stage3.py", line 2964, in backward
    self.loss_scaler.backward(loss.float(), retain_graph=retain_graph)
  File "/mnt/nvme1/code/github/00optimize/DeepSpeed-zero-init-child-only-post_init/deepspeed/runtime/fp16/loss_scaler.py", line 53, in backward
    scaled_loss.backward(retain_graph=retain_graph)
  File "/home/stas/anaconda3/envs/py38-pt19/lib/python3.8/site-packages/torch/_tensor.py", line 255, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph, inputs=inputs)
  File "/home/stas/anaconda3/envs/py38-pt19/lib/python3.8/site-packages/torch/autograd/__init__.py", line 147, in backward
    Variable._execution_engine.run_backward(
  File "/mnt/nvme1/code/github/00optimize/DeepSpeed-zero-init-child-only-post_init/deepspeed/runtime/zero/stage3.py", line 1867, in reduce_partition_and_remove_grads
    self.reduce_ready_partitions_and_remove_grads(param, i)
  File "/mnt/nvme1/code/github/00optimize/DeepSpeed-zero-init-child-only-post_init/deepspeed/runtime/zero/stage3.py", line 2212, in reduce_ready_partitions_and_remove_grads
    self.reduce_independent_p_g_buckets_and_remove_grads(param, i)
  File "/mnt/nvme1/code/github/00optimize/DeepSpeed-zero-init-child-only-post_init/deepspeed/runtime/zero/stage3.py", line 1897, in reduce_independent_p_g_buckets_and_remove_grads
    self.reduce_ipg_grads()
  File "/mnt/nvme1/code/github/00optimize/DeepSpeed-zero-init-child-only-post_init/deepspeed/runtime/zero/stage3.py", line 2193, in reduce_ipg_grads
    self.average_tensor(reduction_list, params_to_reduce)
  File "/mnt/nvme1/code/github/00optimize/DeepSpeed-zero-init-child-only-post_init/deepspeed/runtime/zero/stage3.py", line 1972, in average_tensor
    params_to_reduce[0].reduce_gradients_at_owner(
IndexError: list index out of range
```

Is it always that `params_to_reduce` is not an empty list?

If I add this check (this PR) and skip the code if it's empty - the problem is able to proceed normally.

I have seen this error in other circumstances when the model did something not-kosher and I was able to fix it on the model size. But with the case of Electra I just can't figure out what could be going wrong. This is just a very last linear layer that it bails on on backward. 

Note, that if I remove that layer, things work too. If I add an extra layer after it the problem is the same - it fails on the very last layer then (first in backward). So I'm hesitant at whether the proposed change may somehow mask a real problem.

Also, before the `len(params_to_reduce) > 0` the `tensors` aren't empty - there is one tensor of reduce bucket size (`4096` here). So something is probably wrong there.

But regardless perhaps a more user-friendly assert should be happening and not the list lookup index failure (especially since it always expects just 0th entry).

The init of the problematic layer is at:
https://github.com/huggingface/transformers/blob/ce111feed139d3e2a05bb364ad8ee186093ad3c7/src/transformers/models/electra/modeling_electra.py#L1119

Thank you.
