### PR TITLE
[distributed] print dist init only on rank 0

### DIFF
--- a/deepspeed/utils/distributed.py
+++ b/deepspeed/utils/distributed.py
@@ -42,7 +42,7 @@ def init_distributed(dist_backend="nccl",
             mpi_discovery(distributed_port=distributed_port, verbose=verbose)
 
     if not torch.distributed.is_initialized():
-        if verbose:
+        if verbose and int(os.getenv('RANK', '0')) == 0:
             logger.info(
                 "Initializing torch distributed with backend: {}".format(dist_backend))
         assert isinstance(timeout, timedelta)


### PR DESCRIPTION
Currently, this gets printed on each gpu:
```
[2022-01-30 13:17:54,417] [INFO] [distributed.py:47:init_distributed] Initializing torch distributed with backend: nccl
```
which is a uninformative noise - this PR changes it to print on rank0 only.

@tjruwase 