### PR TITLE
Loosen requirement on packaging dependency

### DIFF
--- a/op_builder/sparse_attn.py
+++ b/op_builder/sparse_attn.py
@@ -62,8 +62,14 @@ class SparseAttnBuilder(OpBuilder):
                 f"please install triton==1.0.0 if you want to use sparse attention")
             return False
 
-        installed_triton = pkg_version.parse(triton.__version__)
-        if installed_triton != pkg_version.parse("1.0.0"):
+        if pkg_version:
+            installed_triton = pkg_version.parse(triton.__version__)
+            triton_mismatch = installed_triton != pkg_version.parse("1.0.0")
+        else:
+            installed_triton = triton.__version__
+            triton_mismatch = installed_triton != "1.0.0"
+
+        if triton_mismatch:
             self.warning(
                 f"using untested triton version ({installed_triton}), only 1.0.0 is known to be compatible"
             )

--- a/op_builder/sparse_attn.py
+++ b/op_builder/sparse_attn.py
@@ -3,7 +3,11 @@ Copyright 2020 The Microsoft DeepSpeed Team
 """
 import warnings
 from .builder import OpBuilder
-from packaging import version as pkg_version
+
+try:
+    from packaging import version as pkg_version
+except ImportError:
+    pkg_version = None
 
 
 class SparseAttnBuilder(OpBuilder):


### PR DESCRIPTION
We've been running into some environments that don't already have `packaging` installed and it's causing install issues. This will fall back to string comparison if `packaging` doesn't exist at install time.