### PR TITLE
WIP: Big science fix passing multiple tensors

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -850,7 +850,7 @@ class PipelineEngine(DeepSpeedEngine):
             for idx in range(num_tensors):
                 recv_dtype = torch.LongTensor(data=[0]).to(self.device)
                 p2p.recv(recv_dtype, send_stage)
-                recv_dtype = recv_dtype.item()
+                recv_dtype = self.ID_TO_DTYPE[recv_dtype.item()]
                 recv_ndims = torch.LongTensor(data=[0]).to(self.device)
                 p2p.recv(recv_ndims, send_stage)
                 recv_ndims = recv_ndims.item()

--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -790,7 +790,7 @@ class PipelineEngine(DeepSpeedEngine):
                 assert isinstance(tensor, torch.Tensor)
                 send_shape = torch.LongTensor(data=tensor.size()).to(self.device)
                 send_ndims = torch.LongTensor(data=[len(tensor.size())]).to(self.device)
-                send_dtype = torch.LongTensor(data=self.DTYPE_TO_ID[tensor.dtype]).to(self.device)
+                send_dtype = torch.LongTensor(data=[self.DTYPE_TO_ID[tensor.dtype]]).to(self.device)
                 p2p.send(send_dtype, recv_stage)
                 p2p.send(send_ndims, recv_stage)
                 p2p.send(send_shape, recv_stage)

--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -63,7 +63,7 @@ class PipelineEngine(DeepSpeedEngine):
         torch.int64,
         torch.bool
     ]
-    DTYPE_TO_ID = {id_: dtype for id_, dtype in enumerate(ID_TO_DTYPE)}
+    DTYPE_TO_ID = {dtype: id_ for id_, dtype in enumerate(ID_TO_DTYPE)}
 
     def __init__(self, *super_args, **super_kwargs):
         super().__init__(*super_args, **super_kwargs)

--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -896,7 +896,7 @@ class PipelineEngine(DeepSpeedEngine):
             # Inject the partitoned tensor into the output before sending
 
             # XXX Hack
-            inputs = tuple([part.to_meta(), part.data(), *inputs[1:]])
+            inputs = ([part.to_meta(), part.data(), *[elt.grad for elt in inputs[1:]]])
 
         # XXX Terrible hack
         # Drop the attention mask from the input buffer here. It does not have
@@ -990,7 +990,7 @@ class PipelineEngine(DeepSpeedEngine):
                 local_part=outputs[1],
                 group=self.grid.get_slice_parallel_group())
             outputs[0].data = part_output.full()
-            outputs = tuple([outputs[0], *outputs[2:]])
+            outputs = ([outputs[0], *outputs[2:]])
             # save for backward
             self.pipe_buffers['outputs'][buffer_id] = outputs
 

--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -673,7 +673,7 @@ class PipelineEngine(DeepSpeedEngine):
                 outputs = (self.pipe_buffers['output_tensors'][buffer_id], *outputs[2:])
             else:
                 # Already restored from partition
-                self.pipe_buffers['output_tensors'][buffer_id].data = outputs
+                self.pipe_buffers['output_tensors'][buffer_id].data = outputs[0]
                 outputs = (self.pipe_buffers['output_tensors'][buffer_id], *outputs[1:])
 
         grad_tensors = self.grad_layer
@@ -911,6 +911,7 @@ class PipelineEngine(DeepSpeedEngine):
 
         # Partition the gradient
         if self.is_grad_partitioned:
+            assert isinstance(inputs, tuple)
             part = PartitionedTensor(tensor=inputs[0].grad,
                                      group=self.grid.get_slice_parallel_group())
             # Clear the large output data, but save the computation graph


### PR DESCRIPTION
Fixes necessary for implementation of prefix lm:
 - Passing tuple of tensors between stages
 - Allowing models to pass bool tensors. (This seems fixed in `torch.distributed` for pytorch > 1.7) 