### PR TITLE
Add `torchvision` to `requirements-dev.txt`

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -10,3 +10,4 @@ pytest-xdist
 recommonmark
 sphinx
 sphinx-rtd-theme
+torchvision


### PR DESCRIPTION
`torchvision` was reasonably removed from `requirements.txt` in #1178 because it is not used by the installed version of DeepSpeed. However, it is directly imported in `tests/`, so it should still be in the dev requirements.

I discovered this when running `pip install -U --upgrade-strategy eager -e '.[dev]'` to update my development environment. I got a pip warning because `torchvision` was not updated while `torch` was. This PR should allow dev installation and updates to now work properly.