### PR TITLE
Fixes for a clean DeepSpeed build on ROCm

### DIFF
--- a/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups.h
+++ b/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups.h
@@ -35,7 +35,7 @@ THE SOFTWARE.
 //#if __cplusplus
 #if __cplusplus && defined(__clang__) && defined(__HIP__)
 #include <hip/hcc_detail/hip_cooperative_groups_helper.h>
-#if ROCM_VERSION_MINOR < 4
+#if ROCM_VERSION_MAJOR < 5 and ROCM_VERSION_MINOR < 4
 #include <hip/hcc_detail/device_functions.h>
 #endif
 namespace cooperative_groups {

--- a/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups_helper.h
+++ b/csrc/includes/patch/hip/hcc_detail/hip_cooperative_groups_helper.h
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
 #if __cplusplus
 
-#if ROCM_VERSION_MINOR < 4
+#if ROCM_VERSION_MAJOR < 5 and ROCM_VERSION_MINOR < 4
 #include <hip/hcc_detail/device_functions.h>
 #include <hip/hcc_detail/hip_runtime_api.h>
 #else

--- a/csrc/lamb/fused_lamb_cuda_kernel.cu
+++ b/csrc/lamb/fused_lamb_cuda_kernel.cu
@@ -508,7 +508,7 @@ void fused_lamb_cuda(at::Tensor& p,
                         lamb_coeff.data<scalar_t>());
             }));
     }
-    THCudaCheck(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
 }
 
 // template __device__ void reduce_two_vectors_in_register<float,512>(float a, float b, float* g_a,


### PR DESCRIPTION
These changes are required for an error free DeepSpeed build on ROCm >= 5.0 (Reference: https://github.com/ROCmSoftwarePlatform/DeepSpeed/pull/44) 

THCudaCheck is deprecated and PyTorch now considers THCDeviceUtils.cuh and THC/THC. Hence, THCudaCheck  is replaced with C10_CUDA_CHECK. (Reference: https://github.com/ROCmSoftwarePlatform/DeepSpeed/pull/51)

