### PR TITLE
[config] fix assert message

### DIFF
--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -995,8 +995,8 @@ class DeepSpeedConfig(object):
         ), f"Gradient accumulation steps: {grad_acc} has to be greater than 0"
 
         assert train_batch == micro_batch * grad_acc * self.world_size, (
-            f"Check batch related parameters. train_batch_size is not equal"
-            " to micro_batch_per_gpu * gradient_acc_step * world_size"
+            f"Check batch related parameters. train_batch_size is not equal "
+            "to micro_batch_per_gpu * gradient_acc_step * world_size "
             f"{train_batch} != {micro_batch} * {grad_acc} * {self.world_size}"
         )
 


### PR DESCRIPTION
Currently the user gets:
```
train_batch_size is not equal to micro_batch_per_gpu * gradient_acc_step * world_size2 != 1 * 1 * 1
                                                                                 ^^^^^^^^^^
```
This PR is adding a missing space

@jeffra 