### PR TITLE
Improve handling of `Init`'s config arguments

### DIFF
--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -374,12 +374,12 @@ class Init(InsertPostInitMethodToModuleSubClasses):
                 ``"cpu"``. Defaults to ``False``.
             config_dict_or_path (dict or ``json file``, optional): If provided, provides configuration.
             config (``json file`` or dict, optional): If provided, provides configuration
-                for swapping fp16 params to NVMe.
+                for swapping fp16 params to NVMe. Deprecated, use ``config_dict_or_path`` instead.
             enabled (bool, optional): If ``False``, this context has no
                 effect. Defaults to ``True``.
             dtype (``dtype``, optional): Can be used to change the data type of the parameters.
                 Supported options are ``torch.half`` and ``torch.float``. Defaults to ``None``
-            mpu (``object``, optional): A model parallelism unit object that implements get_{model,data}_parallel_{rank,group,wolrd_size}.
+            mpu (``object``, optional): A model parallelism unit object that implements get_{model,data}_parallel_{rank,group,world_size}.
 
         This context accelerates model initialization and enables models that
         are too large to allocate in their entirety in CPU memory. It has the
@@ -487,7 +487,6 @@ class Init(InsertPostInitMethodToModuleSubClasses):
 
         # Enable fp16 param swapping to NVMe
         if self.remote_device == OFFLOAD_NVME_DEVICE:
-            _ds_config = DeepSpeedConfig(config)
             self.param_swapper = AsyncPartitionedParameterSwapper(_ds_config)
         else:
             self.param_swapper = None


### PR DESCRIPTION
## Changes

- Remove remaining usage of `config` instead of `config_dict_or_path`
- Add note in docstring that `config` is deprecated
- Fix typo in docstring

## Explanation

I figured out that when using `transformers`, as of DeepSpeed commit e08c239, I was having issues loading models for training as fp32. I figured out that `transformers` is still using the `config` parameter, even though it does not function the way it did back before the commit. This causes `InsertPostInitMethodToModuleSubClasses.dtype` to default to `torch.half`, even though the class should take `ds_config.fp16_enabled` into account.

My fix here is to treat `config` as a deprecated alias for the new `config_dict_or_path` parameter. This seems reasonable given a comment on another PR: <https://github.com/microsoft/DeepSpeed/pull/1271#discussion_r683837140>. In addition, from #1008 and #1271, it seems that there only needs to be one instance of `DeepSpeedConfig` in the method, so I removed the second one.

I added a runtime warning so users can see that the parameter that they were using should be changed. I will be putting a PR out to transfer to the new parameter in `transformers` after this PR is merged and released. I'm guessing that the old `config` parameter should be removed at some point in the future, but I have no clue about the deprecation policy for this library.