### PR TITLE
[save_fp16_model] return status

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -3023,6 +3023,10 @@ class DeepSpeedEngine(Module):
             save_dir: Required. Directory for saving the model
             save_filename: Optional. Filename to save to. Defaults to ``pytorch_model.bin``
 
+        Returns:
+            ``True`` when a model has been saved, ``False`` otherwise. It will not be saved if
+            stage3_gather_fp16_weights_on_model_save is ``False``.
+
         Important: all processes must call this method and not just the process with rank 0. It is
         because the processes need to work in sync to gather the weights. This method will hang
         waiting to synchronize with other processes if it's called just for the process with rank 0.
@@ -3040,7 +3044,7 @@ class DeepSpeedEngine(Module):
                 logger.info(
                     f"Did not save the model {path} because `stage3_gather_fp16_weights_on_model_save` is False"
                 )
-                return
+                return False
         else:
             state_dict = self.module.state_dict()
 
@@ -3048,3 +3052,5 @@ class DeepSpeedEngine(Module):
             os.makedirs(save_dir, exist_ok=True)
             logger.info(f"Saving model weights to {path}")
             torch.save(state_dict, path)
+
+        return True


### PR DESCRIPTION
This PR adds a return status to `save_fp16_model`, so that the caller will now know whether the model was saved or not and do something as a fallback if it wasn't saved (e.g. save the checkpoint instead from which weights can be recovered later).

@tjruwase 