### PR TITLE
[see_memory_usage] fix deprecation

### DIFF
--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -21,6 +21,16 @@ import torch.distributed as dist
 from deepspeed.utils import logger
 from numpy import prod
 
+# pt-1.9 deprecations
+if hasattr(torch.cuda, "memory_reserved"):
+    torch_memory_reserved = torch.cuda.memory_reserved
+else:
+    torch_memory_reserved = torch.cuda.memory_allocated
+if hasattr(torch.cuda, "max_memory_reserved"):
+    torch_max_memory_reserved = torch.cuda.max_memory_reserved
+else:
+    torch_max_memory_reserved = torch.cuda.memory_cached
+
 
 def noop_decorator(func):
     return func
@@ -589,8 +599,8 @@ def see_memory_usage(message, force=False):
     logger.info(
         f"MA {round(torch.cuda.memory_allocated() / (1024 * 1024 * 1024),2 )} GB \
         Max_MA {round(torch.cuda.max_memory_allocated() / (1024 * 1024 * 1024),2)} GB \
-        CA {round(torch.cuda.memory_cached() / (1024 * 1024 * 1024),2)} GB \
-        Max_CA {round(torch.cuda.max_memory_cached() / (1024 * 1024 * 1024))} GB ")
+        CA {round(torch_memory_reserved() / (1024 * 1024 * 1024),2)} GB \
+        Max_CA {round(torch_max_memory_reserved() / (1024 * 1024 * 1024))} GB ")
 
     vm_stats = psutil.virtual_memory()
     used_GB = round(((vm_stats.total - vm_stats.available) / (1024**3)), 2)


### PR DESCRIPTION
This PR fixes pt-1.9 deprecation:
```
python -c "from deepspeed.pt.deepspeed_utils import see_memory_usage; see_memory_usage('yes',1)"
[2021-07-14 18:52:03,194] [INFO] [utils.py:588:see_memory_usage] yes
/home/stas/anaconda3/envs/py38-pt19/lib/python3.8/site-packages/torch/cuda/memory.py:373: FutureWarning: 
torch.cuda.memory_cached has been renamed to torch.cuda.memory_reserved
  warnings.warn(
/home/stas/anaconda3/envs/py38-pt19/lib/python3.8/site-packages/torch/cuda/memory.py:381: FutureWarning: 
torch.cuda.max_memory_cached has been renamed to torch.cuda.max_memory_reserved
  warnings.warn(
```

Thank you.

@tjruwase 