### PR TITLE
aio: enable -O3 optimization

### DIFF
--- a/op_builder/async_io.py
+++ b/op_builder/async_io.py
@@ -30,6 +30,7 @@ class AsyncIOBuilder(OpBuilder):
         return ['csrc/aio/py_lib', 'csrc/aio/common']
 
     def cxx_args(self):
+        # -O0 for improved debugging, since performance is bound by I/O
         CPU_ARCH = self.cpu_arch()
         SIMD_WIDTH = self.simd_width()
         return [


### PR DESCRIPTION
This updates the aio op to build with ``-O3`` rather than ``-O0`` optimization.

It looks like all ops either build with ``-O2`` or ``-O3``, but aio uses ``-O0`` for some reason.  Is that intentional?