### PR TITLE
THH header fix

### DIFF
--- a/csrc/lamb/fused_lamb_cuda_kernel.cu
+++ b/csrc/lamb/fused_lamb_cuda_kernel.cu
@@ -8,7 +8,6 @@
 #include "ATen/cuda/CUDAContext.h"
 #include "ATen/cuda/detail/IndexUtils.cuh"
 //#include "ATen/Type.h"
-#include <THC/THCGeneral.h>
 #include "ATen/AccumulateType.h"
 
 #include <iostream>


### PR DESCRIPTION
Filing this PR to avoid 'THH/THHGeneral.h' file not found error error during DeepSpeed build.

Used rocm/pytorch:rocm4.5.2_ubuntu18.04_py3.8_pytorch_1.9.0 (with an old PyTorch vesion) for testing DeepSpeed. There were no issues.

This issue occurs as THC/THCGeneral.h is deprecated. Reference: https://github.com/pytorch/pytorch/pull/66391/files

cc: @jithunnair-amd 