### PR TITLE
Remove hard tensorboardX requirement

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -18,7 +18,7 @@ from torch.nn.parameter import Parameter
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import _LRScheduler
 from torch.distributed.distributed_c10d import _get_global_rank
-from tensorboardX import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 
 from typing import Callable, Dict, Optional, Union, Iterable
 

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -18,7 +18,6 @@ from torch.nn.parameter import Parameter
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import _LRScheduler
 from torch.distributed.distributed_c10d import _get_global_rank
-from torch.utils.tensorboard import SummaryWriter
 
 from typing import Callable, Dict, Optional, Union, Iterable
 
@@ -533,6 +532,14 @@ class DeepSpeedEngine(Module):
             log_dir = os.path.join(base, summary_writer_dir_name, name)
 
         os.makedirs(log_dir, exist_ok=True)
+        try:
+            import tensorboard
+            from torch.utils.tensorboard import SummaryWriter
+        except ImportError as err:
+            print(
+                'If you want to use tensorboard logging please `pip install tensorboard`'
+            )
+            raise err
 
         return SummaryWriter(log_dir=log_dir)
 

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -533,13 +533,15 @@ class DeepSpeedEngine(Module):
 
         os.makedirs(log_dir, exist_ok=True)
         try:
+            # torch.utils.tensorboard will fail if `tensorboard` is not available,
+            # see their docs for more details: https://pytorch.org/docs/1.8.0/tensorboard.html
             import tensorboard
-            from torch.utils.tensorboard import SummaryWriter
-        except ImportError as err:
+        except ImportError:
             print(
                 'If you want to use tensorboard logging please `pip install tensorboard`'
             )
-            raise err
+            raise
+        from torch.utils.tensorboard import SummaryWriter
 
         return SummaryWriter(log_dir=log_dir)
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,5 @@
 torch
 tqdm
-tensorboardX==1.8
 ninja
 numpy
 psutil


### PR DESCRIPTION
PyTorch 1.2+ has support and same API as tensorboardX, this PR switches to `torch.utils.tensorboard`.

Fixes #1570

Refresh on an old unmerged PR #330