### PR TITLE
fix partition activations issue when mp=2 and pp=2

### DIFF
--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -856,3 +856,14 @@ def call_to_str(base, *args, **kwargs):
         name += ', '.join(f'{key}={repr(arg)}' for key, arg in kwargs.items())
     name += ')'
     return name
+
+def print_backward_tensors(grad_fn):
+    logger.info(f"Backward tensors in {grad_fn}")
+    for funcs in grad_fn.next_functions:
+        if funcs[0]:
+            try:
+                tensor = getattr(funcs[0], 'variable')
+                logger.info(funcs[0])
+                logger.info(f"Tensor - id: {id(tensor)}, shape: {tensor.shape}, data: {tensor}, grad: {tensor.grad}")
+            except AttributeError as e:
+                print_backward_tensors(funcs[0])

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -857,13 +857,20 @@ def call_to_str(base, *args, **kwargs):
     name += ')'
     return name
 
-def print_backward_tensors(grad_fn):
-    logger.info(f"Backward tensors in {grad_fn}")
-    for funcs in grad_fn.next_functions:
-        if funcs[0]:
-            try:
-                tensor = getattr(funcs[0], 'variable')
-                logger.info(funcs[0])
-                logger.info(f"Tensor - id: {id(tensor)}, shape: {tensor.shape}, data: {tensor}, grad: {tensor.grad}")
-            except AttributeError as e:
-                print_backward_tensors(funcs[0])
+
+def print_backward_tensors(tensor):
+    def _print_bwd_tensors(grad_fn):
+        logger.info(f"Backward tensors in {grad_fn}")
+        for funcs in grad_fn.next_functions:
+            if funcs[0]:
+                try:
+                    tensor = getattr(funcs[0], 'variable')
+                    logger.info(funcs[0])
+                    logger.info(
+                        f"Tensor - id: {id(tensor)}, shape: {tensor.shape}, data: {tensor}, grad: {tensor.grad}"
+                    )
+                except AttributeError as e:
+                    _print_bwd_tensors(funcs[0])
+
+    if hasattr(tensor, 'grad_fn'):
+        _print_bwd_tensors(tensor.grad_fn)

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -856,21 +856,3 @@ def call_to_str(base, *args, **kwargs):
         name += ', '.join(f'{key}={repr(arg)}' for key, arg in kwargs.items())
     name += ')'
     return name
-
-
-def print_backward_tensors(tensor):
-    def _print_bwd_tensors(grad_fn):
-        logger.info(f"Backward tensors in {grad_fn}")
-        for funcs in grad_fn.next_functions:
-            if funcs[0]:
-                try:
-                    tensor = getattr(funcs[0], 'variable')
-                    logger.info(funcs[0])
-                    logger.info(
-                        f"Tensor - id: {id(tensor)}, shape: {tensor.shape}, data: {tensor}, grad: {tensor.grad}"
-                    )
-                except AttributeError as e:
-                    _print_bwd_tensors(funcs[0])
-
-    if hasattr(tensor, 'grad_fn'):
-        _print_bwd_tensors(tensor.grad_fn)

--- a/deepspeed/utils/debug.py
+++ b/deepspeed/utils/debug.py
@@ -120,3 +120,21 @@ def log_rank_file(rank, *msgs):
     for m in msgs:
         fh.write(f"{m}\n")
     fh.flush()
+
+
+def print_backward_tensors(tensor):
+    def _print_bwd_tensors(grad_fn):
+        print(f"Backward tensors in {grad_fn}")
+        for funcs in grad_fn.next_functions:
+            if funcs[0]:
+                try:
+                    tensor = getattr(funcs[0], 'variable')
+                    print(funcs[0])
+                    print(
+                        f"Tensor - id: {id(tensor)}, shape: {tensor.shape}, data: {tensor}, grad: {tensor.grad}"
+                    )
+                except AttributeError as e:
+                    _print_bwd_tensors(funcs[0])
+
+    if hasattr(tensor, 'grad_fn'):
+        _print_bwd_tensors(tensor.grad_fn)


### PR DESCRIPTION
The issue is caused by the original input tensor not passed from forward to backward, when using ctx.save_for_backward(), it is fixed by saving as a context attribute.
Also adding a new utility function for printing backward tensors, it is useful in debugging this type issues.

Fix #1538