### PR TITLE
Add a very simple PyTorch Lightning test!

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,3 +101,30 @@ jobs:
           # find reqs used in ds integration tests
           find examples/pytorch  -regextype posix-egrep -regex '.*(language-modeling|question-answering|summarization|image-classification|text-classification|translation).*/requirements.txt' -exec pip install -r {} \;
           TORCH_EXTENSIONS_DIR=./torch-extensions RUN_SLOW=1 pytest --color=yes --durations=0 --verbose tests/deepspeed
+
+  nv-lightning-v100:
+    runs-on: [self-hosted, nvidia, torch18, v100]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: environment
+        run: |
+          nvidia-smi
+          which python
+          python --version
+          which nvcc
+          nvcc --version
+          pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+          python -c "import torch; print('torch:', torch.__version__, torch)"
+          python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
+      - name: Install deepspeed
+        run: |
+          pip install .[dev,autotuning]
+          ds_report
+      - name: PyTorch Lightning Tests
+        run: |
+          if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
+          pip install pytorch-lightning
+          cd tests
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose lightning/

--- a/tests/lightning/test_simple.py
+++ b/tests/lightning/test_simple.py
@@ -1,8 +1,7 @@
 import torch
-from torch.utils.data import DataLoader, Dataset
-
 from pytorch_lightning import LightningModule, Trainer
-from pytorch_lightning.strategies import DeepSpeedStrategy
+from pytorch_lightning.plugins import DeepSpeedPlugin
+from torch.utils.data import DataLoader, Dataset
 
 
 class RandomDataset(Dataset):
@@ -52,5 +51,5 @@ def test_lightning_model():
     """Test that DeepSpeed works with a simple LightningModule and LightningDataModule."""
 
     model = BoringModel()
-    trainer = Trainer(strategy=DeepSpeedStrategy(), max_epochs=1, precision=16, gpus=1)
+    trainer = Trainer(strategy=DeepSpeedPlugin(), max_epochs=1, precision=16, gpus=1)
     trainer.fit(model)

--- a/tests/lightning/test_simple.py
+++ b/tests/lightning/test_simple.py
@@ -52,5 +52,5 @@ def test_lightning_model():
     """Test that DeepSpeed works with a simple LightningModule and LightningDataModule."""
 
     model = BoringModel()
-    trainer = Trainer(strategy=DeepSpeedStrategy(), precision=16, gpus=1)
+    trainer = Trainer(strategy=DeepSpeedStrategy(), max_epochs=1, precision=16, gpus=1)
     trainer.fit(model)

--- a/tests/lightning/test_simple.py
+++ b/tests/lightning/test_simple.py
@@ -1,0 +1,56 @@
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from pytorch_lightning import LightningModule, Trainer
+from pytorch_lightning.strategies import DeepSpeedStrategy
+
+
+class RandomDataset(Dataset):
+    def __init__(self, size, length):
+        self.len = length
+        self.data = torch.randn(length, size)
+
+    def __getitem__(self, index):
+        return self.data[index]
+
+    def __len__(self):
+        return self.len
+
+
+class BoringModel(LightningModule):
+    def __init__(self):
+        super().__init__()
+        self.layer = torch.nn.Linear(32, 2)
+
+    def forward(self, x):
+        return self.layer(x)
+
+    def training_step(self, batch, batch_idx):
+        loss = self(batch).sum()
+        self.log("train_loss", loss)
+        return {"loss": loss}
+
+    def validation_step(self, batch, batch_idx):
+        loss = self(batch).sum()
+        self.log("valid_loss", loss)
+
+    def test_step(self, batch, batch_idx):
+        loss = self(batch).sum()
+        self.log("test_loss", loss)
+
+    def configure_optimizers(self):
+        return torch.optim.SGD(self.layer.parameters(), lr=0.1)
+
+    def train_dataloader(self):
+        return DataLoader(RandomDataset(32, 64), batch_size=2)
+
+    def val_dataloader(self):
+        return DataLoader(RandomDataset(32, 64), batch_size=2)
+
+
+def test_lightning_model():
+    """Test that DeepSpeed works with a simple LightningModule and LightningDataModule."""
+
+    model = BoringModel()
+    trainer = Trainer(strategy=DeepSpeedStrategy(), precision=16, gpus=1)
+    trainer.fit(model)


### PR DESCRIPTION
Related #1674.

As discussed offline with @jeffra would be neat to have some simple Lightning tests to ensure we remain compatible together :)

This test is extremely simple, testing a toy model/dataset using the Lightning DeepSpeed plugin which wraps the DeepSpeed library. It's not a huge test as I didn't want to clog up CI time or start adding extensive testing before we get something rolling.

Let me know if I've done the right thing here cc @jeffra @tjruwase @borda