### PR TITLE
Sparse Attention: Fix Triton errors

### DIFF
--- a/docs/_tutorials/sparse-attention.md
+++ b/docs/_tutorials/sparse-attention.md
@@ -4,7 +4,7 @@ title: "DeepSpeed  Sparse Attention"
 
 In this tutorial we describe how to use DeepSpeed Sparse Attention (SA) and its building-block kernels. The easiest way to use SA is through DeepSpeed launcher. We will describe this through an example in [How to use sparse attention with DeepSpeed launcher](#how-to-use-sparse-attention-with-deepspeed-launcher) section. But before that, we introduce modules provided by DeepSpeed SA in the [next](#sparse-attention-modules) section.
 
-**Note:** Currently DeepSpeed Sparse Attention can be used only on NVIDIA V100 GPU using Torch >= 1.5 and Cuda 10.1 or 10.2.
+**Note:** Currently, DeepSpeed Sparse Attention can be used only on NVIDIA V100 or A100 GPUs using Torch >= 1.6 and CUDA 10.1, 10.2, 11.0, or 11.1.
 {: .notice--warning}
 
 ## Sparse attention modules

--- a/requirements/requirements-sparse_attn.txt
+++ b/requirements/requirements-sparse_attn.txt
@@ -1,1 +1,1 @@
-triton
+triton==1.0.0


### PR DESCRIPTION
This commit fixes #1595 by downgrading Triton to 1.0.0. It also updates the note on the sparse attention tutorial to mention support for A100s and CUDA 11.0 and 11.1.

Tested manually with the script in #1595. Also confirmed the sparse attention unit tests passed.