### PR TITLE
Bug Fixes for autotuner and flops profiler

### DIFF
--- a/deepspeed/autotuning/README.md
+++ b/deepspeed/autotuning/README.md
@@ -94,7 +94,7 @@ Note that ZeRO stages, micro-batch sizes, and other ZeRO configurations to tune 
 The DeepSpeed Autotuner tunes ZeRO stages, micro-batch size per GPU, and ZeRO configurations. Other DeepSpeed configurations are used as defined by the user in the DeepSpeed configuration file. Users can overwrite any of the tuning parameters.
 ### Configuring ZeRO Stage
 
-By default, the DeepSpeed Autotuner tunes ZeRO stages. If `"zero_optimization"` is not defined or set to `"all"`, the Autotuner explores ZeRO stages in the order of `[0, 1, 2, 3]`. Users can overwrite this behavior if they already know what ZeRO stage(s) to use. For example, the below section in the DeepSpeed configuration file limits the Autotuner to only exploring ZeRO stage 2 and 3.
+By default, the DeepSpeed Autotuner does not tune ZeRO stages. If `"zero_optimization"` is not defined, DeepSpeed ZeRO is disabled. If `"zero_optimization"` is set to `"all"`, the Autotuner explores ZeRO stages in the order of `[0, 1, 2, 3]`. Users can overwrite this behavior if they already know what ZeRO stage(s) to use. For example, the below section in the DeepSpeed configuration file limits the Autotuner to only exploring ZeRO stage 2 and 3.
 
 ```json
 {

--- a/deepspeed/autotuning/autotuner.py
+++ b/deepspeed/autotuning/autotuner.py
@@ -422,7 +422,7 @@ class Autotuner:
 
         stage = self.user_config.get(ZERO_OPTIMIZATION,
                                      {}).get(ZERO_OPTIMIZATION_STAGE,
-                                             "all")
+                                             0)
         user_zero_stages = [stage] if not isinstance(stage, list) else stage
         logger.info(f"User-defined zero stages are {stage}.")
 

--- a/deepspeed/profiling/flops_profiler/profiler.py
+++ b/deepspeed/profiling/flops_profiler/profiler.py
@@ -675,7 +675,7 @@ def _upsample_flops_compute(input,
             return int(size), 0
     assert scale_factor is not None, "either size or scale_factor should be defined"
     flops = torch.numel(input)
-    if isinstance(scale_factor, tuple) and len(scale_factor) == len(input):
+    if isinstance(scale_factor, tuple):
         flops * int(_prod(scale_factor))
     else:
         flops * scale_factor**len(input)

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1955,8 +1955,10 @@ class DeepSpeedEngine(Module):
                 STEP_GLOBAL_TIMER,
             ],
                                        reset=False)
-            titer = msg[FORWARD_GLOBAL_TIMER] + msg[BACKWARD_GLOBAL_TIMER] + msg[
-                STEP_GLOBAL_TIMER]
+            titer = 0.0
+            titer += msg[FORWARD_GLOBAL_TIMER] if FORWARD_GLOBAL_TIMER in msg else 0
+            titer += msg[BACKWARD_GLOBAL_TIMER] if BACKWARD_GLOBAL_TIMER in msg else 0
+            titer += msg[STEP_GLOBAL_TIMER] if STEP_GLOBAL_TIMER in msg else 0
             msg["latency"] = titer
             msg["FLOPS_per_gpu"] = self.flops * self.gradient_accumulation_steps(
             ) / titer


### PR DESCRIPTION
This PR makes the following change:
1. fix the autotuner timing bug when backward is not called
2. change autotuner default to not tune zero stage if "zero_optimization" is not defined
3. fix flops profiler bug when computing flops for [torch.nn.functional.interpolate](https://pytorch.org/docs/stable/generated/torch.nn.functional.interpolate.html)