### PR TITLE
[zero3] fix reference counting in backward over multiple forwards

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -35,7 +35,7 @@ FWD_MODULE_STACK = list()
 from deepspeed.utils.debug import debug_module2name_id, debug_param2name_id, debug_param2name_id_numel, debug_param2name_id_shape_device, debug_module2name_class, printflock, log_rank_file
 
 
-def print_rank_0(message, debug=False, force=True):
+def print_rank_0(message, debug=False, force=False):
     rank = torch.distributed.get_rank()
     if rank == 0 and (debug or force):
         print(message)
@@ -1486,9 +1486,11 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
                 # some models (e.g. Albert) may run multiple forwards on the same layer in a loop
                 # before doing backwards, so each backward will need a pre-fetch - using reference
                 # counting to support this scenario
+                #print(f"COUNTER before: {sub_module.applied_pre_backward_ref_cnt}")
                 if sub_module.applied_pre_backward_ref_cnt > 0:
                     self.pre_sub_module_backward_function(sub_module)
                     sub_module.applied_pre_backward_ref_cnt -= 1
+                #print(f"COUNTER after: {sub_module.applied_pre_backward_ref_cnt}")
 
             return _apply_to_tensors_only(module,
                                           PreBackwardFunction,

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -32,10 +32,10 @@ from deepspeed.runtime.swap_tensor.pipelined_optimizer_swapper import PipelinedO
 pg_correctness_test = False
 
 FWD_MODULE_STACK = list()
-from deepspeed.utils.debug import debug_module2name_id, debug_param2name_id_numel, debug_param2name_id_shape_device, debug_module2name_class, printflock, log_rank_file
+from deepspeed.utils.debug import debug_module2name_id, debug_param2name_id, debug_param2name_id_numel, debug_param2name_id_shape_device, debug_module2name_class, printflock, log_rank_file
 
 
-def print_rank_0(message, debug=False, force=False):
+def print_rank_0(message, debug=False, force=True):
     rank = torch.distributed.get_rank()
     if rank == 0 and (debug or force):
         print(message)
@@ -397,7 +397,9 @@ class PartitionedParameterCoordinator(object):
     def fetch_sub_module(self, sub_module):
         partitioned_params = []
         params_in_flight = False
-        # print_rank_0(f"{'--' * self.hierarchy}Fetching params in module {sub_module.__class__.__name__}")
+        print_rank_0(
+            f"{'--' * self.hierarchy}Fetching params in module {debug_module2name_class(sub_module)}"
+        )
         params_to_fetch = [
             param for _,
             param in sub_module.named_parameters(recurse=False)
@@ -416,17 +418,18 @@ class PartitionedParameterCoordinator(object):
         for param in params_to_fetch:
             param.ds_active_sub_modules += 1
             print_rank_0(
-                f"{'--' * self.hierarchy}--Fetching parameters {param.ds_id} {param.ds_shape} with active sub modules {param.ds_active_sub_modules}"
+                f"{'--' * self.hierarchy}--Fetching parameters {debug_param2name_id_shape(param)} with active sub modules {param.ds_active_sub_modules}"
             )
 
             if param.ds_status == ZeroParamStatus.AVAILABLE:
                 print_rank_0(
-                    f"{'--' * self.hierarchy}--Parameter {param.ds_id} is already available"
+                    f"{'--' * self.hierarchy}--Parameter {debug_param2name_id(param)} is already available"
                 )
 
             if param.ds_status == ZeroParamStatus.NOT_AVAILABLE:
                 print_rank_0(
-                    f"{'--' * self.hierarchy}--Parameter {param.ds_id} is being fetched")
+                    f"{'--' * self.hierarchy}--Parameter {debug_param2name_id(param)} is being fetched"
+                )
                 partitioned_params.append(param)
 
                 # keeping track of number of elements consumed by available parmaeters
@@ -436,7 +439,7 @@ class PartitionedParameterCoordinator(object):
             if param.ds_status == ZeroParamStatus.INFLIGHT:
                 params_in_flight = True
                 print_rank_0(
-                    f"{'--' * self.hierarchy}--Parameters {param.ds_id} is already in flight (prefetched)"
+                    f"{'--' * self.hierarchy}--Parameters {debug_param2name_id(param)} is already in flight (prefetched)"
                 )
         self.hierarchy += 1
 
@@ -545,7 +548,9 @@ class PreBackwardFunction(torch.autograd.Function):
     def forward(ctx, module, pre_backward_function, outputs):
         ctx.module = module
         ctx.pre_backward_function = pre_backward_function
-        module.applied_pre_backward = False
+        if not hasattr(module, "applied_pre_backward_ref_cnt"):
+            module.applied_pre_backward_ref_cnt = 0
+        module.applied_pre_backward_ref_cnt += 1
         #print(f"After Forward: {ctx.module.__class__.__name__}")
         outputs = outputs.detach()
         return outputs
@@ -1478,9 +1483,12 @@ class FP16_DeepSpeedZeroOptimizer_Stage3(object):
 
         def _pre_backward_module_hook(module, inputs, output):
             def _run_before_backward_function(sub_module):
-                if sub_module.applied_pre_backward is False:
+                # some models (e.g. Albert) may run multiple forwards on the same layer in a loop
+                # before doing backwards, so each backward will need a pre-fetch - using reference
+                # counting to support this scenario
+                if sub_module.applied_pre_backward_ref_cnt > 0:
                     self.pre_sub_module_backward_function(sub_module)
-                    sub_module.applied_pre_backward = True
+                    sub_module.applied_pre_backward_ref_cnt -= 1
 
             return _apply_to_tensors_only(module,
                                           PreBackwardFunction,

--- a/tests/small_model_debugging/test_model.py
+++ b/tests/small_model_debugging/test_model.py
@@ -15,9 +15,9 @@ class SimpleModel(torch.nn.Module):
         self.cross_entropy_loss = torch.nn.CrossEntropyLoss()
 
     def forward(self, x, y):
-        hidden_dim = x
-        hidden_dim = self.linear(hidden_dim)
-        return self.cross_entropy_loss(hidden_dim, y)
+        hidden = x
+        hidden = self.linear(hidden)
+        return self.cross_entropy_loss(hidden, y)
 
 
 def create_config_from_dict(tmpdir, config_dict):

--- a/tests/unit/test_zero.py
+++ b/tests/unit/test_zero.py
@@ -28,7 +28,7 @@ def run_unbalanced_gradients(model, data_loader):
         enable_grads(model)
 
 
-@pytest.mark.parametrize('zero_stage', [1, 2])
+@pytest.mark.parametrize('zero_stage', [1, 2, 3])
 def test_zero_unbalanced_gradients(tmpdir, zero_stage):
     config_dict = {
         "train_micro_batch_size_per_gpu": 2,
@@ -67,3 +67,64 @@ def test_zero_unbalanced_gradients(tmpdir, zero_stage):
         run_unbalanced_gradients(model, data_loader)
 
     _test_zero_unbalanced_gradients(args=args, model=model, hidden_dim=hidden_dim)
+
+
+# testing the fix https://github.com/microsoft/DeepSpeed/pull/1227
+@pytest.mark.parametrize('zero_stage', [3])
+def test_zero3_repeat_forward_loop(tmpdir, zero_stage):
+
+    # force all params to be partitioned by forcing threshold=0
+    config_dict = {
+        "train_micro_batch_size_per_gpu": 2,
+        "gradient_accumulation_steps": 2,
+        "steps_per_print": 1,
+        "zero_optimization": {
+            "stage": zero_stage,
+            "stage3_param_persistence_threshold": 0
+        },
+        "optimizer": {
+            "type": "Adam",
+            "params": {
+                "lr": 1e-3
+            }
+        },
+        "fp16": {
+            "enabled": True,
+            "initial_scale_power": 8
+        }
+    }
+
+    args = args_from_dict(tmpdir, config_dict)
+    hidden_dim = 4
+
+    class AlbertLikeModel(torch.nn.Module):
+        def __init__(self, hidden_dim):
+            super().__init__()
+            self.linear = torch.nn.Linear(hidden_dim, hidden_dim)
+            self.cross_entropy_loss = torch.nn.CrossEntropyLoss()
+
+        def forward(self, x, y):
+            # run the same layer multiple times in a loop - to test a stack of forwards, followed by a stack of backwards
+            hidden = x
+            for i in range(3):
+                hidden = hidden + self.linear(hidden)
+            return self.cross_entropy_loss(hidden, y)
+
+    model = AlbertLikeModel(hidden_dim=hidden_dim)
+
+    @distributed_test(world_size=[1])
+    def _test_zero3_repeat_forward_loop(args, model, hidden_dim):
+        model, _, _, _ = deepspeed.initialize(args=args,
+                                              model=model,
+                                              model_parameters=model.parameters())
+        data_loader = random_dataloader(model=model,
+                                        total_samples=16,
+                                        hidden_dim=hidden_dim,
+                                        device=model.device)
+
+        for i, batch in enumerate(data_loader):
+            loss = model(batch[0], batch[1])
+            model.backward(loss)
+            model.step()
+
+    _test_zero3_repeat_forward_loop(args=args, model=model, hidden_dim=hidden_dim)


### PR DESCRIPTION
Models like Albert run the same layer's `forward` multiple times in a loop before doing `backward`. The current implementation can't handle that because it  assumes forward/backward pairs and runs prefetch hooks only once, the subsequent backwards get to work with the partitioned / ungathered param which breaks with:

```
Traceback (most recent call last):
  File "/mnt/nvme1/code/huggingface/transformers-ds-model-zoo-2/examples/pytorch/language-modeling/run_mlm.py", line 550, in <module>
    main()
  File "/mnt/nvme1/code/huggingface/transformers-ds-model-zoo-2/examples/pytorch/language-modeling/run_mlm.py", line 501, in main
    train_result = trainer.train(resume_from_checkpoint=checkpoint)
  File "/mnt/nvme1/code/huggingface/transformers-ds-model-zoo-2/src/transformers/trainer.py", line 1275, in train
    tr_loss += self.training_step(model, inputs)
  File "/mnt/nvme1/code/huggingface/transformers-ds-model-zoo-2/src/transformers/trainer.py", line 1784, in training_step
    loss = self.deepspeed.backward(loss)
  File "/mnt/nvme1/code/github/00optimize/deepspeed/deepspeed/runtime/engine.py", line 1191, in backward
    self.optimizer.backward(loss)
  File "/mnt/nvme1/code/github/00optimize/deepspeed/deepspeed/runtime/zero/stage3.py", line 2972, in backward
    self.loss_scaler.backward(loss.float(), retain_graph=retain_graph)
  File "/mnt/nvme1/code/github/00optimize/deepspeed/deepspeed/runtime/fp16/loss_scaler.py", line 53, in backward
    scaled_loss.backward(retain_graph=retain_graph)
  File "/home/stas/anaconda3/envs/py38-pt19/lib/python3.8/site-packages/torch/_tensor.py", line 255, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph, inputs=inputs)
  File "/home/stas/anaconda3/envs/py38-pt19/lib/python3.8/site-packages/torch/autograd/__init__.py", line 147, in backward
    Variable._execution_engine.run_backward(
RuntimeError: Function LinearFunctionForZeroStage3Backward returned an invalid gradient at index 0 - got [2, 512] but expected shape compatible with [2, 512, 256]
``` 

This PR 
- switches to reference counting, instead of on/off flag, which solves the problem.
- adds tests
- also did some other small improvements in tests and code

Thank you @tjruwase and @samyam for helping to diagnose and fix this problem.