### PR TITLE
Remove unused import of `ssl.OP_ENABLE_MIDDLEBOX_COMPAT`

### DIFF
--- a/deepspeed/autotuning/utils.py
+++ b/deepspeed/autotuning/utils.py
@@ -2,7 +2,6 @@ import re
 import collections.abc
 import os
 import json
-from ssl import OP_ENABLE_MIDDLEBOX_COMPAT
 from deepspeed.runtime.constants import GRADIENT_ACCUMULATION_STEPS, TRAIN_MICRO_BATCH_SIZE_PER_GPU
 import hjson
 import sys


### PR DESCRIPTION
An import of [`ssl.OP_ENABLE_MIDDLEBOX_COMPAT`](https://docs.python.org/3.10/library/ssl.html#ssl.OP_ENABLE_MIDDLEBOX_COMPAT) was added in commit 9caa74e, even though it is never used in the file. Although I can't tell why it was added originally, it does not seem to serve any purpose now.

The constant was not introduced until Python 3.8, and it is "only available with OpenSSL 1.1.1 and later". I am running a version of Python 3.9 on CentOS 7, which has OpenSSL 1.0.2 by default, so just having this import causes `deepspeed` to crash on import.
