### PR TITLE
test link against libaio using distutils

### DIFF
--- a/op_builder/async_io.py
+++ b/op_builder/async_io.py
@@ -50,10 +50,14 @@ class AsyncIOBuilder(OpBuilder):
         return ['-laio']
 
     def is_compatible(self):
-        aio_libraries = ['libaio-dev']
-        aio_compatible = self.libraries_installed(aio_libraries)
+        # Check for the existence of libaio by using distutils
+        # to compile and link a test program that calls io_submit,
+        # which is a function provided by libaio that is used in the async_io op.
+        # If needed, one can define -I and -L entries in CFLAGS and LDFLAGS
+        # respectively to specify the directories for libaio.h and libaio.so.
+        aio_compatible = self.has_function('io_submit', ('aio', ))
         if not aio_compatible:
             self.warning(
-                f"{self.NAME} requires the libraries: {aio_libraries} but are missing. Can be fixed by: `apt install libaio-dev`."
+                f"{self.NAME} requires libaio but it is missing. Can be fixed by: `apt install libaio-dev`."
             )
         return super().is_compatible() and aio_compatible

--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -7,6 +7,7 @@ import time
 import importlib
 from pathlib import Path
 import subprocess
+import distutils.ccompiler
 from abc import ABC, abstractmethod
 
 YELLOW = '\033[93m'
@@ -159,6 +160,10 @@ class OpBuilder(ABC):
                                       shell=True)
             valid = valid or result.wait() == 0
         return valid
+
+    def has_function(self, funcname, libraries):
+        compiler = distutils.ccompiler.new_compiler()
+        return compiler.has_function(funcname, libraries=libraries)
 
     def strip_empty_entries(self, args):
         '''


### PR DESCRIPTION
Work in progress...

This implements more robust testing for libaio based on the discussion threads in https://github.com/microsoft/DeepSpeed/issues/1126 and https://github.com/microsoft/DeepSpeed/pull/1213

This first commit implements the fallback solution which lets the user declare where libaio is installed.  This successfully builds against the libaio installed in my conda environment after doing something like:
```
# install libaio into conda environment
conda install libaio

# tip the compiler on where to find libaio.h and libaio.so
export CFLAGS="-I${CONDA_PREFIX}/include $CFLAGS"
export LDFLAGS="-L${CONDA_PREFIX}/lib $LDFLAGS"

export DS_BUILD_OPS=1
python setup.py bdist_wheel
```

I'll work on the package manager detection bit described in https://github.com/microsoft/DeepSpeed/issues/1126#issuecomment-854101593 and submit that as part of this same PR.