### PR TITLE
Several fixes for our read-the-docs build

### DIFF
--- a/deepspeed/__init__.py
+++ b/deepspeed/__init__.py
@@ -46,18 +46,6 @@ __version_major__, __version_minor__, __version_patch__ = _parse_version(__versi
 __git_hash__ = git_hash
 __git_branch__ = git_branch
 
-# Provide backwards compatability with old deepspeed.pt module structure, should hopefully not be used
-pt = types.ModuleType('pt', 'dummy pt module for backwards compatability')
-deepspeed = sys.modules[__name__]
-setattr(deepspeed, 'pt', pt)
-setattr(deepspeed.pt, 'deepspeed_utils', deepspeed.runtime.utils)
-sys.modules['deepspeed.pt'] = deepspeed.pt
-sys.modules['deepspeed.pt.deepspeed_utils'] = deepspeed.runtime.utils
-setattr(deepspeed.pt, 'deepspeed_config', deepspeed.runtime.config)
-sys.modules['deepspeed.pt.deepspeed_config'] = deepspeed.runtime.config
-setattr(deepspeed.pt, 'loss_scaler', deepspeed.runtime.fp16.loss_scaler)
-sys.modules['deepspeed.pt.loss_scaler'] = deepspeed.runtime.fp16.loss_scaler
-
 
 def initialize(args=None,
                model: torch.nn.Module = None,

--- a/deepspeed/runtime/pipe/__init__.py
+++ b/deepspeed/runtime/pipe/__init__.py
@@ -1,1 +1,2 @@
 from .module import PipelineModule, LayerSpec, TiedLayerSpec
+from .topology import ProcessTopology

--- a/docs/code-docs/source/conf.py
+++ b/docs/code-docs/source/conf.py
@@ -79,4 +79,4 @@ add_module_names = True
 
 autoclass_content = 'both'
 
-autodoc_mock_imports = ["torch", "apex", "mpi4py", "tensorboardX", "numpy", "cupy"]
+autodoc_mock_imports = ["apex", "mpi4py", "tensorboardX", "numpy", "cupy"]

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -9,4 +9,3 @@ sphinx-rtd-theme
 megatron-lm==1.1.5
 importlib-metadata>=4
 docutils<0.18
-hjson

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -9,3 +9,4 @@ sphinx-rtd-theme
 megatron-lm==1.1.5
 importlib-metadata>=4
 docutils<0.18
+hjson

--- a/requirements/requirements-readthedocs.txt
+++ b/requirements/requirements-readthedocs.txt
@@ -1,3 +1,4 @@
 tqdm
 psutil
 docutils<0.18
+hjson

--- a/requirements/requirements-readthedocs.txt
+++ b/requirements/requirements-readthedocs.txt
@@ -2,3 +2,4 @@ tqdm
 psutil
 docutils<0.18
 hjson
+torch


### PR DESCRIPTION
* added `hjson` as a RTD requirement
* added torch as a RTD requirement, it seems RTD can now support installing torch without timing out. This greatly improves the readability of our docs that use type hints
* Two fixes to address RTD warnings
  * expose ProcessTopology in deepspeed.runtime.pipe
  * removed deprecated deepspeed.pt references