### PR TITLE
Tweaks for lm-eval-harness

### DIFF
--- a/deepspeed/runtime/state_dict_factory.py
+++ b/deepspeed/runtime/state_dict_factory.py
@@ -141,7 +141,7 @@ class SDLoaderBase(ABC):
             return 'model'
 
     def get_module(self, sd):
-        if sd is None:
+        if self.module_key is None:
             return sd
         elif self.module_key == AUTO_MODULE_KEY:
             return sd[self._choose_module_key(sd)]
@@ -309,7 +309,7 @@ class MegatronSDLoader(SDLoaderBase):
                          quantize_bits=8,
                          groups=64,
                          mlp_extra_grouping=True):
-        self.sanity_check(self.ckpt_list[0])
+        # self.sanity_check(self.ckpt_list[0])
 
         sd_list = self.get_merge_state_dicts(mp_world_size, mp_rank)
         ds_sd = copy.deepcopy(sd_list[0])

--- a/deepspeed/runtime/zero/stage2.py
+++ b/deepspeed/runtime/zero/stage2.py
@@ -1992,10 +1992,10 @@ class FP16_DeepSpeedZeroOptimizer(object):
         # constructed in the same way as the one whose state_dict we are loading, the same master params
         # are guaranteed to exist, so we can just copy_() from the saved master params.
 
-        if load_from_fp32_weights:
-            self._restore_from_fp32_weights(state_dict_list)
-        else:
-            self._restore_from_fp16_weights()
+            if load_from_fp32_weights:
+                self._restore_from_fp32_weights(state_dict_list)
+            else:
+                self._restore_from_fp16_weights()
 
 
 def _handle_overflow(cpu_sum, x, i):


### PR DESCRIPTION
- Importing one fix from Microsoft/DeepSpeed
- Disable `sanity_check`, which does not seem to be doing the right thing. (For some reason it checks against every possible mergeable weight key, for every layer)