### PR TITLE
Add concurrency policy to CI workflow

### DIFF
--- a/.github/workflows/amd.yml
+++ b/.github/workflows/amd.yml
@@ -11,6 +11,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     # The type of runner that the job will run on

--- a/.github/workflows/amd.yml
+++ b/.github/workflows/amd.yml
@@ -12,7 +12,7 @@ on:
       - 'docs/**'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -10,7 +10,7 @@ on:
       '**'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -9,6 +9,10 @@ on:
     branches:
       '**'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   # formatting and basic install on cpu-only machine

--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -11,6 +11,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     runs-on: [self-hosted, nvidia, torch18, v100]

--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -12,7 +12,7 @@ on:
       - 'docs/**'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/nv-torch12-p40.yml
+++ b/.github/workflows/nv-torch12-p40.yml
@@ -11,6 +11,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     runs-on: [self-hosted, nvidia, torch12, p40]

--- a/.github/workflows/nv-torch12-p40.yml
+++ b/.github/workflows/nv-torch12-p40.yml
@@ -12,7 +12,7 @@ on:
       - 'docs/**'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/nv-torch18-v100.yml
+++ b/.github/workflows/nv-torch18-v100.yml
@@ -11,6 +11,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     runs-on: [self-hosted, nvidia, torch18, v100]

--- a/.github/workflows/nv-torch18-v100.yml
+++ b/.github/workflows/nv-torch18-v100.yml
@@ -12,7 +12,7 @@ on:
       - 'docs/**'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -11,6 +11,10 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     runs-on: [self-hosted, nvidia, torch18, v100]

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -12,7 +12,7 @@ on:
       - 'docs/**'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Adds the `concurrency` tags to github actions workflow. This allows for queued and running CI jobs for a given branch/PR to be cancelled when new changes are pushed to that branch/PR. This can speed up unit testing and lower runner resource usage.