### PR TITLE
Fix cudaErrorInvalidConfiguration in attn_softmax() for large values of sequence_length*num_heads

### DIFF
--- a/csrc/transformer/softmax_kernels.cu
+++ b/csrc/transformer/softmax_kernels.cu
@@ -4,6 +4,20 @@
 
 namespace cg = cooperative_groups;
 
+dim3 get_attn_softmax_grid(int batch_size, int heads, int sequence_length, int threads)
+{
+    int seq_length4 = sequence_length / 4;
+    int block_compute_size =
+        (seq_length4 < threads ? (int)pow(2.0, floor(log2((float)(threads / seq_length4)))) : 1);
+    // Note that the Y and Z dimensions are limited to 65535, while X is basically unlimited:
+    // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications
+    // The batch size is typically relatively small, while the sequence length could potentially be
+    // arbitrarily large. We therefore place the batch size second to avoid hitting the Y limit.
+    unsigned x = heads * sequence_length / block_compute_size;
+    unsigned y = batch_size;
+    return {x, y};
+}
+
 // Fused attention + softmax
 template <int tbSize, int blockStride, int tbSeq>
 __global__ void attn_softmax(float* vals,
@@ -22,12 +36,12 @@ __global__ void attn_softmax(float* vals,
     cg::thread_block b = cg::this_thread_block();
     cg::thread_block_tile<tbSize> g = cg::tiled_partition<tbSize>(b);
 
-    int batch = blockIdx.x;
-    int row = blockIdx.y;
+    int batch = blockIdx.y;
+    int row = blockIdx.x;
     int max_threads_in_sequence = std::max(seq_length, tbSeq);
     int seq_lane = threadIdx.x % max_threads_in_sequence;
 
-    int data_offset = batch * (gridDim.y * block_width) + row * block_width +
+    int data_offset = batch * (gridDim.x * block_width) + row * block_width +
                       (threadIdx.x / max_threads_in_sequence) * seq_length;
     int mask_offset = batch * seq_length;
 
@@ -153,12 +167,12 @@ __global__ void attn_softmax(__half* vals,
     cg::thread_block b = cg::this_thread_block();
     cg::thread_block_tile<tbSize> g = cg::tiled_partition<tbSize>(b);
 
-    int batch = blockIdx.x;
-    int row = blockIdx.y;
+    int batch = blockIdx.y;
+    int row = blockIdx.x;
     int max_threads_in_sequence = std::max(seq_length, tbSeq);
     int seq_lane = threadIdx.x % max_threads_in_sequence;
 
-    int data_offset = batch * (gridDim.y * block_width) + row * block_width +
+    int data_offset = batch * (gridDim.x * block_width) + row * block_width +
                       (threadIdx.x / max_threads_in_sequence) * seq_length;
     int mask_offset = batch * seq_length;
 
@@ -300,9 +314,7 @@ void launch_attn_softmax<float>(float* vals,
     const int threads = 128;
     int seq_length4 = sequence_length / 4;
 
-    int block_compute_size =
-        (seq_length4 < threads ? (int)pow(2.0, floor(log2((float)(threads / seq_length4)))) : 1);
-    dim3 grid_dim(batch_size, heads * sequence_length / block_compute_size);
+    dim3 grid_dim = get_attn_softmax_grid(batch_size, heads, sequence_length, threads);
 
     int subblock_max_workload = MAX_THREAD_ITERATIONS * 4 * threads;
 
@@ -333,10 +345,7 @@ void launch_attn_softmax<float>(float* vals,
             <<<grid_dim, block_dim, 0, stream>>>(vals, attn_mask, heads, seq_length4, iterations);
     else {
         const int threads = 256;
-        block_compute_size =
-            (seq_length4 < threads ? (int)pow(2.0, floor(log2((float)(threads / seq_length4))))
-                                   : 1);
-        dim3 grid_dim(batch_size, heads * sequence_length / block_compute_size);
+        dim3 grid_dim = get_attn_softmax_grid(batch_size, heads, sequence_length, threads);
 
         int subblock_max_workload = MAX_THREAD_ITERATIONS * 4 * threads;
 
@@ -370,9 +379,7 @@ void launch_attn_softmax<__half>(__half* vals,
     const int threads = 128;
     int seq_length4 = sequence_length / 4;
 
-    int block_compute_size =
-        (seq_length4 < threads ? (int)pow(2.0, floor(log2((float)(threads / seq_length4)))) : 1);
-    dim3 grid_dim(batch_size, heads * sequence_length / block_compute_size);
+    dim3 grid_dim = get_attn_softmax_grid(batch_size, heads, sequence_length, threads);
 
     int subblock_max_workload = MAX_THREAD_ITERATIONS * 4 * threads;
 
@@ -404,10 +411,7 @@ void launch_attn_softmax<__half>(__half* vals,
             <<<grid_dim, block_dim, 0, stream>>>(vals, attn_mask, heads, seq_length4, iterations);
     else {
         const int threads = 256;
-        block_compute_size =
-            (seq_length4 < threads ? (int)pow(2.0, floor(log2((float)(threads / seq_length4))))
-                                   : 1);
-        dim3 grid_dim(batch_size, heads * sequence_length / block_compute_size);
+        dim3 grid_dim = get_attn_softmax_grid(batch_size, heads, sequence_length, threads);
 
         int subblock_max_workload = MAX_THREAD_ITERATIONS * 4 * threads;
 

--- a/tests/unit/test_cuda_forward.py
+++ b/tests/unit/test_cuda_forward.py
@@ -232,6 +232,7 @@ def run_forward(ds_config, seq_len, atol=1e-2, verbose=False, test_bsz=None):
                              (8,128,128,2,3,True,True),
                              (8,4096,128,64,3,True,True),
                              (8,8192,128,64,3,False,True),
+                             (1,256,2048,32,3,True,True),
                          ]) # yapf: disable
 def test_forward(batch_size,
                  hidden_size,


### PR DESCRIPTION
When testing DeepSpeed internally, we stumbled upon a strange error when training transformer models with 32 heads and max sequence length of 2048. We pinned it down to the forward softmax kernel in `softmax_kernels.cu` using a 2D grid instead of a 1D one, as in other kernels. The CUDA documentation [states](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications) that the `maximum y- or z-dimension of a grid of thread blocks` is `65535`. You're supposed to get a `cudaErrorInvalidConfiguration` error when you try to launch a kernel exceeding this limit, and this is exactly what we're seeing — `heads * sequence_length / block_compute_size` is `32 * 2048 / 1 = 65536` in our case.

This PR fixes this by swapping the `x` and `y` dimensions of the grid. I believe this is the least error-prone approach, and it should work because the current `x` dimension is simply `batch_size`, which, AFAIK, is very unlikely to exceed 65535 anywhere.

Switching the forward softmax kernel to a 1D grid remains an option that I can implement if the current fix has some drawbacks I didn't think of.

Note 1: this kind of error is unfortunately quite hard to debug right now, since there is no error checking after launching custom kernels in [BertTransformerLayer<T>::Forward()](https://github.com/microsoft/DeepSpeed/blob/32e85eda58c560e5d5a596f71fce3682ac2ef80a/csrc/transformer/ds_transformer_cuda.cpp#L147). I solved this locally by copiously applying [this macro](https://github.com/microsoft/DeepSpeed/blob/32e85eda58c560e5d5a596f71fce3682ac2ef80a/csrc/transformer/inference/csrc/softmax.cu#L23) from another part of DeepSpeed in `BertTransformerLayer<T>::Forward()`, but decided not to include this change as part of this PR as it is not directly related to the kernel fix proper.

Note 2: I only tested this very lightly — the new test in `test_cuda_forward.py`, a transformer with a very small hidden size but large `num_heads*seq_length`, passes with this fix and fails on master. Since the fix is very straightforward, I decided that should be enough. I can add more tests if you want me to.