### PR TITLE
launcher save pid + require manual triton install for sparse-attn

### DIFF
--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -441,7 +441,7 @@ def main(args=None):
     if args.save_pid:
         main_pid = os.getpid()
         launcher_pid = result.pid
-        pid_file = os.path.join(PID_FILE_BASEPATH, f"{main_pid}.ds")
+        pid_file = os.path.join(PID_FILE_BASEPATH, f"{main_pid}.deepspeed")
         with open(pid_file, 'w') as fd:
             fd.write(f"{launcher_pid}")
 

--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -29,6 +29,7 @@ EXPORT_ENVS = ["NCCL", "PYTHON", "MV2", "UCX"]
 DEEPSPEED_ENVIRONMENT_NAME = ".deepspeed_env"
 DEEPSPEED_ENVIRONMENT_PATHS = [os.path.expanduser("~"), '.']
 PDSH_MAX_FAN_OUT = 1024
+PID_FILE_BASEPATH = "/tmp"
 
 
 def parse_args(args=None):
@@ -125,6 +126,13 @@ def parse_args(args=None):
                         action="store_true",
                         help="Force multi-node launcher mode, helps in cases where user "
                         "wants to launch on single remote node.")
+
+    parser.add_argument(
+        "--save_pid",
+        action="store_true",
+        help="Save file containing launcher process id (pid) at /tmp/<main-pid>.ds, "
+        "where <main-pid> is the pid of the first process that invoked `deepspeed`. "
+        "Useful when launching deepspeed processes programmatically.")
 
     parser.add_argument(
         "--autotuning",
@@ -428,7 +436,20 @@ def main(args=None):
 
     logger.info(f"cmd = {' '.join(cmd)}")
     result = subprocess.Popen(cmd, env=env)
+
+    pid_file = None
+    if args.save_pid:
+        main_pid = os.getpid()
+        launcher_pid = result.pid
+        pid_file = os.path.join(PID_FILE_BASEPATH, f"{main_pid}.ds")
+        with open(pid_file, 'w') as fd:
+            fd.write(f"{launcher_pid}")
+
     result.wait()
+
+    if args.save_pid and pid_file is not None:
+        # clean-up saved pid file
+        os.remove(pid_file)
 
     # In case of failure must propagate the error-condition back to the caller (usually shell). The
     # actual error and traceback should have been printed in the subprocess, so in order to avoid

--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -449,7 +449,8 @@ def main(args=None):
 
     if args.save_pid and pid_file is not None:
         # clean-up saved pid file
-        os.remove(pid_file)
+        if os.path.isfile(pid_file):
+            os.remove(pid_file)
 
     # In case of failure must propagate the error-condition back to the caller (usually shell). The
     # actual error and traceback should have been printed in the subprocess, so in order to avoid

--- a/op_builder/sparse_attn.py
+++ b/op_builder/sparse_attn.py
@@ -3,6 +3,7 @@ Copyright 2020 The Microsoft DeepSpeed Team
 """
 import warnings
 from .builder import OpBuilder
+from packaging import version as pkg_version
 
 
 class SparseAttnBuilder(OpBuilder):
@@ -51,5 +52,21 @@ class SparseAttnBuilder(OpBuilder):
             self.warning(
                 f'{self.NAME} requires a torch version >= 1.5 but detected {TORCH_MAJOR}.{TORCH_MINOR}'
             )
+
+        try:
+            import triton
+        except ImportError:
+            # auto-install of triton is broken on some systems, reverting to manual install for now
+            # see this issue: https://github.com/microsoft/DeepSpeed/issues/1710
+            self.warning(
+                f"please install triton==1.0.0 if you want to use sparse attention")
+            return False
+
+        installed_triton = pkg_version.parse(triton.__version__)
+        if installed_triton != pkg_version.parse("1.0.0"):
+            self.warning(
+                f"using untested triton version ({installed_triton}), only 1.0.0 is known to be compatible"
+            )
+            return False
 
         return super().is_compatible(verbose) and torch_compatible and cuda_compatible


### PR DESCRIPTION
When launching deepspeed processes programmatically it's useful to save the top-level launcher's process id (pid). This allows one method for cleaning up runner processes since if we kill the top-level launcher process than the children processes will be killed as well (on that worker).

Also removing auto-install of `triton` due to several issues with the triton 1.0.0 install we've seen (e.g., #1710).