### PR TITLE
[zero3] remove debug print

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -277,7 +277,7 @@ class PartitionedParameterCoordinator:
             self.__param_order = tuple(self.__param_order)  # freeze
             self.trace_complete = True
             print_rank_0(f"completed trace: {[m.id for m in self.__submodule_order]}",
-                         force=True)
+                         force=False)
 
         self.__param_queue = collections.deque(self.__param_order)  # reset fetch queue
         self.__most_recent_step_id_param_fetched_for = collections.defaultdict(


### PR DESCRIPTION
started getting:

```
completed trace: [2, 441, 441, 441, 439, 5, 7, 14, 8, 9, 10, 11, 13, 12, 15, 16, 22, 17, 18, 19, 21, 20, 23, 24, 26, 32, 27, 28, 29, 30, 31, 33, 34, 40, 35, 36, 37, 39, 38, 41, 42, 44, 50, 45, 46, 47, 48, 49, 51, 52, 58, 53, 54, 55, 57, 56, 59, 60, 62, 68, 63, 64, 65, 66, 67, 69, 70, 76, 71, 72, 73, 75, 74, 77, 78, 80, 86, 81, 82, 83, 84, 85, 87, 88, 94, 89, 90, 91, 93, 92, 95, 96, 98, 104, 99, 100, 101, 102, 103, 105, 106, 112, 107, 108, 109, 111, 110, 113, 114, 116, 122, 117, 118, 119, 120, 121, 123, 124, 130, 125, 126, 127, 129, 128, 131, 132, 134, 140, 135, 136, 137, 138, 139, 141, 142, 148, 143, 144, 145, 147, 146, 149, 150, 152, 158, 153, 154, 155, 156, 157, 159, 160, 166, 161, 162, 163, 165, 164, 167, 168, 170, 176, 171, 172, 173, 174, 175, 177, 178, 184, 179, 180, 181, 183, 182, 185, 186, 188, 194, 189, 190, 191, 192, 193, 195, 196, 202, 197, 198, 199, 201, 200, 203, 204, 206, 212, 207, 208, 209, 210, 211, 213, 214, 220, 215, 216, 217, 219, 218, 221, 222, 224, 230, 225, 226, 227, 228, 229, 231, 232, 238, 233, 234, 235, 237, 236, 239, 240, 242, 248, 243, 244, 245, 246, 247, 249, 250, 256, 251, 252, 253, 255, 254, 257, 258, 260, 266, 261, 262, 263, 264, 265, 267, 268, 274, 269, 270, 271, 273, 272, 275, 276, 278, 284, 279, 280, 281, 282, 283, 285, 286, 292, 287, 288, 289, 291, 290, 293, 294, 296, 302, 297, 298, 299, 300, 301, 303, 304, 310, 305, 306, 307, 309, 308, 311, 312, 314, 320, 315, 316, 317, 318, 319, 321, 322, 328, 323, 324, 325, 327, 326, 329, 330, 332, 338, 333, 334, 335, 336, 337, 339, 340, 346, 341, 342, 343, 345, 344, 347, 348, 350, 356, 351, 352, 353, 354, 355, 357, 358, 364, 359, 360, 361, 363, 362, 365, 366, 368, 374, 369, 370, 371, 372, 373, 375, 376, 382, 377, 378, 379, 381, 380, 383, 384, 386, 392, 387, 388, 389, 390, 391, 393, 394, 400, 395, 396, 397, 399, 398, 401, 402, 404, 410, 405, 406, 407, 408, 409, 411, 412, 418, 413, 414, 415, 417, 416, 419, 420, 422, 428, 423, 424, 425, 426, 427, 429, 430, 436, 431, 432, 433, 435, 434, 437, 438, 439, 0, 440, 441, 441, 441, 1069, 443, 445, 452, 446, 447, 448, 449, 451, 450, 453, 454, 460, 455, 456, 457, 458, 459, 461, 462, 468, 463, 464, 465, 467, 466, 469, 470, 472, 478, 473, 474, 475, 476, 477, 479, 480, 486, 481, 482, 483, 484, 485, 487, 488, 494, 489, 490, 491, 493, 492, 495, 496, 498, 504, 499, 500, 501, 502, 503, 505, 506, 512, 507, 508, 509, 510, 511, 513, 514, 520, 515, 516, 517, 519, 518, 521, 522, 524, 530, 525, 526, 527, 528, 529, 531, 532, 538, 533, 534, 535, 536, 537, 539, 540, 546, 541, 542, 543, 545, 544, 547, 548, 550, 556, 551, 552, 553, 554, 555, 557, 558, 564, 559, 560, 561, 562, 563, 565, 566, 572, 567, 568, 569, 571, 570, 573, 574, 576, 582, 577, 578, 579, 580, 581, 583, 584, 590, 585, 586, 587, 588, 589, 591, 592, 598, 593, 594, 595, 597, 596, 599, 600, 602, 608, 603, 604, 605, 606, 607, 609, 610, 616, 611, 612, 613, 614, 615, 617, 618, 624, 619, 620, 621, 623, 622, 625, 626, 628, 634, 629, 630, 631, 632, 633, 635, 636, 642, 637, 638, 639, 640, 641, 643, 644, 650, 645, 646, 647, 649, 648, 651, 652, 654, 660, 655, 656, 657, 658, 659, 661, 662, 668, 663, 664, 665, 666, 667, 669, 670, 676, 671, 672, 673, 675, 674, 677, 678, 680, 686, 681, 682, 683, 684, 685, 687, 688, 694, 689, 690, 691, 692, 693, 695, 696, 702, 697, 698, 699, 701, 700, 703, 704, 706, 712, 707, 708, 709, 710, 711, 713, 714, 720, 715, 716, 717, 718, 719, 721, 722, 728, 723, 724, 725, 727, 726, 729, 730, 732, 738, 733, 734, 735, 736, 737, 739, 740, 746, 741, 742, 743, 744, 745, 747, 748, 754, 749, 750, 751, 753, 752, 755, 756, 758, 764, 759, 760, 761, 762, 763, 765, 766, 772, 767, 768, 769, 770, 771, 773, 774, 780, 775, 776, 777, 779, 778, 781, 782, 784, 790, 785, 786, 787, 788, 789, 791, 792, 798, 793, 794, 795, 796, 797, 799, 800, 806, 801, 802, 803, 805, 804, 807, 808, 810, 816, 811, 812, 813, 814, 815, 817, 818, 824, 819, 820, 821, 822, 823, 825, 826, 832, 827, 828, 829, 831, 830, 833, 834, 836, 842, 837, 838, 839, 840, 841, 843, 844, 850, 845, 846, 847, 848, 849, 851, 852, 858, 853, 854, 855, 857, 856, 859, 860, 862, 868, 863, 864, 865, 866, 867, 869, 870, 876, 871, 872, 873, 874, 875, 877, 878, 884, 879, 880, 881, 883, 882, 885, 886, 888, 894, 889, 890, 891, 892, 893, 895, 896, 902, 897, 898, 899, 900, 901, 903, 904, 910, 905, 906, 907, 909, 908, 911, 912, 914, 920, 915, 916, 917, 918, 919, 921, 922, 928, 923, 924, 925, 926, 927, 929, 930, 936, 931, 932, 933, 935, 934, 937, 938, 940, 946, 941, 942, 943, 944, 945, 947, 948, 954, 949, 950, 951, 952, 953, 955, 956, 962, 957, 958, 959, 961, 960, 963, 964, 966, 972, 967, 968, 969, 970, 971, 973, 974, 980, 975, 976, 977, 978, 979, 981, 982, 988, 983, 984, 985, 987, 986, 989, 990, 992, 998, 993, 994, 995, 996, 997, 999, 1000, 1006, 1001, 1002, 1003, 1004, 1005, 1007, 1008, 1014, 1009, 1010, 1011, 1013, 1012, 1015, 1016, 1018, 1024, 1019, 1020, 1021, 1022, 1023, 1025, 1026, 1032, 1027, 1028, 1029, 1030, 1031, 1033, 1034, 1040, 1035, 1036, 1037, 1039, 1038, 1041, 1042, 1044, 1050, 1045, 1046, 1047, 1048, 1049, 1051, 1052, 1058, 1053, 1054, 1055, 1056, 1057, 1059, 1060, 1066, 1061, 1062, 1063, 1065, 1064, 1067, 1068, 1069, 1070]
```

This PR disables this debug print

@jeffra