### PR TITLE
fix: support loading checkpoints with three-digit layer numbers

### DIFF
--- a/deepspeed/runtime/pipe/module.py
+++ b/deepspeed/runtime/pipe/module.py
@@ -543,7 +543,7 @@ class PipelineModule(nn.Module):
     def ckpt_layer_path_list(self, ckpt_dir, local_layer_idx):
         """Get all ckpt file list for a specific pipeline module layer. """
         idx = local_layer_idx + self._local_start
-        layer_ckpt_path = os.path.join(ckpt_dir, f'layer_{idx:02d}')
+        layer_ckpt_path = os.path.join(ckpt_dir, f'layer_{idx:02d}-')
         layer_ckpt_path += "*model_states.pt"
         ckpt_files = glob.glob(layer_ckpt_path)
         ckpt_files.sort()


### PR DESCRIPTION
This fixes the glob regex to support models that have pipeline depths of 100 or more.  For processes trying to match on "layer 10", the previous regex would match file names for both ``layer_10-*`` and ``layer-100-*``, which then led it to incorrectly take the ``elif num_ckpt > mp_world_size:`` branch in ``SDLoaderBase.load()``:

https://github.com/microsoft/DeepSpeed/blob/45a498d09886593bd4cbfc8c0f5f9463880e569e/deepspeed/runtime/state_dict_factory.py#L95

Waiting for a test to complete to verify this fix...  Yes, this seems to work for me.

BTW, I got the following error stack trace when it takes the wrong branch:
```
Traceback (most recent call last):
   File "/Megatron-DeepSpeed.git/pretrain_gpt.py", line 233, in <module>
     args_defaults={'tokenizer_type': 'GPT2BPETokenizer'})
   File "/Megatron-DeepSpeed.git/megatron/training.py", line 118, in pretrain
     model, optimizer, lr_scheduler = setup_model_and_optimizer(model_provider)
   File "/Megatron-DeepSpeed.git/megatron/training.py", line 357, in setup_model_and_optimizer
     args.iteration = load_checkpoint(model, optimizer, lr_scheduler)
   File "/Megatron-DeepSpeed.git/megatron/checkpointing.py", line 270, in load_checkpoint
     loaded_dir, state_dict = model[0].load_checkpoint(load_dir)
   File "/anaconda/envs/deepspeedbigsci/lib/python3.7/site-packages/deepspeed/runtime/engine.py", line 1753, in load_checkpoint
     load_lr_scheduler_states=load_lr_scheduler_states)
   File "/anaconda/envs/deepspeedbigsci/lib/python3.7/site-packages/deepspeed/runtime/engine.py", line 1786, in _load_checkpoint
     strict=load_module_strict)
   File "/anaconda/envs/deepspeedbigsci/lib/python3.7/site-packages/deepspeed/runtime/pipe/engine.py", line 1204, in load_module_state_dict
     self.module.load_state_dir(load_dir=self._curr_ckpt_path, strict=strict)
   File "/anaconda/envs/deepspeedbigsci/lib/python3.7/site-packages/deepspeed/runtime/pipe/module.py", line 576, in load_state_dir
     load_path, checkpoint, _ = sd_loader.load(mp_world_size, mp_rank, module_key=None, is_pipe_parallel=True)
   File "/anaconda/envs/deepspeedbigsci/lib/python3.7/site-packages/deepspeed/runtime/state_dict_factory.py", line 93, in load
     quantize_bits, quantize_groups, mlp_extra_grouping)
   File "/anaconda/envs/deepspeedbigsci/lib/python3.7/site-packages/deepspeed/runtime/state_dict_factory.py", line 312, in merge_state_dict
     self.sanity_check(self.ckpt_list[0])
   File "/anaconda/envs/deepspeedbigsci/lib/python3.7/site-packages/deepspeed/runtime/state_dict_factory.py", line 447, in sanity_check
     assert check_key_exist(key, self.get_module(sd)), f'key: {key} is not found in the checkpoint {ckpt_file_name}'
   File "/anaconda/envs/deepspeedbigsci/lib/python3.7/site-packages/deepspeed/runtime/state_dict_factory.py", line 149, in get_module
     return sd[self.module_key]
 KeyError: None
```
I know it should not have taken this path, but I don't know if that might indicate a different error (i.e., calling ``get_module`` when ``self.module_key == None``).