### PR TITLE
[zero] restore fp16 params if no zero ckpts available

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1884,9 +1884,11 @@ class DeepSpeedEngine(Module):
                                                          load_module_only=load_module_only)
 
         if self.zero_optimization() and load_path is not None:
-            self._load_zero_checkpoint(load_dir,
+            success = self._load_zero_checkpoint(load_dir,
                                        tag,
                                        load_optimizer_states=load_optimizer_states)
+            if not success:
+                self.optimizer._restore_from_fp16_weights()
 
         return load_path, client_states
 
@@ -1998,7 +2000,7 @@ class DeepSpeedEngine(Module):
     def _load_zero_checkpoint(self, load_dir, tag, load_optimizer_states=True):
         zero_sd_list = self._get_all_zero_checkpoints(load_dir, tag)
         if zero_sd_list is None:
-            return
+            return False
 
         self.optimizer.load_state_dict(
             state_dict_list=zero_sd_list,
@@ -2007,6 +2009,7 @@ class DeepSpeedEngine(Module):
         print(
             f'loading {len(zero_sd_list)} zero partition checkpoints for rank {self.global_rank}'
         )
+        return True
 
     def _get_mp_rank_zero_checkpoint_names(self, load_dir, tag, mp_rank, dp_world_size):
         zero_ckpt_names = []

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1884,9 +1884,10 @@ class DeepSpeedEngine(Module):
                                                          load_module_only=load_module_only)
 
         if self.zero_optimization() and load_path is not None:
-            success = self._load_zero_checkpoint(load_dir,
-                                       tag,
-                                       load_optimizer_states=load_optimizer_states)
+            success = self._load_zero_checkpoint(
+                load_dir,
+                tag,
+                load_optimizer_states=load_optimizer_states)
             if not success:
                 self.optimizer._restore_from_fp16_weights()
 


### PR DESCRIPTION
In fine-tuning scenarios the user often wants to only load the model parameter checkpoints and may not have the zero optimizer states on disk since they are not needed. This fixes a bug where the weights are not properly restored from the ckpt if the zero optimizer states are not present on disk.