### PR TITLE
Fix memory leak w. activation checkpointing

### DIFF
--- a/deepspeed/runtime/activation_checkpointing/checkpointing.py
+++ b/deepspeed/runtime/activation_checkpointing/checkpointing.py
@@ -718,6 +718,11 @@ class CheckpointFunction(torch.autograd.Function):
 
         torch.autograd.backward(output_tensors, grad_tensors)
 
+        # Force clear our stashed tensors to prevent a memory leak in certain scenarios
+        ctx.deepspeed_saved_tensors = None
+        ctx.non_tensor_args = None
+        ctx.tensor_flags = None
+
         see_memory_usage("After backward checkpointing code after backward", force=False)
 
         if PROFILE_TIME:


### PR DESCRIPTION
In some scenarios we observe a GPU memory leak when activation checkpointing is enabled. This PR was able to address the issue in these scenarios by force clearing the stashed tensors after the backward has completed.

Thanks goes to @tjruwase for the insight on the fix!