### PR TITLE
Add additional arguments to launch routine

### DIFF
--- a/deepspeed/launcher/multinode_runner.py
+++ b/deepspeed/launcher/multinode_runner.py
@@ -3,6 +3,7 @@ import sys
 import shutil
 import subprocess
 import warnings
+from shlex import quote
 from abc import ABC, abstractmethod
 
 from ..utils import logger
@@ -69,7 +70,7 @@ class PDSHRunner(MultiNodeRunner):
 
         exports = ""
         for key, val in self.exports.items():
-            exports += f"export {key}={val}; "
+            exports += f"export {key}={quote(val)}; "
 
         # https://linux.die.net/man/1/pdsh
         # %n will be replaced by pdsh command
@@ -85,6 +86,12 @@ class PDSHRunner(MultiNodeRunner):
             f"--master_addr={self.args.master_addr}",
             f"--master_port={self.args.master_port}"
         ]
+        if self.args.no_python:
+            deepspeed_launch.append("--no_python")
+        if self.args.module:
+            deepspeed_launch.append("--module")
+        if self.args.no_local_rank:
+            deepspeed_launch.append("--no_local_rank")
 
         return pdsh_cmd_args + deepspeed_launch + [self.user_script
                                                    ] + self.user_arguments
@@ -133,9 +140,13 @@ class OpenMPIRunner(MultiNodeRunner):
 
         export_cmd = []
         for k, v in self.exports.items():
-            export_cmd += ['-x', f'{k}={v}']
+            export_cmd += ['-x', f'{k}={quote(v)}']
 
-        python_exec = [sys.executable, "-u"]
+        python_exec = []
+        if not self.args.no_python:
+            python_exec = [sys.executable, "-u"]
+            if self.args.module:
+                python_exec.append("-m")
 
         return mpirun_cmd + export_cmd + python_exec + [self.user_script
                                                         ] + self.user_arguments
@@ -219,9 +230,13 @@ class MVAPICHRunner(MultiNodeRunner):
 
         export_cmd = []
         for k, v in self.exports.items():
-            export_cmd += ['-env', f'{k}={v}']
+            export_cmd += ['-env', f'{k}={quote(v)}']
 
-        python_exec = [sys.executable, "-u"]
+        python_exec = []
+        if not self.args.no_python:
+            python_exec = [sys.executable, "-u"]
+            if self.args.module:
+                python_exec.append("-m")
 
         return mpirun_cmd + export_cmd + python_exec + [self.user_script
                                                         ] + self.user_arguments

--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -25,7 +25,7 @@ from ..utils import logger
 from ..autotuning import Autotuner
 
 DLTS_HOSTFILE = "/job/hostfile"
-EXPORT_ENVS = ["NCCL", "PYTHON", "MV2", 'UCX']
+EXPORT_ENVS = ["NCCL", "PYTHON", "MV2", "UCX"]
 DEEPSPEED_ENVIRONMENT_NAME = ".deepspeed_env"
 DEEPSPEED_ENVIRONMENT_PATHS = [os.path.expanduser("~"), '.']
 PDSH_MAX_FAN_OUT = 1024
@@ -104,6 +104,22 @@ def parse_args(args=None):
                         type=str,
                         help="(optional) pass launcher specific arguments as a "
                         "single quoted argument.")
+
+    parser.add_argument("--module",
+                        action="store_true",
+                        help="Change each process to interpret the launch "
+                        "script as a Python module, executing with the same "
+                        "behavior as 'python -m'.")
+
+    parser.add_argument("--no_python",
+                        action="store_true",
+                        help="Skip prepending the training script with "
+                        "'python' - just execute it directly.")
+
+    parser.add_argument("--no_local_rank",
+                        action="store_true",
+                        help="Do not pass local_rank as an argument when calling "
+                        "the user's training script.")
 
     parser.add_argument("--force_multi",
                         action="store_true",
@@ -359,6 +375,12 @@ def main(args=None):
             f"--master_addr={args.master_addr}",
             f"--master_port={args.master_port}"
         ]
+        if args.no_python:
+            deepspeed_launch.append("--no_python")
+        if args.module:
+            deepspeed_launch.append("--module")
+        if args.no_local_rank:
+            deepspeed_launch.append("--no_local_rank")
         cmd = deepspeed_launch + [args.user_script] + args.user_args
     else:
         args.launcher = args.launcher.lower()


### PR DESCRIPTION
This PR adds additional arguments to the launcher to support more flexible calls to user script.  Specifically, arguments are added to support calling a module, calling without `python`, and calling without the `local_rank` argument.  There are also small formatting improvements as well as export of some additional info in `launch.py`.