### PR TITLE
Introduce a device rank when setting device

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -593,7 +593,9 @@ class DeepSpeedEngine(Module):
             return None
 
     def _set_distributed_vars(self, args):
-        device_rank = args.device_rank if args is not None and args.device_rank else self.local_rank
+        device_rank = args.device_rank if args is not None and hasattr(
+            args,
+            'device_rank') else self.local_rank
         if device_rank >= 0:
             torch.cuda.set_device(device_rank)
             self.device = torch.device("cuda", device_rank)

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -169,7 +169,7 @@ class DeepSpeedEngine(Module):
             assert not self.elasticity_enabled(), "Elasticity is not currently supported" \
                 " with model parallelism."
 
-        self._set_distributed_vars()
+        self._set_distributed_vars(args)
 
         if self.tensorboard_enabled() and self.global_rank == 0:
             self.summary_writer = self.get_summary_writer()
@@ -592,10 +592,11 @@ class DeepSpeedEngine(Module):
         else:
             return None
 
-    def _set_distributed_vars(self):
-        if self.local_rank >= 0:
-            torch.cuda.set_device(self.local_rank)
-            self.device = torch.device("cuda", self.local_rank)
+    def _set_distributed_vars(self, args):
+        device_rank = args.device_rank if args is not None and args.device_rank else self.local_rank
+        if device_rank >= 0:
+            torch.cuda.set_device(device_rank)
+            self.device = torch.device("cuda", device_rank)
             self.world_size = dist.get_world_size()
             self.global_rank = dist.get_rank()
         else:


### PR DESCRIPTION
When users pass specific device IDs to the Trainer in Lightning, this caused DeepSpeed to have a reference to the incorrect rank when setting device. This was due to the assumption that `local_rank` pointed to the correct CUDA device in the DeepSpeed engine.

Associated issue: https://github.com/PyTorchLightning/pytorch-lightning/issues/9521

This PR introduces a new variable in the args `device_rank`, which if present will be used to set the device (else default to local rank). I would like to add a test for this, but any assistance on where/what format would be appreciated :)