### PR TITLE
wall_clock_breakdown disable failed in moe layer

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1014,11 +1014,11 @@ class DeepSpeedEngine(Module):
             for _, module in self.module.named_modules():
                 if isinstance(module, TopKGate):
                     self.gate_modules.append(module)
-                    if self.wall_clock_breakdown:
+                    if self.wall_clock_breakdown():
                         module.wall_clock_breakdown = True
                 if isinstance(module, MOELayer):
                     self.moe_layers.append(module)
-                    if self.wall_clock_breakdown:
+                    if self.wall_clock_breakdown():
                         module.wall_clock_breakdown = True
 
         if not self.pipeline_parallelism:


### PR DESCRIPTION
wall_clock_breakdown disable failed in moe layer due to incorrectly used a function as property in https://github.com/microsoft/DeepSpeed/blob/d14baad9401bc1de8c982c1b3590d91108c4bbf1/deepspeed/runtime/engine.py#L1017