### PR TITLE
Improve error message of pipeline engine

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -44,11 +44,12 @@ def _tensor_bytes(tensor):
 
 
 class PipelineEngine(DeepSpeedEngine):
-    """ A training engine hybrid pipeline, data, and model parallel training.
+    """A training engine hybrid pipeline, data, and model parallel training.
 
     This engine is created by ``deepspeed.initialize()`` when a :class:`PipelineModule`
     is provided.
     """
+
     ID_TO_DTYPE = [
         torch.float32,
         torch.float64,
@@ -61,7 +62,7 @@ class PipelineEngine(DeepSpeedEngine):
         torch.int16,
         torch.int32,
         torch.int64,
-        torch.bool
+        torch.bool,
     ]
     DTYPE_TO_ID = {dtype: id_ for id_, dtype in enumerate(ID_TO_DTYPE)}
 
@@ -69,7 +70,9 @@ class PipelineEngine(DeepSpeedEngine):
         super().__init__(*super_args, **super_kwargs)
         assert isinstance(self.module, PipelineModule), "model must base PipelineModule"
 
-        assert self.zero_optimization_stage() < 2, "ZeRO-2 and ZeRO-3 are incompatible with pipeline parallelism"
+        assert (
+            self.zero_optimization_stage() < 2
+        ), "ZeRO-2 and ZeRO-3 are incompatible with pipeline parallelism"
 
         # We schedule the all-reduces, so disable it in super().backward()
         self.enable_backward_allreduce = False
@@ -78,8 +81,9 @@ class PipelineEngine(DeepSpeedEngine):
         # used to disable the pipeline all-reduce when used with 1-bit Adam/1-bit LAMB
         self.pipeline_enable_backward_allreduce = True
 
-        assert not self.elasticity_enabled(), "Elasticity is not currently supported" \
-            " with pipeline parallelism."
+        assert not self.elasticity_enabled(), (
+            "Elasticity is not currently supported" " with pipeline parallelism."
+        )
 
         # pipeline step for logging
         self.log_batch_step_id = -1
@@ -90,14 +94,18 @@ class PipelineEngine(DeepSpeedEngine):
         # Set Grid and Communication Groups
         self.grid = self.module._grid
         if self.grid.get_global_rank() == 0:
-            logger.info(f'CONFIG: micro_batches={self.micro_batches} '
-                        f'micro_batch_size={self.micro_batch_size}')
+            logger.info(
+                f"CONFIG: micro_batches={self.micro_batches} "
+                f"micro_batch_size={self.micro_batch_size}"
+            )
 
         self.global_rank = self.grid.get_global_rank()
 
         assert self.dp_world_size == self.grid.data_parallel_size
-        assert self.train_batch_size() == \
-            self.micro_batch_size * self.micro_batches * self.grid.data_parallel_size
+        assert (
+            self.train_batch_size()
+            == self.micro_batch_size * self.micro_batches * self.grid.data_parallel_size
+        )
 
         #  Set Stage Inf
         self.num_stages = self.grid.pipe_parallel_size
@@ -110,12 +118,13 @@ class PipelineEngine(DeepSpeedEngine):
 
         self._force_grad_boundary = False
 
-        self.batch_timer = ThroughputTimer(batch_size=self.micro_batch_size *
-                                           self.micro_batches,
-                                           num_workers=self.dp_world_size,
-                                           logging_fn=self.tput_log,
-                                           monitor_memory=False,
-                                           steps_per_output=self.steps_per_print())
+        self.batch_timer = ThroughputTimer(
+            batch_size=self.micro_batch_size * self.micro_batches,
+            num_workers=self.dp_world_size,
+            logging_fn=self.tput_log,
+            monitor_memory=False,
+            steps_per_output=self.steps_per_print(),
+        )
 
         # PipelineEngine needs to handle data loading specially due to only the first
         # and last stages loading inputs/labels. We construct a sampler that uses
@@ -138,35 +147,38 @@ class PipelineEngine(DeepSpeedEngine):
         if self.module.tied_comms:
             tied_params = 0
             for key, d in self.module.tied_comms.items():
-                if self.global_rank != min(d['ranks']):
-                    tied_params += sum(p.numel() for p in d['module'].parameters())
+                if self.global_rank != min(d["ranks"]):
+                    tied_params += sum(p.numel() for p in d["module"].parameters())
             unique_params -= tied_params
-        params_tensor = torch.LongTensor(data=[num_params,
-                                               unique_params]).to(self.device)
+        params_tensor = torch.LongTensor(data=[num_params, unique_params]).to(
+            self.device
+        )
         dist.all_reduce(params_tensor, group=self.grid.get_model_parallel_group())
         params_tensor = params_tensor.tolist()
         total_params = params_tensor[0]
         unique_params = params_tensor[1]
         if self.grid.data_parallel_id == 0:
-            logger.info(f'RANK={self.global_rank} '
-                        f'STAGE={self.stage_id} '
-                        f'LAYERS={self.module._local_stop - self.module._local_start} '
-                        f'[{self.module._local_start}, {self.module._local_stop}) '
-                        f'STAGE_PARAMS={num_params} ({num_params/1e6:0.3f}M) '
-                        f'TOTAL_PARAMS={total_params} ({total_params/1e6:0.3f}M) '
-                        f'UNIQUE_PARAMS={unique_params} ({unique_params/1e6:0.3f}M)')
+            logger.info(
+                f"RANK={self.global_rank} "
+                f"STAGE={self.stage_id} "
+                f"LAYERS={self.module._local_stop - self.module._local_start} "
+                f"[{self.module._local_start}, {self.module._local_stop}) "
+                f"STAGE_PARAMS={num_params} ({num_params/1e6:0.3f}M) "
+                f"TOTAL_PARAMS={total_params} ({total_params/1e6:0.3f}M) "
+                f"UNIQUE_PARAMS={unique_params} ({unique_params/1e6:0.3f}M)"
+            )
 
-        #intialize peer-2-peer communication and allreduce groups
+        # intialize peer-2-peer communication and allreduce groups
         if self.is_pipe_parallel:
             p2p.init_process_groups(self.grid)
 
         # Pipeline buffers
         self.num_pipe_buffers = 0
         self.pipe_buffers = {
-            'inputs' : [],   # batch input and received activations
-            'labels' : [],   # labels from batch input
-            'outputs' : [],  # activations
-            'output_tensors' : [], # tensor object to preserve backward graph
+            "inputs": [],  # batch input and received activations
+            "labels": [],  # labels from batch input
+            "outputs": [],  # activations
+            "output_tensors": [],  # tensor object to preserve backward graph
         }
         self.pipe_recv_buf = None
         self.grad_layer = None
@@ -176,17 +188,18 @@ class PipelineEngine(DeepSpeedEngine):
         self.first_output_send = True
         self.first_gradient_send = True
 
-        #stores the loss for the current micro batch being processed
+        # stores the loss for the current micro batch being processed
         self.loss = torch.tensor(0.0).to(self.device)
 
-        #stores the loss for the entire batch
+        # stores the loss for the entire batch
         self.total_loss = None
         self.agg_loss = torch.tensor(0.0, requires_grad=False).to(self.device)
         self.dp_group_loss = torch.tensor(0.0, requires_grad=False).to(self.device)
 
-        if self._config.pipeline['activation_checkpoint_interval'] > 0:
+        if self._config.pipeline["activation_checkpoint_interval"] > 0:
             self.module.activation_checkpoint_interval = self._config.pipeline[
-                'activation_checkpoint_interval']
+                "activation_checkpoint_interval"
+            ]
 
         if self.is_last_stage():
             self.loss_model = self.module.loss_fn
@@ -206,25 +219,26 @@ class PipelineEngine(DeepSpeedEngine):
         # XXX look into timer reporting timing
         # Initialize some timers because of early weirdness.
         if self.wall_clock_breakdown():
-            self.timers('forward_microstep').start()
-            self.timers('forward_microstep').stop()
-            self.timers('backward_microstep').start()
-            self.timers('backward_microstep').stop()
-            self.timers('backward_inner_microstep').start()
-            self.timers('backward_inner_microstep').stop()
-            self.timers('backward_allreduce_microstep').start()
-            self.timers('backward_allreduce_microstep').stop()
-            self.timers('backward_allreduce').start()
-            self.timers('backward_allreduce').stop()
-            self.timers('step_microstep').start()
-            self.timers('step_microstep').stop()
+            self.timers("forward_microstep").start()
+            self.timers("forward_microstep").stop()
+            self.timers("backward_microstep").start()
+            self.timers("backward_microstep").stop()
+            self.timers("backward_inner_microstep").start()
+            self.timers("backward_inner_microstep").stop()
+            self.timers("backward_allreduce_microstep").start()
+            self.timers("backward_allreduce_microstep").stop()
+            self.timers("backward_allreduce").start()
+            self.timers("backward_allreduce").stop()
+            self.timers("step_microstep").start()
+            self.timers("step_microstep").stop()
 
     def _build_data_iter(self, dataset):
         sampler = torch.utils.data.distributed.DistributedSampler(
             dataset,
             num_replicas=self.dp_world_size,
             rank=self.mpu.get_data_parallel_rank(),
-            shuffle=False)
+            shuffle=False,
+        )
         # Build a loader and make it repeating.
         pipe_dataloader = self.deepspeed_io(dataset, data_sampler=sampler)
         pipe_dataloader = RepeatingLoader(pipe_dataloader)
@@ -291,7 +305,8 @@ class PipelineEngine(DeepSpeedEngine):
         """
         if not torch._C.is_grad_enabled():
             raise RuntimeError(
-                f'train_batch() requires gradients enabled. Use eval_batch() instead.')
+                f"train_batch() requires gradients enabled. Use eval_batch() instead."
+            )
 
         if data_iter:
             self.set_dataiterator(data_iter)
@@ -301,49 +316,61 @@ class PipelineEngine(DeepSpeedEngine):
         self._compute_loss = True
 
         # Do the work
-        self.timers('train_batch').start()
-        sched = schedule.TrainSchedule(micro_batches=self.micro_batches,
-                                       stages=self.num_stages,
-                                       stage_id=self.stage_id)
+        self.timers("train_batch").start()
+        sched = schedule.TrainSchedule(
+            micro_batches=self.micro_batches,
+            stages=self.num_stages,
+            stage_id=self.stage_id,
+        )
         self._exec_schedule(sched)
         self.agg_train_loss = self._aggregate_total_loss()
 
-        self.timers('train_batch').stop()
+        self.timers("train_batch").stop()
 
         if self.global_steps % self.steps_per_print() == 0:
             if self.global_rank == 0:
-                elapsed = self.timers('train_batch').elapsed(reset=True)
+                elapsed = self.timers("train_batch").elapsed(reset=True)
                 iter_time = elapsed / self.steps_per_print()
                 tput = self.train_batch_size() / iter_time
-                print(f'steps: {self.global_steps} '
-                      f'loss: {self.agg_train_loss:0.4f} '
-                      f'iter time (s): {iter_time:0.3f} '
-                      f'samples/sec: {tput:0.3f}')
+                print(
+                    f"steps: {self.global_steps} "
+                    f"loss: {self.agg_train_loss:0.4f} "
+                    f"iter time (s): {iter_time:0.3f} "
+                    f"samples/sec: {tput:0.3f}"
+                )
 
         # Tensorboard
         if self.tensorboard_enabled():
             if self.global_rank == 0:
-                self.summary_events = [(f'Train/Samples/train_loss',
-                                        self.agg_train_loss.mean().item(),
-                                        self.global_samples)]
+                self.summary_events = [
+                    (
+                        f"Train/Samples/train_loss",
+                        self.agg_train_loss.mean().item(),
+                        self.global_samples,
+                    )
+                ]
                 for event in self.summary_events:  # write_summary_events
                     self.summary_writer.add_scalar(event[0], event[1], event[2])
                 if self.global_steps % self.steps_per_print() == 0:
                     self.summary_writer.flush()
 
-        if self.wall_clock_breakdown(
-        ) and self.global_steps % self.steps_per_print() == 0:
-            self.timers.log([
-                'pipe_send_output',
-                'pipe_send_grad',
-                'pipe_recv_input',
-                'pipe_recv_grad'
-            ])
+        if (
+            self.wall_clock_breakdown()
+            and self.global_steps % self.steps_per_print() == 0
+        ):
+            self.timers.log(
+                [
+                    "pipe_send_output",
+                    "pipe_send_grad",
+                    "pipe_recv_input",
+                    "pipe_recv_grad",
+                ]
+            )
 
         # TODO: should return precisely what loss returned and allow others to be queried?
         return self.agg_train_loss
 
-    def eval_batch(self, data_iter, compute_loss=True, reduce_output='avg'):
+    def eval_batch(self, data_iter, compute_loss=True, reduce_output="avg"):
         """Evaluate the pipeline on a batch of data from ``data_iter``. The
         engine will evaluate ``self.train_batch_size()`` total samples
         collectively across all workers.
@@ -382,9 +409,11 @@ class PipelineEngine(DeepSpeedEngine):
         self.set_dataiterator(data_iter)
 
         # Do the work
-        sched = schedule.InferenceSchedule(micro_batches=self.micro_batches,
-                                           stages=self.num_stages,
-                                           stage_id=self.stage_id)
+        sched = schedule.InferenceSchedule(
+            micro_batches=self.micro_batches,
+            stages=self.num_stages,
+            stage_id=self.stage_id,
+        )
         with torch.no_grad():
             self._exec_schedule(sched)
 
@@ -396,9 +425,13 @@ class PipelineEngine(DeepSpeedEngine):
 
         if self.tensorboard_enabled():
             if self.global_rank == 0:
-                self.summary_events = [(f'Train/Samples/eval_loss',
-                                        eval_output.mean().item(),
-                                        self.global_samples)]
+                self.summary_events = [
+                    (
+                        f"Train/Samples/eval_loss",
+                        eval_output.mean().item(),
+                        self.global_samples,
+                    )
+                ]
                 for event in self.summary_events:  # write_summary_events
                     self.summary_writer.add_scalar(event[0], event[1], event[2])
                 self.summary_writer.flush()
@@ -407,7 +440,7 @@ class PipelineEngine(DeepSpeedEngine):
         self.set_dataiterator(train_iterator)
 
         # Reset any buffers that may have been populated during the forward passes.
-        #ds_checkpointing.reset()
+        # ds_checkpointing.reset()
 
         return eval_output
 
@@ -432,11 +465,11 @@ class PipelineEngine(DeepSpeedEngine):
         """True if this process is in the last stage in the pipeline."""
         return self.stage_id == self.num_stages - 1
 
-    def _reduce_outputs(self, outputs, reduce='avg', reduce_dp=True):
+    def _reduce_outputs(self, outputs, reduce="avg", reduce_dp=True):
         if reduce is None:
             return outputs
 
-        if reduce.lower() == 'avg':
+        if reduce.lower() == "avg":
             # first sum over all microbatches
             if torch.is_tensor(outputs[0]):
                 reduced = sum(outputs)
@@ -456,13 +489,14 @@ class PipelineEngine(DeepSpeedEngine):
                     reduced /= self.dp_world_size
                 else:
                     for idx in range(len(reduced)):
-                        dist.all_reduce(reduced[idx],
-                                        group=self.mpu.get_data_parallel_group())
+                        dist.all_reduce(
+                            reduced[idx], group=self.mpu.get_data_parallel_group()
+                        )
                         reduced[idx] /= self.dp_world_size
 
             return reduced
         else:
-            raise NotImplementedError(f'reduction type {reduce} not supported.')
+            raise NotImplementedError(f"reduction type {reduce} not supported.")
 
     def _bcast_pipe_scalar(self, data, src_rank=None, dtype=torch.float32):
         # Default to last stage (e.g., for broadcasting loss)
@@ -473,11 +507,11 @@ class PipelineEngine(DeepSpeedEngine):
         if self.global_rank == src_rank:
             result = data.clone().detach()
         else:
-            result = torch.Tensor([0.]).type(dtype).to(self.device)
+            result = torch.Tensor([0.0]).type(dtype).to(self.device)
 
-        dist.broadcast(tensor=result,
-                       src=src_rank,
-                       group=self.mpu.get_pipe_parallel_group())
+        dist.broadcast(
+            tensor=result, src=src_rank, group=self.mpu.get_pipe_parallel_group()
+        )
 
         return result
 
@@ -489,25 +523,27 @@ class PipelineEngine(DeepSpeedEngine):
 
             ## Average loss across all data-parallel groups
             agg_loss = self.dp_group_loss.clone().detach()
-            #print(f'RANK={self.global_rank} bcast SENDER src={self.global_rank} group={self.grid.pp_group}', flush=True)
+            # print(f'RANK={self.global_rank} bcast SENDER src={self.global_rank} group={self.grid.pp_group}', flush=True)
             if self.is_data_parallel:
                 dist.all_reduce(agg_loss, group=self.mpu.get_data_parallel_group())
                 agg_loss /= self.dp_world_size
 
             assert self.global_rank in self.grid.pp_group
             losses = torch.Tensor([self.dp_group_loss, agg_loss]).to(self.device)
-            dist.broadcast(tensor=losses,
-                           src=self.global_rank,
-                           group=self.mpu.get_pipe_parallel_group())
+            dist.broadcast(
+                tensor=losses,
+                src=self.global_rank,
+                group=self.mpu.get_pipe_parallel_group(),
+            )
 
         else:
             # Get loss from last stage
             src_rank = self.grid.stage_to_global(self.num_stages - 1)
             assert src_rank in self.grid.pp_group
-            losses = torch.Tensor([0., 0.]).to(self.device)
-            dist.broadcast(tensor=losses,
-                           src=src_rank,
-                           group=self.grid.get_pipe_parallel_group())
+            losses = torch.Tensor([0.0, 0.0]).to(self.device)
+            dist.broadcast(
+                tensor=losses, src=src_rank, group=self.grid.get_pipe_parallel_group()
+            )
             self.dp_group_loss = losses[0].clone().detach()
             agg_loss = losses[1].clone().detach()
 
@@ -520,7 +556,7 @@ class PipelineEngine(DeepSpeedEngine):
             self.data_iterator = iter(self.training_dataloader)
 
     def set_dataiterator(self, iterator):
-        """ Store an iterator to sample for training data. """
+        """Store an iterator to sample for training data."""
         if self.is_first_stage() or self.is_last_stage():
             self.training_dataloader = None
             self.data_iterator = iterator
@@ -543,14 +579,15 @@ class PipelineEngine(DeepSpeedEngine):
         if LOG_STAGE == self.stage_id or LOG_STAGE == -1:
             if DATA_PARALLEL_ID == self.grid.data_parallel_id or DATA_PARALLEL_ID == -1:
                 print(
-                    f'RANK={dist.get_rank()} '
-                    f'PIPE-ID={self.stage_id} '
-                    f'DATA-ID={self.grid.data_parallel_id} '
-                    f'MBATCH-ID={self.microbatch_id} '
-                    f'STEP-ID={self.log_batch_step_id} '
-                    '::',
+                    f"RANK={dist.get_rank()} "
+                    f"PIPE-ID={self.stage_id} "
+                    f"DATA-ID={self.grid.data_parallel_id} "
+                    f"MBATCH-ID={self.microbatch_id} "
+                    f"STEP-ID={self.log_batch_step_id} "
+                    "::",
                     *msg,
-                    flush=True)
+                    flush=True,
+                )
 
     def tput_log(self, *msg):
         if self.global_rank == 0 and self.global_steps % self.steps_per_print() == 0:
@@ -570,27 +607,28 @@ class PipelineEngine(DeepSpeedEngine):
 
     def _exec_forward_pass(self, buffer_id):
         self.tput_timer.start()
-        self.mem_status('BEFORE FWD', reset_max=True)
+        self.mem_status("BEFORE FWD", reset_max=True)
 
-        if isinstance(self.pipe_buffers['inputs'][buffer_id], tuple):
-            inputs = tuple(t.clone() for t in self.pipe_buffers['inputs'][buffer_id])
+        if isinstance(self.pipe_buffers["inputs"][buffer_id], tuple):
+            inputs = tuple(t.clone() for t in self.pipe_buffers["inputs"][buffer_id])
         else:
-            inputs = self.pipe_buffers['inputs'][buffer_id].clone()
+            inputs = self.pipe_buffers["inputs"][buffer_id].clone()
 
         # collect the partitioned input from the previous stage
         if self.is_pipe_partitioned and not self.is_first_stage():
             part_input = PartitionedTensor.from_meta(
                 meta=inputs[0],
                 local_part=inputs[1],
-                group=self.grid.get_slice_parallel_group())
+                group=self.grid.get_slice_parallel_group(),
+            )
 
             inputs = (part_input.full(), *inputs[2:])
             inputs[0].requires_grad = True
             # skip mask
-            #inputs[1].requires_grad = True
+            # inputs[1].requires_grad = True
             part_input = None
             inputs = inputs[0] if len(inputs) == 1 else inputs
-            self.pipe_buffers['inputs'][buffer_id] = inputs
+            self.pipe_buffers["inputs"][buffer_id] = inputs
 
         # Zero out the gradients each time we use the tensor because only the data in
         # tensor changes across batches
@@ -603,31 +641,34 @@ class PipelineEngine(DeepSpeedEngine):
             if isinstance(outputs, tuple):
                 first_output = outputs[0]
                 # TODO: Improve pipe partitioning to pass multiple tensors that require grads
-                assert all([
-                    torch.is_tensor(elt) and elt.requires_grad is False
-                    for elt in outputs[1:]
-                ])
+                assert all(
+                    [
+                        torch.is_tensor(elt) and elt.requires_grad is False
+                        for elt in outputs[1:]
+                    ]
+                )
                 outputs_tail = outputs[1:]
             elif torch.is_tensor(outputs):
                 first_output = outputs
                 outputs_tail = []
             else:
                 raise ValueError("expecting a tensor or a tuple of tensors")
-            part = PartitionedTensor(tensor=first_output,
-                                     group=self.grid.get_slice_parallel_group())
+            part = PartitionedTensor(
+                tensor=first_output, group=self.grid.get_slice_parallel_group()
+            )
             # Clear the large output data, but save the computation graph
             first_output.data = torch.zeros(1)
-            self.pipe_buffers['output_tensors'][buffer_id] = first_output
+            self.pipe_buffers["output_tensors"][buffer_id] = first_output
             # Inject the partitioned tensor into the output before sending
             outputs = (part.to_meta(), part.data(), *outputs_tail)
             part = None
 
-        self.pipe_buffers['outputs'][buffer_id] = outputs
+        self.pipe_buffers["outputs"][buffer_id] = outputs
 
         # Optionally compute loss on the last device
         if self.is_last_stage():
             if self._compute_loss and self.loss_model is not None:
-                labels = self.pipe_buffers['labels'][buffer_id]
+                labels = self.pipe_buffers["labels"][buffer_id]
                 self.loss = self.loss_model(outputs, labels)
             else:
                 # Some models just return loss from forward()
@@ -648,25 +689,26 @@ class PipelineEngine(DeepSpeedEngine):
                     self.total_loss[idx] += l.detach()
 
     def _exec_backward_pass(self, buffer_id):
-        assert self.optimizer is not None, "must provide optimizer during " \
-                                           "init in order to use backward"
+        assert self.optimizer is not None, (
+            "must provide optimizer during " "init in order to use backward"
+        )
 
-        self.mem_status('BEFORE BWD', reset_max=True)
+        self.mem_status("BEFORE BWD", reset_max=True)
 
         # The last stage just runs backward on the loss using DeepSpeed's typical
         # mechanisms.
         if self.is_last_stage():
             super().backward(self.loss)
-            self.mem_status('AFTER BWD')
+            self.mem_status("AFTER BWD")
             return
 
-        outputs = self.pipe_buffers['outputs'][buffer_id]
+        outputs = self.pipe_buffers["outputs"][buffer_id]
 
         if self.wall_clock_breakdown():
-            self.timers('backward_microstep').start()
-            self.timers('backward').start()
-            self.timers('backward_inner_microstep').start()
-            self.timers('backward_inner').start()
+            self.timers("backward_microstep").start()
+            self.timers("backward").start()
+            self.timers("backward_inner_microstep").start()
+            self.timers("backward_inner").start()
 
         # Reconstruct if we previously partitioned the output. We must be
         # careful to also restore the computational graph of the tensors we partitioned.
@@ -675,24 +717,26 @@ class PipelineEngine(DeepSpeedEngine):
                 part_output = PartitionedTensor.from_meta(
                     meta=outputs[0],
                     local_part=outputs[1],
-                    group=self.grid.get_slice_parallel_group())
-                self.pipe_buffers['output_tensors'][buffer_id].data = part_output.full()
-                outputs = (self.pipe_buffers['output_tensors'][buffer_id], *outputs[2:])
+                    group=self.grid.get_slice_parallel_group(),
+                )
+                self.pipe_buffers["output_tensors"][buffer_id].data = part_output.full()
+                outputs = (self.pipe_buffers["output_tensors"][buffer_id], *outputs[2:])
             else:
                 # Already restored from partition
-                self.pipe_buffers['output_tensors'][buffer_id].data = outputs[0]
-                outputs = (self.pipe_buffers['output_tensors'][buffer_id], *outputs[1:])
+                self.pipe_buffers["output_tensors"][buffer_id].data = outputs[0]
+                outputs = (self.pipe_buffers["output_tensors"][buffer_id], *outputs[1:])
 
         grad_tensors = self.grad_layer
         if self.is_grad_partitioned:
-            #print(f'RANK={self.global_rank} BEFORE-BWD restoring grad={self.grad_layer[0].size()} {self.grad_layer[1].size()}')
+            # print(f'RANK={self.global_rank} BEFORE-BWD restoring grad={self.grad_layer[0].size()} {self.grad_layer[1].size()}')
             part_grad = PartitionedTensor.from_meta(
                 meta=self.grad_layer[0],
                 local_part=self.grad_layer[1],
-                group=self.grid.get_slice_parallel_group())
+                group=self.grid.get_slice_parallel_group(),
+            )
             grad_tensors = (part_grad.full(), *grad_tensors[2:])
             part_grad = None
-            #print(f'RANK={self.global_rank} BEFORE-BWD restored grad={self.grad_layer[0].size()} {self.grad_layer[1].size()}')
+            # print(f'RANK={self.global_rank} BEFORE-BWD restored grad={self.grad_layer[0].size()} {self.grad_layer[1].size()}')
 
         # This handles either a single tensor or tuple of tensors.
         if isinstance(outputs, tuple):
@@ -700,24 +744,24 @@ class PipelineEngine(DeepSpeedEngine):
             assert len(out_tensors) == len(grad_tensors)
             torch.autograd.backward(tensors=out_tensors, grad_tensors=grad_tensors)
         else:
-            torch.autograd.backward(tensors=(outputs, ), grad_tensors=(grad_tensors, ))
+            torch.autograd.backward(tensors=(outputs,), grad_tensors=(grad_tensors,))
 
         # Free up the memory from the output of forward()
-        self.pipe_buffers['output_tensors'][buffer_id] = None
-        self.pipe_buffers['outputs'][buffer_id] = None
+        self.pipe_buffers["output_tensors"][buffer_id] = None
+        self.pipe_buffers["outputs"][buffer_id] = None
         grad_tensors = None
 
         if self.wall_clock_breakdown():
-            self.timers('backward_inner').stop()
-            self.timers('backward_inner_microstep').stop()
-            self.timers('backward').stop()
-            self.timers('backward_microstep').stop()
+            self.timers("backward_inner").stop()
+            self.timers("backward_inner_microstep").stop()
+            self.timers("backward").stop()
+            self.timers("backward_microstep").stop()
 
-        self.mem_status('AFTER BWD')
+        self.mem_status("AFTER BWD")
 
     def _exec_load_micro_batch(self, buffer_id):
         if self.wall_clock_breakdown():
-            self.timers('batch_input').start()
+            self.timers("batch_input").start()
 
         batch = self._next_batch()
 
@@ -737,7 +781,7 @@ class PipelineEngine(DeepSpeedEngine):
                     loaded.append(mine)
                 loaded = tuple(loaded)
 
-            self.pipe_buffers['inputs'][buffer_id] = loaded
+            self.pipe_buffers["inputs"][buffer_id] = loaded
 
         if self.is_last_stage():
             loaded = batch[1]
@@ -751,13 +795,13 @@ class PipelineEngine(DeepSpeedEngine):
                     loaded.append(x)
                 loaded = tuple(loaded)
 
-            self.pipe_buffers['labels'][buffer_id] = loaded
+            self.pipe_buffers["labels"][buffer_id] = loaded
 
         if self.wall_clock_breakdown():
-            self.timers('batch_input').stop()
+            self.timers("batch_input").stop()
 
     def _send_tensor_meta(self, buffer, recv_stage):
-        """ Communicate metadata about upcoming p2p transfers.
+        """Communicate metadata about upcoming p2p transfers.
 
         Metadata is communicated in this order:
             * type (0: tensor, 1: list)
@@ -776,7 +820,7 @@ class PipelineEngine(DeepSpeedEngine):
             p2p.send(send_shape, recv_stage)
             send_bytes += _tensor_bytes(buffer)
         elif isinstance(buffer, list):
-            assert (False)
+            assert False
             type_tensor = torch.LongTensor(data=[1]).to(self.device)
             p2p.send(type_tensor, recv_stage)
             count_tensor = torch.LongTensor(data=[len(buffer)]).to(self.device)
@@ -798,12 +842,13 @@ class PipelineEngine(DeepSpeedEngine):
                 send_shape = torch.LongTensor(data=tensor.size()).to(self.device)
                 send_ndims = torch.LongTensor(data=[len(tensor.size())]).to(self.device)
                 send_dtype = torch.LongTensor(data=[self.DTYPE_TO_ID[tensor.dtype]]).to(
-                    self.device)
+                    self.device
+                )
                 p2p.send(send_dtype, recv_stage)
                 p2p.send(send_ndims, recv_stage)
                 p2p.send(send_shape, recv_stage)
                 # Useful for performance debugging.
-                '''
+                """
                 new_bytes = _tensor_bytes(tensor)
                 send_bytes += _tensor_bytes(tensor)
                 # Useful for performance debugging.
@@ -811,15 +856,15 @@ class PipelineEngine(DeepSpeedEngine):
                     print(
                         f'STAGE={self.stage_id} pipe-send-volume[{idx}]: shape={send_shape} {new_bytes/1024**2:0.2f}MB'
                     )
-                '''
+                """
         else:
-            raise NotImplementedError(f'Could not send meta type {type(buffer)}')
+            raise NotImplementedError(f"Could not send meta type {type(buffer)}")
 
         # Useful for performance debugging.
-        '''
+        """
         if self.grid.data_parallel_id == 0:
             print(f'STAGE={self.stage_id} pipe-send-volume: {send_bytes/1024**2:0.2f}MB')
-        '''
+        """
 
     def _recv_tensor_meta(self, send_stage):
         """Receive metadata about upcoming p2p transfers and return allocated buffers.
@@ -873,18 +918,18 @@ class PipelineEngine(DeepSpeedEngine):
             return buffers
 
         else:
-            raise NotImplementedError(f'Could not receive type {type(recv_type)}')
+            raise NotImplementedError(f"Could not receive type {type(recv_type)}")
 
     def _exec_send_activations(self, buffer_id):
         if self.wall_clock_breakdown():
-            self.timers('pipe_send_output').start()
+            self.timers("pipe_send_output").start()
 
-        outputs = self.pipe_buffers['outputs'][buffer_id]
+        outputs = self.pipe_buffers["outputs"][buffer_id]
 
         # NCCL does not like to send torch.BoolTensor types, so cast the mask to half().
         # We could do char, but with half() we can eventually flatten with other fp16
         # messages (TODO)
-        if self.module.__class__.__name__ == 'GPT2ModelPipe' or self.has_bool_tensors:
+        if self.module.__class__.__name__ == "GPT2ModelPipe" or self.has_bool_tensors:
             outputs = list(outputs)
             outputs[-1] = outputs[-1].half()
             outputs = tuple(outputs)
@@ -899,23 +944,24 @@ class PipelineEngine(DeepSpeedEngine):
             for idx, buffer in enumerate(outputs):
                 p2p.send(buffer, self.next_stage)
         else:
-            raise NotImplementedError('Could not send output of type '
-                                      f'{type(outputs)}')
+            raise NotImplementedError(
+                "Could not send output of type " f"{type(outputs)}"
+            )
 
         # Restore the boolean tensor
-        if self.module.__class__.__name__ == 'GPT2ModelPipe' or self.has_bool_tensors:
+        if self.module.__class__.__name__ == "GPT2ModelPipe" or self.has_bool_tensors:
             outputs = list(outputs)
             outputs[-1] = outputs[-1].bool()
             outputs = tuple(outputs)
 
         if self.wall_clock_breakdown():
-            self.timers('pipe_send_output').stop()
+            self.timers("pipe_send_output").stop()
 
     def _exec_send_grads(self, buffer_id):
         if self.wall_clock_breakdown():
-            self.timers('pipe_send_grad').start()
+            self.timers("pipe_send_grad").start()
 
-        inputs = self.pipe_buffers['inputs'][buffer_id]
+        inputs = self.pipe_buffers["inputs"][buffer_id]
 
         # Partition the gradient
         if self.is_grad_partitioned:
@@ -931,8 +977,9 @@ class PipelineEngine(DeepSpeedEngine):
             else:
                 raise ValueError("expecting a tensor or a tuple of tensors")
             assert torch.is_tensor(first_input)
-            part = PartitionedTensor(tensor=first_input.grad,
-                                     group=self.grid.get_slice_parallel_group())
+            part = PartitionedTensor(
+                tensor=first_input.grad, group=self.grid.get_slice_parallel_group()
+            )
 
             inputs = (part.to_meta(), part.data(), *inputs_grad_tail)
 
@@ -941,7 +988,7 @@ class PipelineEngine(DeepSpeedEngine):
         # a grad that needs to be communicated. We free the buffer immediately
         # after, so no need to restore it. The receiver also has a hack that skips
         # the recv. This is because NCCL does not let us send torch.BoolTensor :-(.
-        if self.module.__class__.__name__ == 'GPT2ModelPipe' or self.has_bool_tensors:
+        if self.module.__class__.__name__ == "GPT2ModelPipe" or self.has_bool_tensors:
             inputs = list(inputs)
             inputs.pop()
             inputs = tuple(inputs)
@@ -965,14 +1012,14 @@ class PipelineEngine(DeepSpeedEngine):
                     p2p.send(buffer.grad, self.prev_stage)
 
         # We can free up the input buffer now
-        self.pipe_buffers['inputs'][buffer_id] = None
+        self.pipe_buffers["inputs"][buffer_id] = None
 
         if self.wall_clock_breakdown():
-            self.timers('pipe_send_grad').stop()
+            self.timers("pipe_send_grad").stop()
 
     def _exec_recv_activations(self, buffer_id):
         if self.wall_clock_breakdown():
-            self.timers('pipe_recv_input').start()
+            self.timers("pipe_recv_input").start()
 
         recvd = None
 
@@ -992,9 +1039,9 @@ class PipelineEngine(DeepSpeedEngine):
                 # XXX hardcode meta type
                 if self.is_pipe_partitioned and idx == 0 and buffer.dtype != torch.long:
                     if self.meta_buffer is None:
-                        self.meta_buffer = torch.zeros(buffer.size(),
-                                                       dtype=torch.long,
-                                                       device=self.device)
+                        self.meta_buffer = torch.zeros(
+                            buffer.size(), dtype=torch.long, device=self.device
+                        )
                     buffer = self.meta_buffer
 
                 p2p.recv(buffer, self.prev_stage)
@@ -1002,7 +1049,10 @@ class PipelineEngine(DeepSpeedEngine):
 
             # NCCL does not like to send torch.BoolTensor types, so un-cast the
             # attention mask
-            if self.module.__class__.__name__ == 'GPT2ModelPipe' or self.has_bool_tensors:
+            if (
+                self.module.__class__.__name__ == "GPT2ModelPipe"
+                or self.has_bool_tensors
+            ):
                 recvd[-1] = recvd[-1].bool()
 
             recvd = tuple(recvd)
@@ -1010,40 +1060,43 @@ class PipelineEngine(DeepSpeedEngine):
             for buffer in recvd:
                 buffer.requires_grad = buffer.is_floating_point()
 
-        self.pipe_buffers['inputs'][buffer_id] = recvd
+        self.pipe_buffers["inputs"][buffer_id] = recvd
 
         if self.wall_clock_breakdown():
-            self.timers('pipe_recv_input').stop()
+            self.timers("pipe_recv_input").stop()
 
     def _exec_recv_grads(self, buffer_id):
         if self.wall_clock_breakdown():
-            self.timers('pipe_recv_grad').start()
+            self.timers("pipe_recv_grad").start()
 
-        outputs = self.pipe_buffers['outputs'][buffer_id]
+        outputs = self.pipe_buffers["outputs"][buffer_id]
         # XXX these shapes are hardcoded for Megatron
         # Restore partitioned output if it was partitioned and we are sending full gradients
         if self.is_pipe_partitioned and not self.is_grad_partitioned:
             part_output = PartitionedTensor.from_meta(
                 meta=outputs[0],
                 local_part=outputs[1],
-                group=self.grid.get_slice_parallel_group())
+                group=self.grid.get_slice_parallel_group(),
+            )
             outputs[0].data = part_output.full()
-            outputs = ([outputs[0], *outputs[2:]])
+            outputs = [outputs[0], *outputs[2:]]
             # save for backward
-            self.pipe_buffers['outputs'][buffer_id] = outputs
+            self.pipe_buffers["outputs"][buffer_id] = outputs
 
         # Allocate gradient if necessary
         if self.grad_layer is None:
             if isinstance(outputs, torch.Tensor):
                 s = list(outputs.size())
-                self.grad_layer = self._allocate_buffer(s,
-                                                        dtype=outputs.dtype,
-                                                        num_buffers=1)[0]
+                self.grad_layer = self._allocate_buffer(
+                    s, dtype=outputs.dtype, num_buffers=1
+                )[0]
             else:
-                sizes_and_dtypes = [(list(t.size()),
-                                     t.dtype) for t in outputs if t.is_floating_point()]
-                self.grad_layer = self._allocate_buffers(sizes_and_dtypes,
-                                                         num_buffers=1)[0]
+                sizes_and_dtypes = [
+                    (list(t.size()), t.dtype) for t in outputs if t.is_floating_point()
+                ]
+                self.grad_layer = self._allocate_buffers(
+                    sizes_and_dtypes, num_buffers=1
+                )[0]
 
         if isinstance(self.grad_layer, torch.Tensor):
             p2p.recv(self.grad_layer, self.next_stage)
@@ -1052,59 +1105,67 @@ class PipelineEngine(DeepSpeedEngine):
             for idx, buffer in enumerate(self.grad_layer):
                 # XXX GPT-2 hack
                 if self.is_grad_partitioned and idx == 0 and buffer.dtype != torch.long:
-                    buffer.data = torch.zeros(buffer.size(),
-                                              dtype=torch.long,
-                                              device=self.device)
+                    buffer.data = torch.zeros(
+                        buffer.size(), dtype=torch.long, device=self.device
+                    )
                 p2p.recv(buffer, self.next_stage)
 
         if self.wall_clock_breakdown():
-            self.timers('pipe_recv_grad').stop()
+            self.timers("pipe_recv_grad").stop()
 
     def _exec_optimizer_step(self, lr_kwargs=None):
         if self.wall_clock_breakdown():
-            self.timers('step_microstep').start()
-            self.timers('step').start()
-        self.mem_status('BEFORE STEP', reset_max=True)
+            self.timers("step_microstep").start()
+            self.timers("step").start()
+        self.mem_status("BEFORE STEP", reset_max=True)
 
         self._force_grad_boundary = True
         self._take_model_step(lr_kwargs)
         self._force_grad_boundary = False
 
-        self.mem_status('AFTER STEP')
+        self.mem_status("AFTER STEP")
 
         if self.tensorboard_enabled():
             if self.global_rank == 0:
-                self.summary_events = [(f'Train/Samples/lr',
-                                        self.get_lr()[0],
-                                        self.global_samples)]
-                if self.fp16_enabled() and hasattr(self.optimizer, 'cur_scale'):
-                    self.summary_events.append((f'Train/Samples/loss_scale',
-                                                self.optimizer.cur_scale,
-                                                self.global_samples))
+                self.summary_events = [
+                    (f"Train/Samples/lr", self.get_lr()[0], self.global_samples)
+                ]
+                if self.fp16_enabled() and hasattr(self.optimizer, "cur_scale"):
+                    self.summary_events.append(
+                        (
+                            f"Train/Samples/loss_scale",
+                            self.optimizer.cur_scale,
+                            self.global_samples,
+                        )
+                    )
                 for event in self.summary_events:  # write_summary_events
                     self.summary_writer.add_scalar(event[0], event[1], event[2])
 
         if self.wall_clock_breakdown():
-            self.timers('step_microstep').stop()
-            self.timers('step').stop()
+            self.timers("step_microstep").stop()
+            self.timers("step").stop()
             if self.global_steps % self.steps_per_print() == 0:
-                self.timers.log([
-                    'batch_input',
-                    'forward_microstep',
-                    'backward_microstep',
-                    'backward_inner_microstep',
-                    'backward_allreduce_microstep',
-                    'backward_tied_allreduce_microstep',
-                    'step_microstep'
-                ])
+                self.timers.log(
+                    [
+                        "batch_input",
+                        "forward_microstep",
+                        "backward_microstep",
+                        "backward_inner_microstep",
+                        "backward_allreduce_microstep",
+                        "backward_tied_allreduce_microstep",
+                        "step_microstep",
+                    ]
+                )
             if self.global_steps % self.steps_per_print() == 0:
-                self.timers.log([
-                    'forward',
-                    'backward',
-                    'backward_inner',
-                    'backward_allreduce',
-                    'step'
-                ])
+                self.timers.log(
+                    [
+                        "forward",
+                        "backward",
+                        "backward_inner",
+                        "backward_allreduce",
+                        "step",
+                    ]
+                )
 
     def _zero_grads(self, inputs):
         if isinstance(inputs, torch.Tensor):
@@ -1116,7 +1177,7 @@ class PipelineEngine(DeepSpeedEngine):
                     t.grad.data.zero_()
 
     def _allocate_zeros(self, shape, **kwargs):
-        """ Allocate a tensor of zeros on the engine's device.
+        """Allocate a tensor of zeros on the engine's device.
 
         Arguments:
             shape: the shape of the tensor to allocate
@@ -1146,29 +1207,39 @@ class PipelineEngine(DeepSpeedEngine):
             buffer = []
             for shape, dtype in shapes_and_dtypes:
                 buffer.append(
-                    self._allocate_zeros(shape,
-                                         dtype=dtype,
-                                         requires_grad=requires_grad))
+                    self._allocate_zeros(
+                        shape, dtype=dtype, requires_grad=requires_grad
+                    )
+                )
             buffers.append(buffer)
         return buffers
 
     def forward(self, *args, **kwargs):
-        """Disabled for pipeline parallel training. See ``train_batch()`` and ``eval_batch()``. """
-        raise PipelineError("Only train_batch() and eval_batch() are accessible in pipeline mode.")
+        """Disabled for pipeline parallel training. See ``train_batch()`` and
+        ``eval_batch()``. """
+        raise PipelineError(
+            "Only train_batch() and eval_batch() are accessible in pipeline mode."
+        )
 
     def backward(self, *args, **kwargs):
-        """Disabled for pipeline parallel training. See ``train_batch()`` and ``eval_batch()``. """
-        raise PipelineError("Only train_batch() and eval_batch() are accessible in pipeline mode.")
+        """Disabled for pipeline parallel training. See ``train_batch()`` and
+        ``eval_batch()``. """
+        raise PipelineError(
+            "Only train_batch() and eval_batch() are accessible in pipeline mode."
+        )
 
     def step(self, *args, **kwargs):
-        """Disabled for pipeline parallel training. See ``train_batch()`` and ``eval_batch()``. """
-        raise PipelineError("Only train_batch() and eval_batch() are accessible in pipeline mode.")
+        """Disabled for pipeline parallel training. See ``train_batch()`` and
+        ``eval_batch()``. """
+        raise PipelineError(
+            "Only train_batch() and eval_batch() are accessible in pipeline mode."
+        )
 
     def mem_status(self, msg, print_rank=-1, reset_max=False):
         return
         global mem_alloced, mem_cached
         if not self.global_steps == 0 or not self.global_steps == 9:
-            #return
+            # return
             pass
         if self.mpu.get_data_parallel_rank() != 0:
             return
@@ -1199,18 +1270,18 @@ class PipelineEngine(DeepSpeedEngine):
         max_cached = torch.cuda.max_memory_cached()
 
         # convert to GB for printing
-        new_alloced /= 1024**3
-        new_cached /= 1024**3
-        delta_alloced /= 1024**3
-        delta_cached /= 1024**3
-        max_alloced /= 1024**3
-        max_cached /= 1024**3
+        new_alloced /= 1024 ** 3
+        new_cached /= 1024 ** 3
+        delta_alloced /= 1024 ** 3
+        delta_cached /= 1024 ** 3
+        max_alloced /= 1024 ** 3
+        max_cached /= 1024 ** 3
 
         print(
-            f'RANK={rank} STAGE={self.stage_id} STEP={self.global_steps} MEMSTATS',
+            f"RANK={rank} STAGE={self.stage_id} STEP={self.global_steps} MEMSTATS",
             msg,
-            f'current alloc={new_alloced:0.4f}GB (delta={delta_alloced:0.4f}GB max={max_alloced:0.4f}GB) '
-            f'current cache={new_cached:0.4f}GB (delta={delta_cached:0.4f}GB max={max_cached:0.4f}GB)'
+            f"current alloc={new_alloced:0.4f}GB (delta={delta_alloced:0.4f}GB max={max_alloced:0.4f}GB) "
+            f"current cache={new_cached:0.4f}GB (delta={delta_cached:0.4f}GB max={max_cached:0.4f}GB)",
         )
 
     def module_state_dict(self):
@@ -1224,8 +1295,9 @@ class PipelineEngine(DeepSpeedEngine):
             None
         """
         assert isinstance(self.module, PipelineModule)
-        assert self._curr_ckpt_path is not None, \
-            "PipelineEngine expects module_state_dict() to be called from save_checkpoint()"
+        assert (
+            self._curr_ckpt_path is not None
+        ), "PipelineEngine expects module_state_dict() to be called from save_checkpoint()"
 
         self.module.save_state_dict(self._curr_ckpt_path)
         return None
@@ -1273,7 +1345,7 @@ class PipelineEngine(DeepSpeedEngine):
             for cmd in step_cmds:
                 if type(cmd) not in self._INSTRUCTION_MAP:
                     raise RuntimeError(
-                        f'{self.__class__.__name__} does not understand instruction {repr(cmd)}'
+                        f"{self.__class__.__name__} does not understand instruction {repr(cmd)}"
                     )
 
                 # Equivalent to: self._exec_forward_pass(buffer_id=0)


### PR DESCRIPTION
There are two accessible frontend method of pipeline engine, `train_batch()` and `eval_batch()`. but currently, pipeline engine informs only `train_batch()` is accessible. So I added `eval_batch()` to error message.