### PR TITLE
[tests] force pr-moe tests to be sequential

### DIFF
--- a/.github/workflows/amd.yml
+++ b/.github/workflows/amd.yml
@@ -44,5 +44,5 @@ jobs:
         run: |
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
           cd tests
-          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -x -n 4 -m 'not sequential' unit/
-          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -x -m 'sequential' unit/
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -n 4 -m 'not sequential' unit/
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -m 'sequential' unit/

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -266,7 +266,10 @@ class DeepSpeedZeroOptimizer(object):
 
             # push this group to list before modify
             # TODO: Explore simplification that avoids the extra book-keeping by pushing the reordered group
-            self.bit16_groups.append(param_group['params'])
+            trainable_parameters = [
+                param for param in param_group['params'] if param.requires_grad
+            ]
+            self.bit16_groups.append(trainable_parameters)
 
             # Record padding required to align group to world size
             if partition_id == dist.get_world_size(

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+  sequential: used to force some tests to run sequentially instead of in parallel w. xdist

--- a/tests/unit/test_moe.py
+++ b/tests/unit/test_moe.py
@@ -72,6 +72,7 @@ def test_moe(tmpdir, ep_size, use_residual):
               use_residual=use_residual)
 
 
+@pytest.mark.sequential
 @pytest.mark.parametrize("ep_size, use_residual", [(2, True), (2, False)])
 def test_pr_moe(tmpdir, ep_size, use_residual):
     if not required_torch_version():


### PR DESCRIPTION
On AMD we've been seeing intermittent memory access errors when running our MoE tests in parallel. This should hopefully reduce the frequency we see these errors.