### PR TITLE
Update exp_counts in top2gating

### DIFF
--- a/deepspeed/moe/sharded_moe.py
+++ b/deepspeed/moe/sharded_moe.py
@@ -280,6 +280,7 @@ def top2gating(logits: torch.Tensor,
 
     # gating decisions
     exp_counts = torch.sum(mask1, dim=0).detach().to('cpu')
+    exp_counts.add_(torch.sum(mask2, dim=0).detach().to('cpu'))
 
     # Compute l_aux
     me = torch.mean(gates, dim=0)


### PR DESCRIPTION
My understanding is the `exp_counts` should take the second gate activation into account. Correct me if wrong or if this is intentional.