### PR TITLE
Bug fix for flops profilers output

### DIFF
--- a/deepspeed/profiling/flops_profiler/profiler.py
+++ b/deepspeed/profiling/flops_profiler/profiler.py
@@ -734,7 +734,6 @@ def _einsum_flops_compute(equation, *operands):
     np_arrs = [np.zeros(s) for s in input_shapes]
     optim = np.einsum_path(equation, *np_arrs, optimize="optimal")[1]
     for line in optim.split("\n"):
-        print(line.lower())
         if "optimized flop" in line.lower():
             flop = int(float(line.split(":")[-1]))
             return flop, 0


### PR DESCRIPTION
When flops profiler is enabled, it will print lots of numpy `einsum_path` results in the standard output, which will whelm profilers output and waste much time on printing, especially when profiling large models.


This PR makes the following change:

1. directly remove the print line. 