### PR TITLE
Fix the memory offset of cpu adam when using fp16 param

### DIFF
--- a/csrc/includes/cpu_adam.h
+++ b/csrc/includes/cpu_adam.h
@@ -27,7 +27,10 @@
 
 #if defined(__AVX512__)
 #define SIMD_STORE(a, d) _mm512_storeu_ps(a, d)
+#define SIMD_STORE_HALF(a, d) \
+    _mm256_store_ps(a, _mm256_castsi256_ps(_mm512_cvtps_ph(d, _MM_FROUND_TO_NEAREST_INT)))
 #define SIMD_LOAD(x) _mm512_loadu_ps(x)
+#define SIMD_LOAD_HALF(x) _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i*)(x)))
 #define SIMD_SET(x) _mm512_set1_ps(x)
 #define SIMD_MUL(x, y) _mm512_mul_ps(x, y)
 #define SIMD_FMA(x, y, c) _mm512_fmadd_ps(x, y, c)
@@ -35,29 +38,26 @@
 #define SIMD_DIV(x, y) _mm512_div_ps(x, y)
 #define SIMD_WIDTH 16
 
-#define SIMD_LOAD2(x, h) \
-    ((h) ? _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i*)x)) : _mm512_loadu_ps(x))
-#define SIMD_STORE2(x, d, h)                                                                      \
-    ((h) ? _mm256_store_ps(x, _mm256_castsi256_ps(_mm512_cvtps_ph(d, _MM_FROUND_TO_NEAREST_INT))) \
-         : _mm512_storeu_ps(x, d))
+#define SIMD_LOAD2(x, h) ((h) ? SIMD_LOAD_HALF(x) : SIMD_LOAD(x))
+#define SIMD_STORE2(x, d, h) ((h) ? SIMD_STORE_HALF(x, d) : SIMD_STORE(x, d))
 
 #define INTV __m256i
 #else
 #if defined(__AVX256__)
 #define SIMD_STORE(a, d) _mm256_storeu_ps(a, d)
+#define SIMD_STORE_HALF(a, d) \
+    _mm_store_ps(a, _mm_castsi128_ps(_mm256_cvtps_ph(d, _MM_FROUND_TO_NEAREST_INT)))
 #define SIMD_LOAD(x) _mm256_loadu_ps(x)
+#define SIMD_LOAD_HALF(x) _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)(x)))
 #define SIMD_SET(x) _mm256_set1_ps(x)
 #define SIMD_MUL(x, y) _mm256_mul_ps(x, y)
 #define SIMD_FMA(x, y, c) _mm256_fmadd_ps(x, y, c)
 #define SIMD_SQRT(x) _mm256_sqrt_ps(x)
 #define SIMD_DIV(x, y) _mm256_div_ps(x, y)
 #define SIMD_WIDTH 8
-#define SIMD_LOAD2(x, h) \
-    ((h) ? _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)x)) : _mm256_loadu_ps(x))
 
-#define SIMD_STORE2(x, d, h)                                                                \
-    ((h) ? _mm_store_ps(x, _mm_castsi128_ps(_mm256_cvtps_ph(d, _MM_FROUND_TO_NEAREST_INT))) \
-         : _mm256_storeu_ps(x, d))
+#define SIMD_LOAD2(x, h) ((h) ? SIMD_LOAD_HALF(x) : SIMD_LOAD(x))
+#define SIMD_STORE2(x, d, h) ((h) ? SIMD_STORE_HALF(x, d) : SIMD_STORE(x, d))
 
 #define INTV __m128i
 


### PR DESCRIPTION
This PR fixed the wrong memory offsetting when using fp16 parameters and gradients in cpu adam. 

In version 0.5.0, it is great that the cpu adam now supports calulating with fp16 param and grad! However, the old implementation was using `grads + i` when `grads` is of type `float*` and the underlying tensor was actually of type fp16. This will cause segmentation fault and huge numeric errors. And in this pr, I use the converted pointer `grads_cast_h` and `params_cast_h`:
```c++
    __half* grads_cast_h;
    __half* params_cast_h;
    if (half_precision) {
        grads_cast_h = reinterpret_cast<__half*>(grads);
        params_cast_h = reinterpret_cast<__half*>(_params);
    }
```
as the correct pointer and `grads_cast_h + i` is the correct memory offset.

Notice that these two helper pointers were introduced in the old implementation (in `Step`) but  were not used across the whole `Step_8`, `Step_4`, `Step` process.

Thank you for your time on reviewing this Pr :)