### PR TITLE
[build] support cuda-11.5

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -64,14 +64,19 @@ def get_default_compute_capabilities():
 # list compatible minor CUDA versions - so that for example pytorch built with cuda-11.0 can be used
 # to build deepspeed and system-wide installed cuda 11.2
 cuda_minor_mismatch_ok = {
-    10: ["10.0",
-         "10.1",
-         "10.2"],
-    11: ["11.0",
-         "11.1",
-         "11.2",
-         "11.3",
-         "11.4"],
+    10: [
+        "10.0",
+        "10.1",
+        "10.2",
+    ],
+    11: [
+        "11.0",
+        "11.1",
+        "11.2",
+        "11.3",
+        "11.4",
+        "11.5",
+    ],
 }
 
 


### PR DESCRIPTION
Not sure if it'd be easier to just not check the minor version rather than add it explicitly every time a new cuda is released. 

But for now just adding 11.5 as it tested to work ok w/o matching pytorch's cuda version.

@tjruwase, @jeffra 