### PR TITLE
Add tensor methods in flops counting and separate macs and flops

### DIFF
--- a/deepspeed/profiling/flops_profiler/README.md
+++ b/deepspeed/profiling/flops_profiler/README.md
@@ -1,6 +1,6 @@
 # DeepSpeed Flops Profiler
 
-> Measures the parameters, latency, and floating point operations of your model.
+> Measures the parameters, latency, and floating-point operations of your model.
 
   - [Overview](#overview)
   - [Flops Measurement](#flops-measurement)
@@ -8,7 +8,7 @@
   - [Usage](#usage)
 ## Overview
 
-Effective use of hardware resources is critical to good performance, but performance inefficiency in existing implementations for large-scale model training and inference are often hard to spot and attributed to specific module components. DeepSpeed Flops Profiler helps users easily measure both the model training/inference speed (latency, throughput) and efficiency (floating point operations per second, i.e., FLOPS) of a model and its submodules, with an eye towards eliminating inefficiencies in existing implementations.
+Effective use of hardware resources is critical to good performance, but performance inefficiency in existing implementations for large-scale model training and inference are often hard to spot and attributed to specific module components. DeepSpeed Flops Profiler helps users easily measure both the model training/inference speed (latency, throughput) and efficiency (floating-point operations per second, i.e., FLOPS) of a model and its submodules, with an eye towards eliminating inefficiencies in existing implementations.
 
 Below is an example output for BERT-Large(NVIDIA) on an A100 GPU with batch size `80`:
 
@@ -18,7 +18,7 @@ Profile Summary at step 10:
 Notations:
 data parallel size (dp_size), model paralel size(mp_size),
 number of parameters (params), number of multiply-accumulate operations(MACs),
-umber of floating point operations (flops), floating point operations per second (FLOPS),
+number of floating-point operations (flops), floating-point operations per second (FLOPS),
 fwd latency (forward propagation latency), bwd latency (backward propagation latency),
 step (weights update latency), iter latency (sum of fwd, bwd and step latency)
 
@@ -29,7 +29,7 @@ batch size per GPU:                                           80
 params per gpu:                                               336.23 M
 params of model = params per GPU * mp_size:                   336.23 M
 fwd MACs per GPU:                                             3139.93 G
-fwd flops per GPU = 2 * fwd MACs per GPU:                     6279.86 G
+fwd flops per GPU:                                            6279.86 G
 fwd flops of model = fwd flops per GPU * mp_size:             6279.86 G
 fwd latency:                                                  76.67 ms
 bwd latency:                                                  108.02 ms
@@ -127,7 +127,7 @@ BertForPreTrainingPreLN(
 
 ```
 
-In the summary profile, the DeepSpeed Flops Profiler outputs the number of parameters, floating point operations (flops), FLOPS, latency, and throughput in samples/second of the model. This profile shows how much performance gap (compared to the peak hardware performance) the current model execution has and helps users tune the training or inference setup (e.g., hyperparameters, data parallelism, model parallelism, system configurations, etc.) for better performance.
+In the summary profile, the DeepSpeed Flops Profiler outputs the number of parameters, floating-point operations (flops), FLOPS, latency, and throughput in samples/second of the model. This profile shows how much performance gap (compared to the peak hardware performance) the current model execution has and helps users tune the training or inference setup (e.g., hyperparameters, data parallelism, model parallelism, system configurations, etc.) for better performance.
 
 The DeepSpeed Flops Profiler also measures significant modules at different model depths (aggregated profile) and module-specific profile in the model architecture (detailed profile). Using these profiles DeepSpeed users can understand how each layer or submodule contributes to the overall model complexity/performance. Then users can adjust or refactor the model design to achieve better performance. For example, using the profiler, DeepSpeed users can quantitatively tell if stacking smaller layers is lighter or more performant than having bigger ones. The aggregated and detailed profiles also allow users to quickly identify bottleneck modules. In the BERT-Large example above, using the DeepSpeed Flops Profiler, we find that BertLayer is the most significant layer and contains quite a few dropout, softmax, and layer norm along with linear modules. These modules are not heavy in flops and would trigger many GPU kernel invocations and create excessive read/write requests to memory. The pattern shown in the detailed profile suggests this is a perfect match for kernel fusion, and we developed fused transformer-kernels to reduce data movement (See DeepSpeedBert). After applying our optimizations, we see a 25% improvement in FLOPS per GPU and overall training samples/second in the DeepSpeed Flops Profiler output.
 
@@ -187,7 +187,7 @@ Profile Summary at step 10:
 Notations:
 data parallel size (dp_size), model paralel size(mp_size),
 number of parameters (params), number of multiply-accumulate operations(MACs),
-umber of floating point operations (flops), floating point operations per second (FLOPS),
+number of floating-point operations (flops), floating-point operations per second (FLOPS),
 fwd latency (forward propagation latency), bwd latency (backward propagation latency),
 step (weights update latency), iter latency (sum of fwd, bwd and step latency)
 
@@ -198,7 +198,7 @@ batch size per GPU:                                           1024
 params per gpu:                                               1.29 M
 params of model = params per GPU * mp_size:                   1.29 M
 fwd MACs per GPU:                                             41271.95 G
-fwd flops per GPU = 2 * fwd MACs per GPU:                     82543.9 G
+fwd flops per GPU:                                            82543.9 G
 fwd flops of model = fwd flops per GPU * mp_size:             82543.9 G
 fwd latency:                                                  1.89 s
 bwd latency:                                                  5.38 s
@@ -241,7 +241,7 @@ Each module profile is listed after its name in the following order:
 params, percentage of total params, MACs, percentage of total MACs, fwd latency, percentage of total fwd latency, fwd FLOPS
 
 Note: 1. A module can have torch.nn.module or torch.nn.functional to compute logits (e.g. CrossEntropyLoss). They are not counted as submodules, thus not to be printed out. However they make up the difference between a parent's MACs(or latency) and the sum of its submodules'.
-2. Number of floating point operations is a theoretical estimation, thus FLOPS computed using that could be larger than the maximum system throughput.
+2. Number of floating-point operations is a theoretical estimation, thus FLOPS computed using that could be larger than the maximum system throughput.
 3. The fwd latency listed in the top module's profile is directly captured at the module forward function in PyTorch, thus it's less than the fwd latency shown above which is captured in DeepSpeed.
 
 GPT2Model(
@@ -374,11 +374,12 @@ with torch.cuda.device(0):
 To profile model forward in a training workflow, use the `FlopsProfiler`class.
 The `FlopsProfiler`class provides the following methods:
   * `start_profile()` - starts profiling
-  * `get_total_flops(as_string=False)` - returns the total number of MACs in the model
+  * `get_total_flops(as_string=False)` - returns the total number of floating-point operations in the model
+  * `get_total_macs(as_string=False)` - returns the total number of MACs in the model
   * `get_total_params(as_string=False)` - returns the total number of parameters in the model
   * `print_model_profile(profile_step=1, module_depth=-1, top_modules=1, detailed=True, output_file=None)` - prints the model profile
   * `stop_profile()` - stops profiling. This stops the flops counting in the model.
-  * `end_profile()` - cleans up. This cleans up the profile attributes added to the model during the profiling. This should be invoked at the end of the profiling and AFTER `get_total_flops`, `get_total_params` or `print_model_profile`.
+  * `end_profile()` - cleans up. This cleans up the profile attributes added to the model during the profiling. This should be invoked at the end of the profiling and AFTER `get_total_flops`, `get_total_macs`, `get_total_params` or `print_model_profile`.
 
 ##### Example Training Workflow
 
@@ -404,8 +405,9 @@ for step, batch in enumerate(data_loader):
   # end profiling and print output
   if step == profile_step: # if using multi nodes, check global_rank == 0 as well
     prof.stop_profile()
-    flops = prof.get_total_flops(as_string=True)
-    params = prof.get_total_params(as_string=True)
+    flops = prof.get_total_flops()
+    macs = prof.get_total_macs()
+    params = prof.get_total_params()
     if print_profile:
         prof.print_model_profile(profile_step=profile_step)
     prof.end_profile()

--- a/deepspeed/profiling/flops_profiler/README.md
+++ b/deepspeed/profiling/flops_profiler/README.md
@@ -313,7 +313,7 @@ from deepspeed.profiling.flops_profiler import get_model_profile
 with torch.cuda.device(0):
     model = models.alexnet()
     batch_size = 256
-    macs, params = get_model_profile(model=model, # model
+    flops, macs, params = get_model_profile(model=model, # model
                                      input_res=(batch_size, 3, 224, 224), # input shape or input to the input_constructor
                                      input_constructor=None, # if specified, a constructor taking input_res is used as input to the model
                                      print_profile=True, # prints the model graph with the measured profile attached to each module
@@ -356,7 +356,7 @@ with torch.cuda.device(0):
     seq_len = 128
     enable_profile = True
     if enable_profile:
-      macs, params = get_model_profile(
+      flops, macs, params = get_model_profile(
           model,
           (batch_size, seq_len),
           input_constructor=partial(bert_input_constructor,

--- a/deepspeed/profiling/flops_profiler/profiler.py
+++ b/deepspeed/profiling/flops_profiler/profiler.py
@@ -3,8 +3,14 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from functools import partial
+from typing import Callable, List, Optional, Tuple
+from collections import OrderedDict
+import numpy as np
+
+Tensor = torch.Tensor
 
 module_flop_count = []
+module_mac_count = []
 old_functions = {}
 
 
@@ -60,6 +66,7 @@ class FlopsProfiler(object):
         """
         self.reset_profile()
         _patch_functionals()
+        _patch_tensor_methods()
 
         def register_module_hooks(module, ignore_list):
             if ignore_list and type(module) in ignore_list:
@@ -74,6 +81,7 @@ class FlopsProfiler(object):
             # if computing the flops of the functionals in a module
             def pre_hook(module, input):
                 module_flop_count.append([])
+                module_mac_count.append([])
 
             module.__pre_hook_handle__ = module.register_forward_pre_hook(pre_hook)
 
@@ -81,6 +89,8 @@ class FlopsProfiler(object):
                 if module_flop_count:
                     module.__flops__ += sum([elem[1] for elem in module_flop_count[-1]])
                     module_flop_count.pop()
+                    module.__macs__ += sum([elem[1] for elem in module_mac_count[-1]])
+                    module_mac_count.pop()
 
             module.__post_hook_handle__ = module.register_forward_hook(post_hook)
 
@@ -106,6 +116,7 @@ class FlopsProfiler(object):
         """
         if self.started and self.func_patched:
             _reload_functionals()
+            _reload_tensor_methods()
             self.func_patched = False
 
         def remove_profile_attrs(module):
@@ -134,6 +145,7 @@ class FlopsProfiler(object):
         """
         def add_or_reset_attrs(module):
             module.__flops__ = 0
+            module.__macs__ = 0
             module.__params__ = sum(p.numel() for p in module.parameters()
                                     if p.requires_grad)
             module.__start_time__ = 0
@@ -154,6 +166,8 @@ class FlopsProfiler(object):
         def remove_profile_attrs(module):
             if hasattr(module, "__flops__"):
                 del module.__flops__
+            if hasattr(module, "__macs__"):
+                del module.__macs__
             if hasattr(module, "__params__"):
                 del module.__params__
             if hasattr(module, "__start_time__"):
@@ -163,7 +177,7 @@ class FlopsProfiler(object):
 
         self.model.apply(remove_profile_attrs)
 
-    def get_total_flops(self, as_string=False):
+    def get_total_flops(self):
         """Returns the total flops of the model.
 
         Args:
@@ -173,7 +187,19 @@ class FlopsProfiler(object):
             The number of multiply-accumulate operations of the model forward pass.
         """
         total_flops = get_module_flops(self.model)
-        return macs_to_string(total_flops) if as_string else total_flops
+        return total_flops
+
+    def get_total_macs(self, as_string=False):
+        """Returns the total MACs of the model.
+
+        Args:
+            as_string (bool, optional): whether to output the flops as string. Defaults to False.
+
+        Returns:
+            The number of multiply-accumulate operations of the model forward pass.
+        """
+        total_macs = get_module_macs(self.model)
+        return macs_to_string(total_macs) if as_string else total_macs
 
     def get_total_duration(self, as_string=False):
         """Returns the total duration of the model forward pass.
@@ -230,6 +256,7 @@ class FlopsProfiler(object):
             sys.stdout = f
 
         total_flops = self.get_total_flops()
+        total_macs = self.get_total_macs()
         total_duration = self.get_total_duration()
         total_params = self.get_total_params()
 
@@ -259,13 +286,14 @@ class FlopsProfiler(object):
             params_to_string(total_params *
                              (self.ds_engine.mp_world_size) if self.ds_engine else 1)))
 
-        print('{:<60}  {:<8}'.format('fwd MACs per GPU: ', num_to_string(total_flops)))
-        print('{:<60}  {:<8}'.format('fwd flops per GPU = 2 * fwd MACs per GPU: ',
-                                     num_to_string(2 * total_flops)))
+        print('{:<60}  {:<8}'.format('fwd MACs per GPU: ', macs_to_string(total_macs)))
+
+        print('{:<60}  {:<8}'.format('fwd flops per GPU: ',
+                                     num_to_string(total_flops)))
 
         print('{:<60}  {:<8}'.format(
             'fwd flops of model = fwd flops per GPU * mp_size: ',
-            num_to_string(2 * total_flops *
+            num_to_string(total_flops *
                           (self.ds_engine.mp_world_size) if self.ds_engine else 1)))
 
         fwd_latency = self.get_total_duration()
@@ -274,7 +302,7 @@ class FlopsProfiler(object):
         print('{:<60}  {:<8}'.format('fwd latency: ', duration_to_string(fwd_latency)))
         print('{:<60}  {:<8}'.format(
             'fwd FLOPS per GPU = fwd flops per GPU / fwd latency: ',
-            flops_to_string(2 * total_flops / fwd_latency)))
+            flops_to_string(total_flops / fwd_latency)))
 
         if self.ds_engine and self.ds_engine.wall_clock_breakdown():
             bwd_latency = self.ds_engine.timers('backward').elapsed(False)
@@ -283,10 +311,10 @@ class FlopsProfiler(object):
                                          duration_to_string(bwd_latency)))
             print('{:<60}  {:<8}'.format(
                 'bwd FLOPS per GPU = 2 * fwd flops per GPU / bwd latency: ',
-                flops_to_string(2 * 2 * total_flops / bwd_latency)))
+                flops_to_string(2 * total_flops / bwd_latency)))
             print('{:<60}  {:<8}'.format(
                 'fwd+bwd FLOPS per GPU = 3 * fwd flops per GPU / (fwd+bwd latency): ',
-                flops_to_string(3 * 2 * total_flops / (fwd_latency + bwd_latency))))
+                flops_to_string(3 * total_flops / (fwd_latency + bwd_latency))))
 
             print('{:<60}  {:<8}'.format('step latency: ',
                                          duration_to_string(step_latency)))
@@ -296,7 +324,7 @@ class FlopsProfiler(object):
                                          duration_to_string(iter_latency)))
             print('{:<60}  {:<8}'.format(
                 'FLOPS per GPU = 3 * fwd flops per GPU / iter latency: ',
-                flops_to_string(3 * 2 * total_flops / iter_latency)))
+                flops_to_string(3 * total_flops / iter_latency)))
 
             samples_per_iter = self.ds_engine.train_micro_batch_size_per_gpu(
             ) * self.ds_engine.world_size
@@ -306,11 +334,12 @@ class FlopsProfiler(object):
         def flops_repr(module):
             params = module.__params__
             flops = get_module_flops(module)
+            macs = get_module_macs(module)
             items = [
                 params_to_string(params),
                 "{:.2%} Params".format(params / total_params),
                 macs_to_string(flops),
-                "{:.2%} MACs".format(0.0 if total_flops == 0 else flops / total_flops),
+                "{:.2%} MACs".format(0.0 if total_macs == 0 else macs / total_macs),
             ]
             duration = get_module_duration(module)
 
@@ -318,8 +347,7 @@ class FlopsProfiler(object):
             items.append(
                 "{:.2%} latency".format(0.0 if total_duration == 0 else duration /
                                         total_duration))
-            # flops = 2 * MACs
-            items.append(flops_to_string(0.0 if duration == 0 else 2 * flops / duration))
+            items.append(flops_to_string(0.0 if duration == 0 else flops / duration))
             items.append(module.original_extra_repr())
             return ", ".join(items)
 
@@ -387,8 +415,8 @@ class FlopsProfiler(object):
                     0,
                     0,
                     0,
-                ]  # flops, params, time
-            info[curr_depth][module.__class__.__name__][0] += get_module_flops(module)
+                ]  # macs, params, time
+            info[curr_depth][module.__class__.__name__][0] += get_module_macs(module)
             info[curr_depth][module.__class__.__name__][1] += module.__params__
             info[curr_depth][module.__class__.__name__][2] += get_module_duration(module)
             has_children = len(module._modules.items()) != 0
@@ -409,7 +437,7 @@ class FlopsProfiler(object):
         for d in range(depth):
             num_items = min(top_modules, len(info[d]))
 
-            sort_flops = {
+            sort_macs = {
                 k: macs_to_string(v[0])
                 for k,
                 v in sorted(info[d].items(),
@@ -433,9 +461,8 @@ class FlopsProfiler(object):
 
             print(f"depth {d}:")
             print(f"    params      - {sort_params}")
-            print(f"    MACs        - {sort_flops}")
+            print(f"    MACs        - {sort_macs}")
             print(f"    fwd latency - {sort_time}")
-
 
 def _prod(dims):
     p = 1
@@ -443,15 +470,31 @@ def _prod(dims):
         p *= v
     return p
 
-
 def _linear_flops_compute(input, weight, bias=None):
     out_features = weight.shape[0]
-    return torch.numel(input) * out_features
-
+    macs = torch.numel(input) * out_features
+    return 2 * macs, macs
 
 def _relu_flops_compute(input, inplace=False):
-    return torch.numel(input)
+    return torch.numel(input), 0
 
+def _prelu_flops_compute(input: Tensor, weight: Tensor):
+    return torch.numel(input), 0
+
+def _elu_flops_compute(input: Tensor, alpha: float = 1.0, inplace: bool = False):
+    return torch.numel(input), 0
+
+def _leaky_relu_flops_compute(input: Tensor, negative_slope: float = 0.01, inplace: bool = False):
+    return torch.numel(input), 0
+
+def _relu6_flops_compute(input: Tensor, inplace: bool = False):
+    return torch.numel(input), 0
+
+def _silu_flops_compute(input: Tensor, inplace: bool = False):
+    return torch.numel(input), 0
+
+def _gelu_flops_compute(input):
+    return torch.numel(input), 0
 
 def _pool_flops_compute(
     input,
@@ -462,7 +505,7 @@ def _pool_flops_compute(
     count_include_pad=True,
     divisor_override=None,
 ):
-    return torch.numel(input)
+    return torch.numel(input), 0
 
 
 def _conv_flops_compute(input,
@@ -493,17 +536,16 @@ def _conv_flops_compute(input,
         output_dims.append(output_dim)
 
     filters_per_channel = out_channels // groups
-    conv_per_position_flops = int(_prod(kernel_dims)) * in_channels * filters_per_channel
+    conv_per_position_macs = int(_prod(kernel_dims)) * in_channels * filters_per_channel
     active_elements_count = batch_size * int(_prod(output_dims))
-    overall_conv_flops = conv_per_position_flops * active_elements_count
+    overall_conv_macs = conv_per_position_macs * active_elements_count
+    overall_conv_flops = 2 * overall_conv_macs
 
     bias_flops = 0
     if bias is not None:
         bias_flops = out_channels * active_elements_count
 
-    overall_flops = overall_conv_flops + bias_flops
-
-    return int(overall_flops)
+    return int(overall_conv_flops + bias_flops), int(overall_conv_macs)
 
 
 def _conv_trans_flops_compute(
@@ -540,17 +582,16 @@ def _conv_trans_flops_compute(
     dilations = dilation if type(dilation) is tuple else (dilation, dilation)
 
     filters_per_channel = out_channels // groups
-    conv_per_position_flops = int(_prod(kernel_dims)) * in_channels * filters_per_channel
+    conv_per_position_macs = int(_prod(kernel_dims)) * in_channels * filters_per_channel
     active_elements_count = batch_size * int(_prod(input_dims))
-    overall_conv_flops = conv_per_position_flops * active_elements_count
+    overall_conv_macs = conv_per_position_macs * active_elements_count
+    overall_conv_flops = 2 * overall_conv_macs
 
     bias_flops = 0
     if bias is not None:
         bias_flops = out_channels * batch_size * int(_prod(output_dims))
 
-    overall_flops = overall_conv_flops + bias_flops
-
-    return int(overall_flops)
+    return int(overall_conv_flops + bias_flops), int(overall_conv_macs)
 
 
 def _batch_norm_flops_compute(
@@ -563,9 +604,45 @@ def _batch_norm_flops_compute(
     momentum=0.1,
     eps=1e-05,
 ):
-    # assume affine is true
-    flops = 2 * torch.numel(input)
-    return flops
+    has_affine = weight is not None
+    if training:
+        # estimation
+        return torch.numel(input) * (5 if has_affine else 4)
+    flops = torch.numel(input) * (2 if has_affine else 1)
+    return flops, 0
+
+def _layer_norm_flops_compute(
+    input: Tensor,
+    normalized_shape: List[int],
+    weight: Optional[Tensor] = None,
+    bias: Optional[Tensor] = None,
+    eps: float = 1e-5,
+):
+    has_affine = weight is not None
+    # estimation
+    return torch.numel(input) * (5 if has_affine else 4), 0
+
+def _group_norm_flops_compute(
+    input: Tensor, num_groups: int, weight: Optional[Tensor] = None, bias: Optional[Tensor] = None, eps: float = 1e-5
+
+):
+    has_affine = weight is not None
+    # estimation
+    return torch.numel(input) * (5 if has_affine else 4), 0
+
+def _instance_norm_flops_compute(
+    input: Tensor,
+    running_mean: Optional[Tensor] = None,
+    running_var: Optional[Tensor] = None,
+    weight: Optional[Tensor] = None,
+    bias: Optional[Tensor] = None,
+    use_input_stats: bool = True,
+    momentum: float = 0.1,
+    eps: float = 1e-5,
+):
+    has_affine = weight is not None
+    # estimation
+    return torch.numel(input) * (5 if has_affine else 4), 0
 
 
 def _upsample_flops_compute(input,
@@ -581,11 +658,11 @@ def _upsample_flops_compute(input,
         flops * int(_prod(scale_factor))
     else:
         flops * scale_factor**len(input)
-    return flops
+    return flops, 0
 
 
 def _softmax_flops_compute(input, dim=None, _stacklevel=3, dtype=None):
-    return torch.numel(input)
+    return torch.numel(input), 0
 
 
 def _embedding_flops_compute(
@@ -597,12 +674,83 @@ def _embedding_flops_compute(
     scale_grad_by_freq=False,
     sparse=False,
 ):
-    return 0
+    return 0, 0
 
 
 def _dropout_flops_compute(input, p=0.5, training=True, inplace=False):
-    return 0
+    return 0, 0
 
+
+def _matmul_flops_compute(input, other, *, out=None):
+    """
+    Count flops for the matmul operation.
+    """
+    macs = _prod(input.shape) * other.shape[-1]
+    return 2 * macs , macs
+
+def _addmm_flops_compute(input, mat1, mat2, *, beta=1, alpha=1, out=None):
+    """
+    Count flops for the addmm operation.
+    """
+    macs = _prod(mat1.shape) * mat2.shape[-1]
+    return 2 * macs + _prod(input.shape), macs
+
+def _einsum_flops_compute(equation, *operands):
+    """
+    Count flops for the einsum operation.
+    """
+    equation = equation.toIValue()
+    # Get rid of white space in the equation string.
+    equation = equation.replace(" ", "")
+    input_shapes = [o.shape for o in operands]
+
+    # Re-map equation so that same equation with different alphabet
+    # representations will look the same.
+    letter_order = OrderedDict((k, 0) for k in equation if k.isalpha()).keys()
+    mapping = {ord(x): 97 + i for i, x in enumerate(letter_order)}
+    equation = equation.translate(mapping)
+
+    if equation == "abc,abd->acd":
+        n, c, t = input_shapes[0]
+        p = input_shapes[-1][-1]
+        flop = n * c * t * p
+        return flop, 0
+
+    elif equation == "abc,adc->adb":
+        n, t, g = input_shapes[0]
+        c = input_shapes[-1][1]
+        flop = n * t * g * c
+        return flop, 0
+    else:
+        np_arrs = [np.zeros(s) for s in input_shapes]
+        optim = np.einsum_path(equation, *np_arrs, optimize="optimal")[1]
+        for line in optim.split("\n"):
+            if "optimized flop" in line.lower():
+                # divided by 2 because we count MAC (multiply-add counted as one flop)
+                flop = float(np.floor(float(line.split(":")[-1]) / 2))
+                return flop, 0
+        raise NotImplementedError("Unsupported einsum operation.")
+
+
+def _tensor_matmul_flops_compute(self, other):
+    assert type(self) == torch.Tensor
+    assert type(other) == torch.Tensor
+    macs = _prod(self.shape) * other.shape[-1]
+    return 2 * macs, macs
+
+def _elementwise_flops_compute(input, other, *, out=None):
+    dim_input = len(input.shape)
+    dim_other = len(other.shape)
+    max_dim = max(dim_input, dim_other)
+
+    final_shape = []
+    for i in range(max_dim):
+        if input.shape[i] > other.shape[i]:
+            final_shape.append(input.shape[i])
+        else:
+            final_shape.append(other.shape[i])
+    flops = _prod(final_shape)
+    return flops, 0
 
 def wrapFunc(func, funcFlopCompute):
     oldFunc = func
@@ -610,9 +758,11 @@ def wrapFunc(func, funcFlopCompute):
     old_functions[name] = oldFunc
 
     def newFunc(*args, **kwds):
-        flops = funcFlopCompute(*args, **kwds)
+        flops, macs = funcFlopCompute(*args, **kwds)
         if module_flop_count:
             module_flop_count[-1].append((name, flops))
+        if module_mac_count and macs:
+            module_mac_count[-1].append((name, macs))
         return oldFunc(*args, **kwds)
 
     newFunc.__name__ = func.__name__
@@ -636,13 +786,18 @@ def _patch_functionals():
 
     # activations
     F.relu = wrapFunc(F.relu, _relu_flops_compute)
-    F.prelu = wrapFunc(F.prelu, _relu_flops_compute)
-    F.elu = wrapFunc(F.elu, _relu_flops_compute)
-    F.leaky_relu = wrapFunc(F.leaky_relu, _relu_flops_compute)
-    F.relu6 = wrapFunc(F.relu6, _relu_flops_compute)
+    F.prelu = wrapFunc(F.prelu, _prelu_flops_compute)
+    F.elu = wrapFunc(F.elu, _elu_flops_compute)
+    F.leaky_relu = wrapFunc(F.leaky_relu, _leaky_relu_flops_compute)
+    F.relu6 = wrapFunc(F.relu6, _relu6_flops_compute)
+    F.silu = wrapFunc(F.silu, _silu_flops_compute)
+    F.gelu = wrapFunc(F.gelu, _gelu_flops_compute)
 
-    # BatchNorms
+    # Normalizations
     F.batch_norm = wrapFunc(F.batch_norm, _batch_norm_flops_compute)
+    F.layer_norm = wrapFunc(F.layer_norm, _layer_norm_flops_compute)
+    F.instance_norm = wrapFunc(F.instance_norm, _instance_norm_flops_compute)
+    F.group_norm = wrapFunc(F.group_norm, _group_norm_flops_compute)
 
     # poolings
     F.avg_pool1d = wrapFunc(F.avg_pool1d, _pool_flops_compute)
@@ -668,6 +823,23 @@ def _patch_functionals():
     # embedding
     F.embedding = wrapFunc(F.embedding, _embedding_flops_compute)
 
+def _patch_tensor_methods():
+    torch.matmul = wrapFunc(torch.matmul, _matmul_flops_compute)
+    # torch.Tensor.__matmul__ = wrapFunc(torch.Tensor.__matmul__, _tensor_matmul_flops_compute)
+    torch.mm = wrapFunc(torch.mm, _matmul_flops_compute)
+    # torch.Tensor.__mm__ = wrapFunc(torch.Tensor.__mm__, _matmul_flops_compute)
+    torch.bmm = wrapFunc(torch.bmm, _matmul_flops_compute)
+    torch.addmm = wrapFunc(torch.addmm, _addmm_flops_compute)
+
+    torch.mul = wrapFunc(torch.mul, _elementwise_flops_compute)
+    # torch.Tensor.__mul__ = wrapFunc(torch.Tensor.__mul__, _elementwise_flops_compute)
+    # torch.Tensor.__imul__ = wrapFunc(torch.Tensor.__imul__, _elementwise_flops_compute)
+
+    torch.add = wrapFunc(torch.add, _elementwise_flops_compute)
+    # torch.Tensor.__add__ = wrapFunc(torch.Tensor.__add__, _elementwise_flops_compute)
+    # torch.Tensor.__iadd__ = wrapFunc(torch.Tensor.__iadd__, _elementwise_flops_compute)
+
+    torch.einsum = wrapFunc(torch.einsum, _einsum_flops_compute)
 
 def _reload_functionals():
     # torch.nn.functional does not support importlib.reload()
@@ -701,6 +873,8 @@ def _reload_functionals():
     F.softmax = old_functions[F.softmax.__name__]
     F.embedding = old_functions[F.embedding.__name__]
 
+def _reload_tensor_methods():
+    torch.matmul = old_functions[torch.matmul.__name__]
 
 def _rnn_flops(flops, rnn_module, w_ih, w_hh, input_size):
     # matrix matrix mult ih state and internal state
@@ -814,6 +988,26 @@ def macs_to_string(macs, units=None, precision=2):
         else:
             return str(macs) + " MACs"
 
+def number_to_string(num, units=None, precision=2):
+    if units is None:
+        if num // 10**9 > 0:
+            return str(round(num / 10.0**9, precision)) + " G"
+        elif num // 10**6 > 0:
+            return str(round(num / 10.0**6, precision)) + " M"
+        elif num // 10**3 > 0:
+            return str(round(num / 10.0**3, precision)) + " K"
+        else:
+            return str(num) + " "
+    else:
+        if units == "G":
+            return str(round(num / 10.0**9, precision)) + " " + units
+        elif units == "M":
+            return str(round(num / 10.0**6, precision)) + " " + units
+        elif units == "K":
+            return str(round(num / 10.0**3, precision)) + " " + units
+        else:
+            return str(num) + " "
+
 
 def flops_to_string(flops, units=None, precision=2):
     if units is None:
@@ -885,6 +1079,12 @@ def get_module_flops(module):
         sum += get_module_flops(child)
     return sum
 
+def get_module_macs(module):
+    sum = module.__macs__
+    # iterate over immediate children modules
+    for child in module.children():
+        sum += get_module_macs(child)
+    return sum
 
 def get_module_duration(module):
     duration = module.__duration__
@@ -907,7 +1107,7 @@ def get_model_profile(
     output_file=None,
     ignore_modules=None,
 ):
-    """Returns the total MACs and parameters of a model.
+    """Returns the total floating-point operations, MACs, and parameters of a model.
 
     Example:
 
@@ -915,7 +1115,7 @@ def get_model_profile(
 
         model = torchvision.models.alexnet()
         batch_size = 256
-        macs, params = get_model_profile(model=model, input_res= (batch_size, 3, 224, 224)))
+        flops, macs, params = get_model_profile(model=model, input_res= (batch_size, 3, 224, 224)))
 
     Args:
         model ([torch.nn.Module]): the PyTorch model to be profiled.
@@ -931,7 +1131,7 @@ def get_model_profile(
         ignore_modules ([type], optional): the list of modules to ignore during profiling. Defaults to None.
 
     Returns:
-        The number of multiply-accumulate operations (MACs) and parameters in the model.
+        The number of floating-point operations, multiply-accumulate operations (MACs), and parameters in the model.
     """
     assert type(input_res) is tuple
     assert len(input_res) >= 1
@@ -972,6 +1172,7 @@ def get_model_profile(
         _ = model(batch)
 
     flops = prof.get_total_flops()
+    macs = prof.get_total_macs()
     params = prof.get_total_params()
     if print_profile:
         prof.print_model_profile(profile_step=warm_up,
@@ -982,6 +1183,6 @@ def get_model_profile(
 
     prof.end_profile()
     if as_string:
-        return macs_to_string(flops), params_to_string(params)
+        return number_to_string(flops), macs_to_string(macs), params_to_string(params)
 
-    return flops, params
+    return flops, macs, params

--- a/docs/_tutorials/flops-profiler.md
+++ b/docs/_tutorials/flops-profiler.md
@@ -1,6 +1,6 @@
 ---
 title: "Flops Profiler"
-excerpt: "Measure the parameters, latency, and floating point operations of your model"
+excerpt: "Measure the parameters, latency, and floating-point operations of your model"
 ---
 
 In this tutorial, we introduce the DeepSpeed Flops Profiler and provide examples of its usage.
@@ -12,7 +12,7 @@ In this tutorial, we introduce the DeepSpeed Flops Profiler and provide examples
 
 ## Overview
 
-Effective use of hardware resources is critical to good performance, but performance inefficiency in existing implementations for large-scale model training and inference are often hard to spot and attributed to specific module components. DeepSpeed Flops Profiler helps users easily measure both the model training/inference speed (latency, throughput) and efficiency (floating point operations per second, i.e., FLOPS) of a model and its submodules, with an eye towards eliminating inefficiencies in existing implementations.
+Effective use of hardware resources is critical to good performance, but performance inefficiency in existing implementations for large-scale model training and inference are often hard to spot and attributed to specific module components. DeepSpeed Flops Profiler helps users easily measure both the model training/inference speed (latency, throughput) and efficiency (floating-point operations per second, i.e., FLOPS) of a model and its submodules, with an eye towards eliminating inefficiencies in existing implementations.
 
 Below is an example output for BERT-Large(NVIDIA) on an A100 GPU with batch size `80`:
 
@@ -22,7 +22,7 @@ Profile Summary at step 10:
 Notations:
 data parallel size (dp_size), model paralel size(mp_size),
 number of parameters (params), number of multiply-accumulate operations(MACs),
-umber of floating point operations (flops), floating point operations per second (FLOPS),
+number of floating-point operations (flops), floating-point operations per second (FLOPS),
 fwd latency (forward propagation latency), bwd latency (backward propagation latency),
 step (weights update latency), iter latency (sum of fwd, bwd and step latency)
 
@@ -33,7 +33,7 @@ batch size per GPU:                                           80
 params per gpu:                                               336.23 M
 params of model = params per GPU * mp_size:                   336.23 M
 fwd MACs per GPU:                                             3139.93 G
-fwd flops per GPU = 2 * fwd MACs per GPU:                     6279.86 G
+fwd flops per GPU:                                            6279.86 G
 fwd flops of model = fwd flops per GPU * mp_size:             6279.86 G
 fwd latency:                                                  76.67 ms
 bwd latency:                                                  108.02 ms
@@ -131,7 +131,7 @@ BertForPreTrainingPreLN(
 
 ```
 
-In the summary profile, the DeepSpeed Flops Profiler outputs the number of parameters, floating point operations (flops), FLOPS, latency, and throughput in samples/second of the model. This profile shows how much performance gap (compared to the peak hardware performance) the current model execution has and helps users tune the training or inference setup (e.g., hyperparameters, data parallelism, model parallelism, system configurations, etc.) for better performance.
+In the summary profile, the DeepSpeed Flops Profiler outputs the number of parameters, floating-point operations (flops), FLOPS, latency, and throughput in samples/second of the model. This profile shows how much performance gap (compared to the peak hardware performance) the current model execution has and helps users tune the training or inference setup (e.g., hyperparameters, data parallelism, model parallelism, system configurations, etc.) for better performance.
 
 The DeepSpeed Flops Profiler also measures significant modules at different model depths (aggregated profile) and module-specific profile in the model architecture (detailed profile). Using these profiles DeepSpeed users can understand how each layer or submodule contributes to the overall model complexity/performance. Then users can adjust or refactor the model design to achieve better performance. For example, using the profiler, DeepSpeed users can quantitatively tell if stacking smaller layers is lighter or more performant than having bigger ones. The aggregated and detailed profiles also allow users to quickly identify bottleneck modules. In the BERT-Large example above, using the DeepSpeed Flops Profiler, we find that BertLayer is the most significant layer and contains quite a few dropout, softmax, and layer norm along with linear modules. These modules are not heavy in flops and would trigger many GPU kernel invocations and create excessive read/write requests to memory. The pattern shown in the detailed profile suggests this is a perfect match for kernel fusion, and we developed fused transformer-kernels to reduce data movement (See DeepSpeedBert). After applying our optimizations, we see a 25% improvement in FLOPS per GPU and overall training samples/second in the DeepSpeed Flops Profiler output.
 
@@ -191,7 +191,7 @@ Profile Summary at step 10:
 Notations:
 data parallel size (dp_size), model paralel size(mp_size),
 number of parameters (params), number of multiply-accumulate operations(MACs),
-umber of floating point operations (flops), floating point operations per second (FLOPS),
+number of floating-point operations (flops), floating-point operations per second (FLOPS),
 fwd latency (forward propagation latency), bwd latency (backward propagation latency),
 step (weights update latency), iter latency (sum of fwd, bwd and step latency)
 
@@ -202,7 +202,7 @@ batch size per GPU:                                           1024
 params per gpu:                                               1.29 M
 params of model = params per GPU * mp_size:                   1.29 M
 fwd MACs per GPU:                                             41271.95 G
-fwd flops per GPU = 2 * fwd MACs per GPU:                     82543.9 G
+fwd flops per GPU:                                            82543.9 G
 fwd flops of model = fwd flops per GPU * mp_size:             82543.9 G
 fwd latency:                                                  1.89 s
 bwd latency:                                                  5.38 s
@@ -245,7 +245,7 @@ Each module profile is listed after its name in the following order:
 params, percentage of total params, MACs, percentage of total MACs, fwd latency, percentage of total fwd latency, fwd FLOPS
 
 Note: 1. A module can have torch.nn.module or torch.nn.functional to compute logits (e.g. CrossEntropyLoss). They are not counted as submodules, thus not to be printed out. However they make up the difference between a parent's MACs(or latency) and the sum of its submodules'.
-1. Number of floating point operations is a theoretical estimation, thus FLOPS computed using that could be larger than the maximum system throughput.
+1. Number of floating-point operations is a theoretical estimation, thus FLOPS computed using that could be larger than the maximum system throughput.
 2. The fwd latency listed in the top module's profile is directly captured at the module forward function in PyTorch, thus it's less than the fwd latency shown above which is captured in DeepSpeed.
 
 GPT2Model(
@@ -317,7 +317,7 @@ from deepspeed.profiling.flops_profiler import get_model_profile
 with torch.cuda.device(0):
     model = models.alexnet()
     batch_size = 256
-    macs, params = get_model_profile(model=model, # model
+    flops, macs, params = get_model_profile(model=model, # model
                                      input_res=(batch_size, 3, 224, 224), # input shape or input to the input_constructor
                                      input_constructor=None, # if specified, a constructor taking input_res is used as input to the model
                                      print_profile=True, # prints the model graph with the measured profile attached to each module
@@ -378,7 +378,8 @@ with torch.cuda.device(0):
 To profile model forward in a training workflow, use the `FlopsProfiler`class.
 The `FlopsProfiler`class provides the following methods:
   * `start_profile()` - starts profiling
-  * `get_total_flops(as_string=False)` - returns the total number of MACs in the model
+  * `get_total_flops(as_string=False)` - returns the total number of floating-point operations in the model
+  * `get_total_macs(as_string=False)` - returns the total number of MACs in the model
   * `get_total_params(as_string=False)` - returns the total number of parameters in the model
   * `print_model_profile(profile_step=1, module_depth=-1, top_modules=3, detailed=True, output_file=None)` - prints the model profile
   * `stop_profile()` - stops profiling. This stops the flops counting in the model.
@@ -408,8 +409,9 @@ for step, batch in enumerate(data_loader):
   # end profiling and print output
   if step == profile_step: # if using multi nodes, check global_rank == 0 as well
     prof.stop_profile()
-    flops = prof.get_total_flops(as_string=True)
-    params = prof.get_total_params(as_string=True)
+    flops = prof.get_total_flops()
+    macs = prof.get_total_macs()
+    params = prof.get_total_params()
     if print_profile:
         prof.print_model_profile(profile_step=profile_step)
     prof.end_profile()

--- a/tests/unit/test_flops_profiler.py
+++ b/tests/unit/test_flops_profiler.py
@@ -49,7 +49,7 @@ def test_flops_profiler_in_ds_training(tmpdir):
             model.backward(loss)
             model.step()
             if n == 3: break
-        assert model.flops_profiler.flops == 100
+        assert model.flops_profiler.flops == 200
         assert model.flops_profiler.params == 110
 
     _test_flops_profiler_in_ds_training(args, model, hidden_dim)
@@ -99,7 +99,7 @@ def test_flops_profiler_in_inference():
     mod = LeNet5(10)
     batch_size = 1024
     input = torch.randn(batch_size, 1, 32, 32)
-    macs, params = get_model_profile(
+    flops, macs, params = get_model_profile(
         mod,
         tuple(input.shape),
         print_profile=True,
@@ -110,6 +110,7 @@ def test_flops_profiler_in_inference():
         as_string=True,
         ignore_modules=None,
     )
-    print(macs, params)
-    assert macs == "439.56 MMACs"
+    print(flops, macs, params)
+    assert flops == "866.08 M"
+    assert macs == "426.52 MMACs"
     assert params == "61.71 k"


### PR DESCRIPTION
This PR adds support to count flops for the following operations:

1. PyTorch tensor methods such as torch.matmul, torch.mm, torch.addmm, torch.bmm, etc, and the corresponding torch.Tensor.xxx methods
2. other activations, e.g.  sigmoid, silu, and gelu
3. other norms

This PR also separates the MACs and flops counting. multiply-add operations are counted as 2 flops while others are counted as 1. FLOPS is computed using flops. 
