### PR TITLE
add now required `-lcurand` to solve `undefined symbol: curandCreateGenerator`

### DIFF
--- a/op_builder/cpu_adam.py
+++ b/op_builder/cpu_adam.py
@@ -18,6 +18,9 @@ class CPUAdamBuilder(TorchCPUOpBuilder):
     def sources(self):
         return ['csrc/adam/cpu_adam.cpp', 'csrc/common/custom_cuda_kernel.cu']
 
+    def libraries_args(self):
+        return ['curand']
+
     def include_paths(self):
         import torch
         if not self.is_rocm_pytorch():

--- a/op_builder/cpu_adam.py
+++ b/op_builder/cpu_adam.py
@@ -19,7 +19,9 @@ class CPUAdamBuilder(TorchCPUOpBuilder):
         return ['csrc/adam/cpu_adam.cpp', 'csrc/common/custom_cuda_kernel.cu']
 
     def libraries_args(self):
-        return ['curand']
+        args = super().libraries_args()
+        args += ['curand']
+        return args
 
     def include_paths(self):
         import torch


### PR DESCRIPTION
This is needed with pip installed torch>=1.11 and when using pre-building

It fixes:

```
$ python -c "import deepspeed; deepspeed.ops.op_builder.CPUAdamBuilder().load()"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/mnt/nvme0/code/github/00optimize/deepspeed/deepspeed/ops/op_builder/builder.py", line 461, in load
    return importlib.import_module(self.absolute_name())
  File "/home/stas/anaconda3/envs/py38-pt112/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 657, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 556, in module_from_spec
  File "<frozen importlib._bootstrap_external>", line 1166, in create_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
ImportError: /mnt/nvme0/code/github/00optimize/deepspeed/deepspeed/ops/adam/cpu_adam_op.cpython-38-x86_64-linux-gnu.so: undefined symbol: curandCreateGenerator
```
which I think is the cause of:
```
'DeepSpeedCPUAdam' object has no attribute 'ds_opt_adam'
```

Fixes: https://github.com/microsoft/DeepSpeed/issues/1846 (for real this time)

@jeffra 