### PR TITLE
add segfault guard for cpu adam/adagrad

### DIFF
--- a/deepspeed/ops/adagrad/cpu_adagrad.py
+++ b/deepspeed/ops/adagrad/cpu_adagrad.py
@@ -70,11 +70,17 @@ class DeepSpeedCPUAdagrad(torch.optim.Optimizer):
             with torch.enable_grad():
                 loss = closure()
 
+        # intended device for step
+        device = torch.device('cpu')
+
         for group_id, group in enumerate(self.param_groups):
             for param_id, p in enumerate(group['params']):
 
                 if p.grad is None:
                     continue
+
+                assert p.device == device, f"CPUAdagrad param is on {p.device} and must be 'cpu', make " \
+                        "sure you enabled 'offload_optimizer': 'cpu' in your ZeRO config."
 
                 state = self.state[p]
                 # State initialization

--- a/deepspeed/ops/adam/cpu_adam.py
+++ b/deepspeed/ops/adam/cpu_adam.py
@@ -126,6 +126,9 @@ class DeepSpeedCPUAdam(torch.optim.Optimizer):
             with torch.enable_grad():
                 loss = closure()
 
+        # intended device for step
+        device = torch.device('cpu')
+
         # converting the fp16 params to a group of parameter
         if type(fp16_param_groups) is list:
             if type(fp16_param_groups[0]) is not list:
@@ -139,6 +142,9 @@ class DeepSpeedCPUAdam(torch.optim.Optimizer):
                 if p.grad is None:
                     continue
 
+                assert p.device == device, f"CPUAdam param is on {p.device} and must be 'cpu', make " \
+                        "sure you enabled 'offload_optimizer': 'cpu' in your ZeRO config."
+
                 state = self.state[p]
                 # State initialization
                 if len(state) == 0:
@@ -151,12 +157,12 @@ class DeepSpeedCPUAdam(torch.optim.Optimizer):
                     # gradient momentums
                     state['exp_avg'] = torch.zeros_like(p.data,
                                                         dtype=state_dtype,
-                                                        device='cpu')
+                                                        device=device)
                     #memory_format=torch.preserve_format)
                     # gradient variances
                     state['exp_avg_sq'] = torch.zeros_like(p.data,
                                                            dtype=state_dtype,
-                                                           device='cpu')
+                                                           device=device)
                     #memory_format=torch.preserve_format)
 
                 state['step'] += 1

--- a/tests/unit/test_cpu_adagrad.py
+++ b/tests/unit/test_cpu_adagrad.py
@@ -123,3 +123,14 @@ def test_cpu_adagrad_opt_sparse_embedding(model_size, vocabulary_size, dim):
         optimizer1.step()
 
     check_equal(param, param1, atol=1e-2, verbose=True)
+
+
+def test_cpu_adam_gpu_error():
+    model_size = 64
+    device = 'cuda:0'
+    param = torch.nn.Parameter(torch.randn(model_size, device=device))
+    optimizer = DeepSpeedCPUAdagrad([param])
+
+    param.grad = torch.randn(model_size, device=device)
+    with pytest.raises(AssertionError):
+        optimizer.step()

--- a/tests/unit/test_cpu_adam.py
+++ b/tests/unit/test_cpu_adam.py
@@ -60,3 +60,15 @@ def test_cpu_adam_opt(model_size):
 
     check_equal(param, param1, atol=1e-2, verbose=True)
     check_equal(param, param2.cpu(), atol=1e-2, verbose=True)
+
+
+def test_cpu_adam_gpu_error():
+    model_size = 64
+    from deepspeed.ops.adam import DeepSpeedCPUAdam
+    device = 'cuda:0'
+    param = torch.nn.Parameter(torch.randn(model_size, device=device))
+    optimizer = DeepSpeedCPUAdam([param])
+
+    param.grad = torch.randn(model_size, device=device)
+    with pytest.raises(AssertionError):
+        optimizer.step()


### PR DESCRIPTION
In some instances, we've seen users instantiate CPUAdam/Adagrad without using zero-offload. In this case if the params are not moved to the CPU our kernel will segfault with no useful error on what is happening. This PR adds an assert to ensure the user knows there is an issue before the segfault would occur.

One specific way we've seen this occur is when using the pytorch-lightning DeepSpeed plug-in. If a user specificizes `DeepSpeedCPUAdam` they must also pass `offload_optimizer=True` into the plugin if they are not using an explicit ds_config.json. Such as: `pytorch_lightning.plugins.training_type.DeepSpeedPlugin(..., offload_optimizer=True)`. We saw this in lightning v1.3.8, not sure if newer versions handle this in a different way though.

/cc @javier-alvarez, @SeanNaren 