### PR TITLE
[zero3] release tmp memory when consolidating fp16 weights

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -2017,7 +2017,8 @@ class DeepSpeedEngine(Module):
         def get_layer_state_dict(module, prefix=""):
             # gather one layer at a time to be memory-efficient
             with deepspeed.zero.GatheredParameters(list(
-                    module.parameters(recurse=False))):
+                    module.parameters(recurse=False)),
+                                                   modifier_rank=0):
                 if torch.distributed.get_rank() == 0:
                     for name, param in module.named_parameters(recurse=False):
                         if param is None:

--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -1094,7 +1094,7 @@ class GatheredParameters:
             enabled (bool, optional): If ``False``, this context is a no-op. Defaults to ``True``.
 
         Important: Make sure you use ``modifier_rank`` that is not ``None`` (e.g. ``modifier_rank=0``)
-        if you need the gathered memory to be released upon exit from the context manager.
+        if you need the GPU memory allocated by gather to be released upon exit from the context manager.
 
         Examples
         ========

--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -1093,6 +1093,9 @@ class GatheredParameters:
                 registered as external parameters of ``fwd_module``. See :meth:`deepspeed.zero.register_external_parameter`.
             enabled (bool, optional): If ``False``, this context is a no-op. Defaults to ``True``.
 
+        Important: Make sure you use ``modifier_rank`` that is not ``None`` (e.g. ``modifier_rank=0``)
+        if you need the gathered memory to be released upon exit from the context manager.
+
         Examples
         ========
 

--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -1093,7 +1093,7 @@ class GatheredParameters:
                 registered as external parameters of ``fwd_module``. See :meth:`deepspeed.zero.register_external_parameter`.
             enabled (bool, optional): If ``False``, this context is a no-op. Defaults to ``True``.
 
-        Important: Make sure you use ``modifier_rank`` that is not ``None`` (e.g. ``modifier_rank=0``)
+        Important: Make sure to use ``modifier_rank`` that is not ``None`` (e.g. ``modifier_rank=0``)
         if you need the GPU memory allocated by gather to be released upon exit from the context manager.
 
         Examples


### PR DESCRIPTION
Currently `GatheredParameters` with `modifier_rank=None` doesn't release memory until the param is used next time some time in the future. As a result `_zero3_consolidated_fp16_state_dict` was leaking memory. This PR uses the read/write mode which re-partitions the memory right away and releases the temporarily gathered params.

@tjruwase 