### PR TITLE
comm backend: cast bool when not supported by torch2cupy

### DIFF
--- a/deepspeed/runtime/comm/nccl.py
+++ b/deepspeed/runtime/comm/nccl.py
@@ -21,6 +21,11 @@ class NcclBackend(object):
         self.rank = dist.get_rank(group=self.world_group)
         self.size = dist.get_world_size(group=self.world_group)
         self.compression_backend = CupyBackend()
+        self.bool_not_supported = False
+        TORCH_MAJOR = int(torch.__version__.split('.')[0])
+        TORCH_MINOR = int(torch.__version__.split('.')[1])
+        if TORCH_MAJOR >= 1 and TORCH_MINOR >= 10:
+            self.bool_not_supported = True
 
     def my_igather(self, rank, size, group, sendbuf, recvbuf, root):
         req = []
@@ -68,9 +73,15 @@ class NcclBackend(object):
         worker_error.set_(buffer_m - worker_scale *
                           buffer_m.sign().add_(1).bool().float().add_(-0.5).mul_(2.0))
 
-        cupy_sign_list_packed = self.compression_backend.compress_by_chunk(
-            self.compression_backend.torch2cupy(buffer_m.sign_().add_(1).bool()),
-            self.size)
+        if self.bool_not_supported:
+            cupy_sign_list_packed = self.compression_backend.compress_by_chunk(
+                self.compression_backend.torch2cupy(
+                    buffer_m.sign_().add_(1).bool().to(dtype=torch.uint8)),
+                self.size)
+        else:
+            cupy_sign_list_packed = self.compression_backend.compress_by_chunk(
+                self.compression_backend.torch2cupy(buffer_m.sign_().add_(1).bool()),
+                self.size)
         cupy_worker_scale = self.compression_backend.torch2cupy(worker_scale)
 
         cupy_recvbuf_sign = cupy.zeros(
@@ -124,10 +135,16 @@ class NcclBackend(object):
 
         # cupy_server_scale = self.compression_backend.torch2cupy(server_scale)
 
-        cupy_server_sign_packed = self.compression_backend.compress_by_chunk(
-            self.compression_backend.torch2cupy(
-                compensated_server_m.sign_().add_(1).bool()),
-            1)
+        if self.bool_not_supported:
+            cupy_server_sign_packed = self.compression_backend.compress_by_chunk(
+                self.compression_backend.torch2cupy(
+                    compensated_server_m.sign_().add_(1).bool().to(dtype=torch.uint8)),
+                1)
+        else:
+            cupy_server_sign_packed = self.compression_backend.compress_by_chunk(
+                self.compression_backend.torch2cupy(
+                    compensated_server_m.sign_().add_(1).bool()),
+                1)
         compensated_server_m = None
 
         cupy_recvbuf_sign_server = cupy.zeros(


### PR DESCRIPTION
Solves https://github.com/microsoft/DeepSpeed/issues/1859

Confirmed that the convergence and performance of BERT pretraining are consistent between torch 1.8 w/o the change versus torch 1.10 w/ the change.