### PR TITLE
[code readability] pipe

### DIFF
--- a/deepspeed/runtime/pipe/module.py
+++ b/deepspeed/runtime/pipe/module.py
@@ -380,9 +380,8 @@ class PipelineModule(nn.Module):
             binary_weights = [0] * len(self._layer_specs)
             for idx in self._find_layer_type(layertype):
                 binary_weights[idx] = 1
-            else:
-                self.parts = ds_utils.partition_balanced(weights=binary_weights,
-                                                         num_parts=num_stages)
+            self.parts = ds_utils.partition_balanced(weights=binary_weights,
+                                                     num_parts=num_stages)
         elif method == 'profile':
             raise NotImplementedError(f'Partitioning method {method} not implemented.')
         else:


### PR DESCRIPTION
This PR suggests a small improvement to code readability.

--------------------------

I was puzzling over this code:

https://github.com/microsoft/DeepSpeed/blob/85ce85dd5f4b18c0019a5121b06900e3a2c3933b/deepspeed/runtime/pipe/module.py#L381-L385

I had no idea this construct existed. 

After reading up on it, it appears to be used incorrectly . The only point to using it is with `break`. (but it doesn't lead to a bug, just a harder to understand the code)

It's explained here https://docs.python.org/3/tutorial/controlflow.html#break-and-continue-statements-and-else-clauses-on-loops

So I'm proposing to remove the `else` control and just run the code in its branch normally since it *always* gets executed as there is no `break` statement.

And the objective of this code is to always be run if I understand it correctly. So let's make it loud and clear.

Here is a quick proof:
```
for i in []:
    print(i)
else:
    print("loop did not finish via break") # runs!

for i in [0]:
    print(i)
else:
    print("loop did not finish via break") # runs!


for i in [0]:
    print(i)
    break
else:
    print("loop did not finish via break") # does not run
```

@tjruwase