### PR TITLE
[zero3] remove debug print 2

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -585,8 +585,10 @@ class DeepSpeedZeroOptimizer_Stage3(object):
 
         see_memory_usage("Stage 3 initialize beginning", force=False)
 
+        print_rank_0(f"initialized {__class__.__name__} with args: {locals()}",
+                     force=False)
+
         if dist.get_rank() == 0:
-            logger.info(f"initialized {__class__.__name__} with args: {locals()}")
             logger.info(f"Reduce bucket size {reduce_bucket_size}")
             logger.info(f"Allgather bucket size {prefetch_bucket_size}")
         # The fused optimizer does all the work. We need this layer for two reason:


### PR DESCRIPTION
This PR makes the really loud debug print that was added in the bf16 merge, to be just that a debug print and disable it by default.

The way it was manifesting during startup.

```
initialized DeepSpeedZeroOptimizer_Stage3 with args: {'self': <deepspeed.runtime.zero.stage3.DeepSpeedZeroOptimizer_Stage3 object at 0x7f8ae145d340>, 'module': T5ForConditionalGeneration(
  (shared): Embedding(32128, 2048)
```

and dumping the whole model

and then continuing with more new dumps:
```
'init_optimizer': <deepspeed.runtime.utils.DummyOptim object at 0x7f8ae145d040>, 'timers': None, 'ds_config': {'fp16': {'enabled': True, 'loss_scale': 0, 'loss_scale_window': 1000, 'initial_scale_power': 16, 'hysteresis': 2, 'min_loss_scale': 1}, 'zero_optimization': {'stage': 3, 'overlap_comm': True, 'contiguous_gradients': True, 'sub_group_size': 1000000000.0, 'stage3_max_live_parameters': 1000000000.0, 'stage3_max_reuse_distance': 1000000000.0, 'stage3_gather_fp16_weights_on_model_save': True}, 'gradient_accumulation_steps': 1, 'gradient_clipping': 0, 'steps_per_print': 2000, 'train_batch_size': 2, 'train_micro_batch_size_per_gpu': 1, 'wall_clock_breakdown': False}, 'static_loss_scale': 0, 'dynamic_loss_scale': True, 'dynamic_loss_args': {'init_scale': 65536, 'scale_window': 1000, 'delayed_shift': 2, 'min_scale': 1}, 'verbose': True, 'contiguous_gradients': True, 'reduce_bucket_size': 500000000, 'prefetch_bucket_size': 50000000, 'max_reuse_distance': 1000000000.0, 'max_live_parameters': 1000000000.0, 'param_persistence_threshold': 100000, 'dp_process_group': <torch._C._distributed_c10d.ProcessGroupNCCL object at 0x7f8ae14645f0>, 'reduce_scatter': True, 'overlap_comm': True, 'offload_optimizer_config': None, 'offload_param_config': None, 'sub_group_size': 1000000000.0, 'mpu': None, 'clip_grad': 0, 'communication_data_type': torch.float16, 'postscale_gradients': True, 'gradient_predivide_factor': 1.0, 'gradient_accumulation_steps': 1, 'elastic_checkpoint': False, 'aio_config': {'block_size': 1048576, 'queue_depth': 8, 'thread_count': 1, 'single_submit': False, 'overlap_events': True}, '__class__': <class 'deepspeed.runtime.zero.stage3.DeepSpeedZeroOptimizer_Stage3'>}
```

Thanks

@tjruwase 