### PR TITLE
fix file-system race condition in saving/loading to disk on some test nodes

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -2256,7 +2256,9 @@ class DeepSpeedEngine(Module):
             expert_save_dir = self._get_expert_ckpt_name(save_dir, global_expert_id, tag)
             logger.info(
                 f'Saving model expert {global_expert_id} checkpoint: {expert_save_dir}')
-            torch.save(expert_state_dict, expert_save_dir)
+            with open(expert_save_dir, 'wb') as fd:
+                torch.save(expert_state_dict, fd)
+                fd.flush()
 
         # Save optimizer states. They are different across each exp parallel rank.
         optimizer_state = {
@@ -2264,10 +2266,9 @@ class DeepSpeedEngine(Module):
             self.optimizer.state_dict()
             if self.optimizer and not self.zero_optimization() else None
         }
-        torch.save(optimizer_state,
-                   self._get_optimizer_ckpt_name(save_dir,
-                                                 tag,
-                                                 expp_rank))
+        with open(self._get_optimizer_ckpt_name(save_dir, tag, expp_rank), 'wb') as fd:
+            torch.save(optimizer_state, fd)
+            fd.flush()
 
         if expp_rank == 0:
             # TODO: update num experts info,.. in checkpoint
@@ -2294,7 +2295,9 @@ class DeepSpeedEngine(Module):
             }
             state.update(client_state)
             logger.info(f'Saving model checkpoint: {save_path}')
-            torch.save(state, save_path)
+            with open(save_path, 'wb') as fd:
+                torch.save(state, fd)
+                fd.flush()
         self._curr_save_path = None
 
     def _create_checkpoint_file(self, save_dir, tag, zero_checkpoint):
@@ -2345,7 +2348,9 @@ class DeepSpeedEngine(Module):
 
         log_dist(message=f'Saving model checkpoint: {save_path}', ranks=[0, 1])
         #logger.info('Saving model checkpoint: {}'.format(save_path))
-        torch.save(state, save_path)
+        with open(save_path, 'wb') as fd:
+            torch.save(state, fd)
+            fd.flush()
         self._curr_save_path = None
 
     def _get_buffer_names(self):
@@ -2424,7 +2429,9 @@ class DeepSpeedEngine(Module):
                        param_shapes=self._get_zero_param_shapes(),
                        ds_config=self.config,
                        ds_version=version)
-        torch.save(zero_sd, zero_checkpoint_name)
+        with open(zero_checkpoint_name, 'wb') as fd:
+            torch.save(zero_sd, fd)
+            fd.flush()
         if self.global_rank == 0:
             self._copy_recovery_script(save_path)
         logger.info('zero checkpoint saved {}'.format(zero_checkpoint_name))
@@ -2529,7 +2536,9 @@ class DeepSpeedEngine(Module):
         if torch.distributed.get_rank() == 0:
             os.makedirs(save_dir, exist_ok=True)
             logger.info(f"Saving model weights to {path}")
-            torch.save(state_dict, path)
+            with open(path, 'wb') as fd:
+                torch.save(state_dict, fd)
+                fd.flush()
 
     def set_train_batch_size(self, train_batch_size):
         """Adjust the global batch size by increasing or decreasing the size of


### PR DESCRIPTION
For some reason we were seeing corrupt checkpoints in our unit tests where we immediately save/restore checkpoints. These changes seem to fix the issue by bypassing the `torch.save` file descriptor and forcing a flush at the end of the same.

Also, this commit bumps DSE to latest commit