### PR TITLE
allow external control of gradient accumulation boundary

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1757,6 +1757,26 @@ class DeepSpeedEngine(Module):
             return self._is_gradient_accumulation_boundary
 
     def set_gradient_accumulation_boundary(self, is_boundary):
+        """Manually overrides the DeepSpeed engine's gradient accumulation boundary state, this is an optional
+        feature and should be used with care. The state should be set before to the intended
+        value before each forward/backward. The final fordward/backward should have the
+        boundary state set to True. See example below:
+
+        .. code-block:: python
+
+        engine.set_gradient_accumulation_boundary(False)
+        for _ in range(gradient_accumulation_steps - 1):
+            micro_batch = next(data_loader)
+            loss = engine(micro_batch)
+            engine.backward(loss)
+        engine.set_gradient_accumulation_boundary(True)
+        micro_batch = next(data_loader)
+        loss = engine(micro_batch)
+        engine.backward(loss)
+
+        Arguments:
+            is_boundary (bool): are we at a gradient accumulation boundary or not?
+        """
         self._is_gradient_accumulation_boundary = is_boundary
         self.optimizer.is_gradient_accumulation_boundary = is_boundary
 

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1760,7 +1760,8 @@ class DeepSpeedEngine(Module):
         """Manually overrides the DeepSpeed engine's gradient accumulation boundary state, this is an optional
         feature and should be used with care. The state should be set before to the intended
         value before each forward/backward. The final fordward/backward should have the
-        boundary state set to True. See example below:
+        boundary state set to True. This style allows client code to only call engine.step() once after all
+        the gradient accumulation passes are complete. See example below:
 
         .. code-block:: python
 
@@ -1773,6 +1774,7 @@ class DeepSpeedEngine(Module):
         micro_batch = next(data_loader)
         loss = engine(micro_batch)
         engine.backward(loss)
+        engine.step()
 
         Arguments:
             is_boundary (bool): are we at a gradient accumulation boundary or not?

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -212,6 +212,7 @@ class DeepSpeedEngine(Module):
         self.moe_layers = []
         self._step_applied = False
         self._global_grad_norm = None
+        self._is_gradient_accumulation_boundary = None
 
         # for debug purposes - can then debug print: debug_get_module_name(module)
         debug_extract_module_and_param_names(model)

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1746,11 +1746,18 @@ class DeepSpeedEngine(Module):
         """Query whether the current micro-batch is at the boundary of
         gradient accumulation, and thus will trigger gradient reductions and
         an optimizer step.
-
         Returns:
             bool: if the current step is a gradient accumulation boundary.
         """
-        return (self.micro_steps + 1) % self.gradient_accumulation_steps() == 0
+        if self._is_gradient_accumulation_boundary is None:
+            return (self.micro_steps + 1) % \
+                self.gradient_accumulation_steps() == 0
+        else:
+            return self._is_gradient_accumulation_boundary
+
+    def set_gradient_accumulation_boundary(self, is_boundary):
+        self._is_gradient_accumulation_boundary = is_boundary
+        self.optimizer.is_gradient_accumulation_boundary = is_boundary
 
     def zero_grad(self):
         """


### PR DESCRIPTION
Many integrations are made a lot easier by deferring to the client code for when we are in a gradient accumulation boundary or not. This PR allows the client code to manually set the boundary state and propagates it to the right places in the DS engine.

`self.optimizer` may optionally use the `is_gradient_accumulation_boundary` state, but no harm in passing the state there for non-zero optimizers as well.