### PR TITLE
Fix for bitsandbytes 8-bit optimizers.

### DIFF
--- a/deepspeed/runtime/zero/stage2.py
+++ b/deepspeed/runtime/zero/stage2.py
@@ -2028,7 +2028,7 @@ class FP16_DeepSpeedZeroOptimizer(object):
     def _partition_base_optimizer_state(self, state_key, all_partition_states, group_id):
         partition_id = dist.get_rank(group=self.real_dp_process_group[group_id])
         alignment = dist.get_world_size(group=self.real_dp_process_group[group_id])
-        if torch.is_tensor(all_partition_states[0]):
+        if torch.is_tensor(all_partition_states[0]) and 'qmap' not in state_key:
             flat_merged_partitions = self.flatten_dense_tensors_aligned(
                 all_partition_states,
                 alignment)


### PR DESCRIPTION
This is a fix for loading [bitsandbytes 8-bit optimizer](https://github.com/facebookresearch/bitsandbytes) with optimizer sharding. By default, DeepSpeed shards all tensors held by the optimizer state automatically. However, 8-bit optimizers also hold the quantization datatype (`qmap1` and `qmap2` in the case of Adam) without which the 8-bit state is undefined. The full datatype is needed to perform quantization and restore the optimizer state and if this tensor is sharded the optimizer state cannot be recovered.

This is a quick fix for the BigScience team. See this [PR](https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/198) for more info. A more general fix would be to be able to specify in the config if some tensor keys do not need to be sharded. Alternatively, in this case, it would also suffice to disable sharding for tensors equal or smaller than the size of 256 elements (the size of the 8-bit data type).