### PR TITLE
add -lcurand to fix torch-nightly issue w. JIT

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -556,6 +556,9 @@ class CUDAOpBuilder(OpBuilder):
 
 
 class TorchCPUOpBuilder(CUDAOpBuilder):
+    def extra_ldflags(self):
+        return ['-lcurand']
+
     def cxx_args(self):
         import torch
         CUDA_LIB64 = os.path.join(torch.utils.cpp_extension.CUDA_HOME, "lib64")


### PR DESCRIPTION
Partial fix for #1625. This should allow torch-nightly builds to JIT compile the CPU[Adam|Agagrad] ops. There still exists an issue with pre-compiling the ops which is currently being discussed here: https://github.com/pytorch/pytorch/issues/69666#issuecomment-994042076

/cc @stas00 