### PR TITLE
Reducing the memory-overhead of creating large-models for multi-GPU run

### DIFF
--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -137,6 +137,9 @@ def replace_transformer_layer(orig_layer_impl,
 
         if inference:
             hidden_size, num_attention_heads = policy.get_hidden_heads()
+            assert num_attention_heads % mp_size == 0,\
+                "To run the model parallel across the GPUs, the attention_heads require to be divisible by the world_size!" +\
+                "This is because the attention computation is partitioned evenly among the parallel GPUs."
 
         attn_linear_layer, qkvw, qkvb, dense_w, dense_b, scale_attention = policy.attention()
         mlp_linear_layer, _h4h_w, _h4h_b, _4hh_w, _4hh_b = policy.mlp()


### PR DESCRIPTION
This PR addresses the issue of creating large models for inference. We first partition the parallelable tensors on CPU based on the number of GPUs to run the model and then move each partition to the device. 

This fixes https://github.com/microsoft/DeepSpeed/issues/1209 and https://github.com/microsoft/DeepSpeed/issues/1161

TODO: I will change the inference test scripts to reflect these changes.