### PR TITLE
[CI] use last known good HF hash until fix is merged for PR-14408

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,6 +92,8 @@ jobs:
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
           git clone https://github.com/huggingface/transformers
           cd transformers
+          # use known good HF hash until fix is merged for PR-14408
+          git checkout 1cc453d33
           git rev-parse --short HEAD
           # scipy/sklearn required for tests, using the 'dev' extra forces torch re-install
           pip install .[testing]


### PR DESCRIPTION
Currently DeepSpeed + HF integration tests are broken, this temp workaround fixes the commit hash to the last known good commit. Will revert when a fix for https://github.com/huggingface/transformers/pull/14408 is created/merged on HF side.