### PR TITLE
[zero_to_fp32] fix padding removal

### DIFF
--- a/deepspeed/utils/zero_to_fp32.py
+++ b/deepspeed/utils/zero_to_fp32.py
@@ -212,7 +212,9 @@ def _get_fp32_state_dict_from_zero_checkpoint(ds_checkpoint_dir):
                                                  offset,
                                                  partitioned_numel)
                       for i in range(world_size)),
-                0).narrow(0, 0, unpartitioned_numel).view(shape)
+                0).narrow(0,
+                          0,
+                          unpartitioned_numel).view(shape)
             offset += partitioned_numel
 
     if zero_stage == 3:

--- a/deepspeed/utils/zero_to_fp32.py
+++ b/deepspeed/utils/zero_to_fp32.py
@@ -117,14 +117,9 @@ def parse_optim_states(files, ds_checkpoint_dir):
 
 
 def zero3_partitioned_param_info(unpartitioned_numel, world_size):
-    #print("*** ", unpartitioned_numel, world_size, " ***",)
-    # handle an edge case where there is only 1 element (e.g. bias in a tiny test model)
-    if unpartitioned_numel == 1:
-        return 1, 0
-
     remainder = unpartitioned_numel % world_size
     padding_numel = (world_size - remainder) if remainder else 0
-    partitioned_numel = int(unpartitioned_numel / world_size)
+    partitioned_numel = math.ceil(unpartitioned_numel / world_size)
     return partitioned_numel, padding_numel
 
 
@@ -211,21 +206,14 @@ def _get_fp32_state_dict_from_zero_checkpoint(ds_checkpoint_dir):
                     f"{total_params} {name} full shape: {shape} partition0 numel={partitioned_numel} partitioned_padding_numel={partitioned_padding_numel}"
                 )
 
-            if unpartitioned_numel > 1:
-                # XXX: memory usage doubles here (zero3)
-                state_dict[name] = torch.cat(
-                    tuple(fp32_flat_groups[i].narrow(0,
-                                                     offset,
-                                                     partitioned_numel)
-                          for i in range(world_size)),
-                    0).view(shape)
-            else:
-                # handle an edge case where there is only 1 element (e.g. bias in a tiny test model)
-                state_dict[name] = fp32_flat_groups[0].narrow(
-                    0,
-                    offset,
-                    partitioned_numel).view(shape)
-            offset += partitioned_numel + partitioned_padding_numel
+            # XXX: memory usage doubles here (zero3)
+            state_dict[name] = torch.cat(
+                tuple(fp32_flat_groups[i].narrow(0,
+                                                 offset,
+                                                 partitioned_numel)
+                      for i in range(world_size)),
+                0).narrow(0, 0, unpartitioned_numel).view(shape)
+            offset += partitioned_numel
 
     if zero_stage == 3:
         offset *= world_size

--- a/tests/unit/test_zero.py
+++ b/tests/unit/test_zero.py
@@ -184,7 +184,7 @@ def test_zero_to_fp32(tmpdir, zero_stage):
                 return self.cross_entropy_loss(hidden, y)
 
         args = args_from_dict(tmpdir, config_dict)
-        hidden_dim = 3 # do not change
+        hidden_dim = 3  # do not change
 
         world_size = dist.get_world_size()
         # we want at least 2x layers as there are gpus to trigger round_robin_fp16_groups reshuffle in zero2

--- a/tests/unit/test_zero.py
+++ b/tests/unit/test_zero.py
@@ -166,13 +166,15 @@ def test_zero_to_fp32(tmpdir, zero_stage):
         class MyModel(torch.nn.Module):
             def __init__(self, hidden_dim, n_layers):
                 super().__init__()
+                # to reproduce https://github.com/microsoft/DeepSpeed/pull/1372 it is important that
+                # the number of total params is uneven -
+                # (1) 4 layers are 3*(3+1)=12 elements each, 48 in total
                 self.ll = torch.nn.ModuleList(
                     torch.nn.Linear(hidden_dim,
                                     hidden_dim) for i in range(n_layers))
-                # to reproduce https://github.com/microsoft/DeepSpeed/pull/1372 it is important that
-                # the number of params is uneven - the following adds 4+1 params - the linear
-                # layers are 6 param each + 5 - so total 17 elements (for 1 gpu)
+                # the following adds 4+1=5 elements
                 self.classifier = torch.nn.Linear(4, 1)
+                # so total 48+5=53 (uneven as desired) elements
                 self.cross_entropy_loss = torch.nn.CrossEntropyLoss()
 
             def forward(self, x, y):
@@ -182,7 +184,7 @@ def test_zero_to_fp32(tmpdir, zero_stage):
                 return self.cross_entropy_loss(hidden, y)
 
         args = args_from_dict(tmpdir, config_dict)
-        hidden_dim = 2
+        hidden_dim = 3 # do not change
 
         world_size = dist.get_world_size()
         # we want at least 2x layers as there are gpus to trigger round_robin_fp16_groups reshuffle in zero2

--- a/tests/unit/test_zero.py
+++ b/tests/unit/test_zero.py
@@ -167,14 +167,14 @@ def test_zero_to_fp32(tmpdir, zero_stage):
             def __init__(self, hidden_dim, n_layers):
                 super().__init__()
                 # to reproduce https://github.com/microsoft/DeepSpeed/pull/1372 it is important that
-                # the number of total params is uneven -
-                # (1) 4 layers are 3*(3+1)=12 elements each, 48 in total
+                # the number of total elements is uneven:
+                # (1) 4 layers of 3*(3+1)=12 elements each, 48 in total
                 self.ll = torch.nn.ModuleList(
                     torch.nn.Linear(hidden_dim,
                                     hidden_dim) for i in range(n_layers))
-                # the following adds 4+1=5 elements
+                # (2) the following adds 4+1=5 elements
                 self.classifier = torch.nn.Linear(4, 1)
-                # so total 48+5=53 (uneven as desired) elements
+                # total 48+5=53 (uneven as desired) elements
                 self.cross_entropy_loss = torch.nn.CrossEntropyLoss()
 
             def forward(self, x, y):


### PR DESCRIPTION
It appears that my initial implementation of zero_to_fp32 with zero3 was broken when padding was involved and it just happened to work since all models I worked with were w/o the padding (i.e. all params were even/divisible by n_gpus). This PR remedies that and adds a very specific test that verifies the various edges when params are not divisible by n_gpus.

@tjruwase 