### PR TITLE
[zero_to_fp32] fix to handle world_size

### DIFF
--- a/deepspeed/runtime/zero/stage2.py
+++ b/deepspeed/runtime/zero/stage2.py
@@ -770,10 +770,7 @@ class FP16_DeepSpeedZeroOptimizer(object):
 
     # create a flat tensor aligned at the alignment boundary
     def flatten_dense_tensors_aligned(self, tensor_list, alignment):
-        num_elements = 0
-        for tensor in tensor_list:
-            num_elements = num_elements + tensor.numel()
-
+        num_elements = sum(t.numel() for t in tensor_list)
         remaining = num_elements % alignment
 
         if remaining:
@@ -782,8 +779,6 @@ class FP16_DeepSpeedZeroOptimizer(object):
                                      device=tensor_list[0].device,
                                      dtype=tensor_list[0].dtype)
             padded_tensor_list = tensor_list + [pad_tensor]
-
-            num_elements = num_elements + elements_to_add
         else:
             padded_tensor_list = tensor_list
 


### PR DESCRIPTION
This PR is trying to address specifically https://github.com/microsoft/DeepSpeed/issues/1317#issuecomment-926998777
as my original fix used a hardcoded alignment to 4, but the correct one is `2*world_size`

While at it I simplified `flatten_dense_tensors_aligned` a bit. hope it's ok.

-------------------------

Trying to unravel the padding in zero2 w/o the optimizer object looks impossible.

e.g. if I use a tiny model from the test with 57 params, and 2 gpus, 

1. zero2 pads with 3 ending up with 60 params and then splits it into 2x30 so this aligns to 2*world_size
2. but then before saving it, it looks up a different type of padding `self.groups_padding` which is totally different from nccl padding, so when it saves the `single_partition_of_fp32_groups` partitions it actually saves these 2 sizes `[30, 29]`

So when trying to reconstruct I end up with wanting 57 params and having 59 - so that gap is impossible to work out.

I suspect there is a bug somewhere there, as I think it should save `[30, 27]` instead, but it sort of works when DS reconstructs it using the complex logic.

The workaround I use is to basically align both numbers to `2*world_size` and only then compare that they are the same.

Please correct me if I'm wrong but I didn't see that the saved `single_partition_of_fp32_groups` actually ever include any padding. If they do that would explain why other users sometimes have an issue using this script with zero2. Because the padding would completely mess up the weights. I tried hard to write a test that would break, but I couldn't, I always get the exact same model back.

in Z2 I simply concatenate all `single_partition_of_fp32_groups` and then re-shape into params. (which apparently is only correct for single param group and will be fixed shortly).

@tjruwase, am I missing something here? The partitioning plus double padding code is so complex.

