### PR TITLE
Fix multiple zero 3 tracing errors

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1556,10 +1556,6 @@ class DeepSpeedEngine(Module):
         loss = self.module(*inputs, **kwargs)
 
         if self.zero_optimization_partition_weights():
-            # Reset the ZeRO-3 state if we are only doing forward-passes (ie evaluation).
-            if not torch._C.is_grad_enabled():
-                self.optimizer.param_coordinator.reset_step()
-
             # Disable automated discovery of external parameters
             for module in self.module.modules():
                 module._parameters._in_forward = False

--- a/deepspeed/runtime/zero/partitioned_param_coordinator.py
+++ b/deepspeed/runtime/zero/partitioned_param_coordinator.py
@@ -110,17 +110,13 @@ class PartitionedParameterCoordinator:
     Bookkeeping operations used to track where we are in the forward/backward pass
     """
 
-    def record_trace(self, sub_module: Module, forward_pass) -> None:
+    def record_trace(self, sub_module: Module) -> None:
         """adds sub module to trace"""
         if self.trace_complete:
             raise RuntimeError(
                 "attempted to record trace when trace was already complete")
 
         self.__submodule_order.append(sub_module)
-        ids = [p.ds_id for p in iter_params(sub_module)]
-        print_rank_0(
-            f'record_trace{forward_pass}: step_id={self.__step_id}, mod_id={sub_module.id} p_ids = {ids}',
-            force=True)
         for param in sorted(set(iter_params(sub_module)), key=lambda p: p.ds_id):
             self.__param_order.append(
                 __class__.__ParamInTrace(param=param,

--- a/deepspeed/runtime/zero/partitioned_param_coordinator.py
+++ b/deepspeed/runtime/zero/partitioned_param_coordinator.py
@@ -1,0 +1,361 @@
+"""
+"Copyright 2020 The Microsoft DeepSpeed Team.
+Licensed under the MIT license.
+"""
+
+from dataclasses import dataclass
+import functools
+import collections
+from collections import OrderedDict, UserDict
+from typing import Deque, Dict, Iterable, Set, Tuple
+import torch
+from torch.cuda import Event, Stream
+from torch.nn import Module, Parameter
+
+from deepspeed.utils.logging import logger
+from deepspeed.runtime.zero.partition_parameters import *
+from deepspeed.runtime.zero.offload_constants import *
+from deepspeed.runtime.swap_tensor.partitioned_param_swapper import PartitionedParamStatus
+
+
+def debug_rank0(message: str) -> None:
+    if dist.get_rank() == 0:
+        logger.debug(message)
+
+
+@instrument_w_nvtx
+def get_all_parameters(sub_module, recurse=False):
+    return itertools.chain(sub_module.named_parameters(recurse=recurse),
+                           sub_module.ds_external_parameters())
+
+
+def iter_params(module: Module, recurse=False) -> Iterable[Parameter]:
+    return map(lambda pair: pair[1], get_all_parameters(module, recurse))
+
+
+class PartitionedParameterCoordinator:
+    """Handles partitioning and gathering of parameters."""
+    class __InflightParamRegistry(UserDict):
+        """registry for parameters in flight"""
+        def __setitem__(self,
+                        param: Parameter,
+                        handle: AllGatherCoalescedHandle) -> None:
+            if param in self.data:
+                raise RuntimeError(f"{param.ds_summary()} already in registry")
+            if param.ds_status != ZeroParamStatus.INFLIGHT:
+                raise RuntimeError(
+                    f"attempted to add non-inflight parameter to registry {param.ds_summary()}"
+                )
+            self.data[param] = handle
+
+    @dataclass
+    class __ParamInTrace:
+        param: Parameter
+        step_id_last_used_at: int
+
+    def __init__(
+        self,
+        prefetch_bucket_sz: int,
+        max_reuse_distance_in_numel: int,
+        max_available_parameters_in_numel: int,
+        allgather_stream: Stream,
+        prefetch_nvme: bool = False,
+    ) -> None:
+        # mapping of param -> handle for each param that is currently in flight
+        self.__inflight_param_registry = __class__.__InflightParamRegistry()
+        # keeps track of the number of submodules invoked so far.
+        self.__step_id: int = 0
+        # whether or not we have completed a trace of the entire network. This should
+        # always be true after the first forward pass + backward pass.
+        self.trace_complete: bool = False
+        # sequence of submodules/parameters in forward pass + backward pass
+        self.__submodule_order: Iterable[Module] = []
+        self.__param_order: Iterable[__class__.__ParamInTrace] = []
+        self.__most_recent_step_id_param_fetched_for = collections.defaultdict(
+            lambda: int(-1e10))
+        # number of available params, and max number of available params
+        self.__n_available_params: int = 0
+        self.__max_n_available_params: int = max_available_parameters_in_numel
+        # max distance between two use of the module beyond which module is released
+        self.__max_reuse_dist_in_numel: int = max_reuse_distance_in_numel
+        # queue for parameters to fetch. parameters will be popped off the left
+        # side of the dequeue as they are fetched
+        self.__param_queue: Deque[__class__.__ParamInTrace] = None
+        self.__prefetch_bucket_sz: int = prefetch_bucket_sz
+        self.__prefetch_nvme: bool = prefetch_nvme
+        self.hierarchy: int = 0
+
+        # stream that will be used for allgather operations
+        self.__allgather_stream: Stream = allgather_stream
+
+        # limit the number of fetch events that can be queued at once
+        # otherwise, what happens is memory is allocated by the host thread at the
+        # time of the call, but not used until later by the asynchronous cuda stream.
+        # allowing an infinite number of these to queue up causes a lot of memory
+        # pressure that then becomes detrimental to performance.
+        # this is a much less elegant way of fixing this vs something like using
+        # cudaMallocAsync/cudaFreeAsync. Choosing to not expose this to the user now
+        # because ideally in the future its replaced by an async allocation
+        # mechanism which doesn't require any configuration by the user.
+        self.__ongoing_fetch_events: Deque[Event] = collections.deque()
+        # TODO. make this configurable via JSON
+        self.__max_ongoing_fetch_events: int = 2
+
+    """Tracing and Tracking
+    TODO. consider performing trace before initializing PartitionedParameterCoordinator
+    and passing trace results into constructor. This way all the code in here can
+    just assume that the trace is complete and the results can be entirely
+    immutable.
+
+    Bookkeeping operations used to track where we are in the forward/backward pass
+    """
+
+    def record_trace(self, sub_module: Module, forward_pass) -> None:
+        """adds sub module to trace"""
+        if self.trace_complete:
+            raise RuntimeError(
+                "attempted to record trace when trace was already complete")
+
+        self.__submodule_order.append(sub_module)
+        ids = [p.ds_id for p in iter_params(sub_module)]
+        print_rank_0(
+            f'record_trace{forward_pass}: step_id={self.__step_id}, mod_id={sub_module.id} p_ids = {ids}',
+            force=True)
+        for param in sorted(set(iter_params(sub_module)), key=lambda p: p.ds_id):
+            self.__param_order.append(
+                __class__.__ParamInTrace(param=param,
+                                         step_id_last_used_at=self.__step_id))
+
+    def reset_step(self) -> None:
+        """indicate that we have completed one fwd+bwd for the model"""
+        if self.__inflight_param_registry:
+            raise RuntimeError(
+                f"still have inflight params "
+                f"{[p.ds_summary for p in self.__inflight_param_registry.keys()]}")
+
+        if not self.trace_complete:
+            # make sure that recorded parameter and submodule orders are
+            # identical across ranks
+            assert_ints_same_as_other_ranks([m.id for m in self.__submodule_order])
+            assert_ints_same_as_other_ranks([p.param.ds_id for p in self.__param_order])
+            assert_ints_same_as_other_ranks(
+                [p.step_id_last_used_at for p in self.__param_order])
+
+            self.__submodule_order = tuple(self.__submodule_order)  # freeze
+            self.__param_order = tuple(self.__param_order)  # freeze
+            self.trace_complete = True
+            print_rank_0(f"completed trace: {[m.id for m in self.__submodule_order]}",
+                         force=False)
+
+        self.__param_queue = collections.deque(self.__param_order)  # reset fetch queue
+        self.__most_recent_step_id_param_fetched_for = collections.defaultdict(
+            lambda: int(-1e10))
+        self.__step_id = 0
+        self.__n_available_params = 0
+
+    """Fetch and Release
+    Fetching, prefetching, and releasing parameters
+    """
+
+    @instrument_w_nvtx
+    @torch.no_grad()
+    def fetch_sub_module(self, current_submodule: Module) -> None:
+        """This method does the following (in order):
+        1. kick off fetch for parameters in immediately required sub module
+        2. kick off fetch for next few parameters we will need later (prefetch)
+        3. block on parameters in immediately required sub module
+        """
+        debug_rank0(
+            f"{self.__step_id}: M{current_submodule.id}({type(current_submodule).__name__}) P{[p.ds_id for p in iter_params(current_submodule)]} "
+            + str({
+                "avail": f"{self.__n_available_params:.1e}",
+                "queue_sz": f"{len(self.__param_queue or [])}",
+                "inflight": [p.ds_id for p in self.__inflight_param_registry],
+            }))
+
+        params_to_fetch = frozenset(iter_params(current_submodule))
+
+        # kick off all gather for params in the immediately required submodule
+        for param in params_to_fetch:
+            debug_rank0(f"-fetch: {param.ds_summary()}")
+        self.__all_gather_params(params_to_fetch)
+
+        # wait for parameters in the immediately needed submodule to become available
+        for param in params_to_fetch:
+            param.ds_active_sub_modules.add(current_submodule.id)
+            debug_rank0(f"-wait: {param.ds_summary()}")
+            if param in self.__inflight_param_registry:
+                with torch.cuda.stream(self.__allgather_stream):
+                    while self.__ongoing_fetch_events and self.__ongoing_fetch_events[
+                            0].query():
+                        self.__ongoing_fetch_events.popleft()
+                    if len(self.__ongoing_fetch_events
+                           ) > self.__max_ongoing_fetch_events:
+                        self.__ongoing_fetch_events.popleft().synchronize()
+
+                    self.__inflight_param_registry.pop(param).wait()
+
+                    event = Event()
+                    event.record()
+                    self.__ongoing_fetch_events.append(event)
+
+            assert param.ds_status == ZeroParamStatus.AVAILABLE, param.ds_summary()
+        torch.cuda.current_stream().wait_stream(self.__allgather_stream)
+
+        # kick off parameter prefetches for upcoming modules
+        # don't prefetch if we dont have a completed model trace, or if we aren't
+        # training (throws off the tracing and don't want to prefetch modules for bwd)
+        if self.trace_complete and current_submodule.training:
+            # go through the parameters we need for the current module and pop them
+            # off the fetch queue so that they aren't prefetched later.
+            # if params have already been popped off the fetch queue by earlier
+            # prefetches we won't look for them here
+            discarded_from_prefetch_queue = set()
+            params_not_already_fetched = set(
+                filter(
+                    lambda p: self.__most_recent_step_id_param_fetched_for[p] < self.
+                    __step_id,
+                    params_to_fetch))
+            while self.__param_queue and len(discarded_from_prefetch_queue) < len(
+                    params_not_already_fetched):
+                param_in_trace = self.__param_queue.popleft()
+                self.__most_recent_step_id_param_fetched_for[
+                    param_in_trace.param] = param_in_trace.step_id_last_used_at
+                discarded_from_prefetch_queue.add(param_in_trace.param)
+            if discarded_from_prefetch_queue != params_not_already_fetched:
+                raise RuntimeError(
+                    f"tracing error at step {self.__step_id}: \n"
+                    f"module id: {current_submodule.id}, training: {current_submodule.training}\n"
+                    f"expected the next {len(params_not_already_fetched)} parameters in the "
+                    f"parameter fetch queue to be {tuple(p.ds_summary() for p in params_not_already_fetched)} \n"
+                    f"but got \n {tuple(p.ds_summary() for p in discarded_from_prefetch_queue)}."
+                )
+
+            # kick off all gather for params in the next few submodules (prefetch)
+            max_params_to_prefetch = min(
+                self.__max_n_available_params - self.__n_available_params,
+                self.__prefetch_bucket_sz)
+            params_to_prefetch = set()
+            numel_prefetching = 0
+            while self.__param_queue and numel_prefetching < max_params_to_prefetch:
+                param_in_trace: __class__.__ParamInTrace = self.__param_queue.popleft()
+                self.__most_recent_step_id_param_fetched_for[
+                    param_in_trace.param] = param_in_trace.step_id_last_used_at
+                if param_in_trace.param not in params_to_prefetch:
+                    params_to_prefetch.add(param_in_trace.param)
+                    numel_prefetching += param_in_trace.param.ds_numel
+            for param in params_to_prefetch:
+                debug_rank0(f"-prefetch: {param.ds_summary()}")
+            self.__all_gather_params(params_to_prefetch)
+
+            if self.__prefetch_nvme:
+                self.__prefetch_nvme_param_partitions()
+
+        self.__step_id += 1
+
+    @instrument_w_nvtx
+    @torch.no_grad()
+    def release_sub_module(self, submodule: Module) -> None:
+        """release the parameters of a sub module, assuming they meet conditions to
+        be released."""
+        params_to_release = (self.__params_to_release(submodule,
+                                                      self.__step_id)
+                             if self.trace_complete else set(
+                                 p.ds_id for p in iter_params(submodule)))
+
+        for param in iter_params(submodule):
+            param.ds_active_sub_modules.discard(submodule.id)
+            if param.ds_id in params_to_release and not param.is_external_param:
+                self.__release_param(param)
+
+    @instrument_w_nvtx
+    @torch.no_grad()
+    def release_and_reset_all(self, module: Module) -> None:
+        """release all module parameters"""
+        for param in iter_params(module, recurse=True):
+            if param in self.__inflight_param_registry:
+                raise RuntimeError(f"param {param.ds_summary()} still in flight")
+
+            # TODO. make this throw if if there are still active submodules. currently
+            # there's a hook execution issue
+            param.ds_active_sub_modules.clear()
+            self.__release_param(param)
+
+        for param in iter_params(module, recurse=True):
+            if param.ds_status != ZeroParamStatus.NOT_AVAILABLE:
+                raise RuntimeError(f"{param.ds_summary()} expected to be released")
+
+    @instrument_w_nvtx
+    def __all_gather_params(self, params: Set[Parameter]) -> None:
+        """for each partitioned parameter, kick off an async allgather and store
+        the work handle for the in flight parameters."""
+        partitioned_params = []
+        for param in params:
+            if param.ds_status == ZeroParamStatus.NOT_AVAILABLE:
+                partitioned_params.append(param)
+                self.__n_available_params += param.ds_numel
+
+        if partitioned_params:
+            with torch.cuda.stream(self.__allgather_stream):
+                handle = partitioned_params[0].all_gather_coalesced(partitioned_params)
+
+            for param in partitioned_params:
+                assert param.ds_status == ZeroParamStatus.INFLIGHT, param.ds_summary()
+                self.__inflight_param_registry[param] = handle
+
+    @instrument_w_nvtx
+    def __release_param(self, param: Parameter) -> None:
+        if param.ds_status == ZeroParamStatus.AVAILABLE and not param.ds_active_sub_modules:
+            debug_rank0(f"-release: {param.ds_summary()}")
+            param.partition()
+            self.__n_available_params -= param.ds_numel
+
+    @instrument_w_nvtx
+    @functools.lru_cache(maxsize=None)
+    def __params_to_release(self,
+                            submodule_to_release: Module,
+                            step_id: int) -> Set[int]:
+        if not self.trace_complete:
+            raise RuntimeError("expected trace to be complete")
+
+        params_to_release = set(p.ds_id for p in iter_params(submodule_to_release)
+                                if not p.ds_persist)
+
+        # examine all modules within `max_reuse_dist_in_numel` of the current step,
+        # if we see any of the candidate parameters to be released reoccur while
+        # doing this, remove them from the set of parameters to release.
+        params_traversed = 0
+        for module in self.__submodule_order[step_id:]:
+            if params_traversed > self.__max_reuse_dist_in_numel:
+                break
+            for param in iter_params(module):
+                params_to_release.discard(param.ds_id)
+                params_traversed += param.ds_numel
+
+        return params_to_release
+
+    @instrument_w_nvtx
+    def __prefetch_nvme_param_partitions(self) -> None:
+        """swap in parameter partitions from nvme for those parameters that will be used
+        after the ones that are already being prefetched into full parameters
+        """
+        if not self.trace_complete:
+            return
+
+        numel_in_flight = sum(param.ds_numel for param in self.__inflight_param_registry)
+
+        numel_considered = 0
+        swap_in_params = []
+        for param_in_trace in self.__param_queue:
+            param = param_in_trace.param
+            if param.nvme_swapper is None:
+                continue
+            if (numel_considered > 2 * numel_in_flight or len(swap_in_params) >=
+                    param.nvme_swapper.available_swap_in_buffers()):
+                break
+            if param.ds_tensor.status == PartitionedParamStatus.NOT_AVAILABLE:
+                swap_in_params.append(param)
+            numel_considered += param.ds_numel
+
+        if swap_in_params:
+            swap_in_params[0].nvme_swapper.swap_in(swap_in_params, async_op=True)

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -1208,7 +1208,7 @@ class DeepSpeedZeroOptimizer_Stage3(object):
 
         param_coordinator = self._get_param_coordinator(sub_module.training)
         if not param_coordinator.trace_complete:
-            param_coordinator.record_trace(sub_module, True)
+            param_coordinator.record_trace(sub_module)
 
         param_coordinator.release_sub_module(sub_module)
 
@@ -1220,7 +1220,7 @@ class DeepSpeedZeroOptimizer_Stage3(object):
     def pre_sub_module_backward_function(self, sub_module):
         param_coordinator = self._get_param_coordinator(sub_module.training)
         if not param_coordinator.trace_complete:
-            param_coordinator.record_trace(sub_module, False)
+            param_coordinator.record_trace(sub_module)
         param_coordinator.fetch_sub_module(sub_module)
 
     @torch.no_grad()

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -30,6 +30,7 @@ from deepspeed.runtime.zero.constants import ZERO_OPTIMIZATION_WEIGHTS
 from deepspeed.ops.adam import DeepSpeedCPUAdam
 from deepspeed.ops.op_builder import UtilsBuilder
 from deepspeed.runtime.zero.offload_constants import *
+from deepspeed.runtime.zero.partitioned_param_coordinator import PartitionedParameterCoordinator, iter_params
 from deepspeed.runtime.swap_tensor.partitioned_param_swapper import PartitionedParamStatus
 from deepspeed.runtime.swap_tensor.partitioned_optimizer_swapper import PartitionedOptimizerSwapper
 from deepspeed.runtime.swap_tensor.pipelined_optimizer_swapper import PipelinedOptimizerSwapper
@@ -67,24 +68,9 @@ def lcm(x, y):
     return x * y // gcd(x, y)
 
 
-def debug_rank0(message: str) -> None:
-    if dist.get_rank() == 0:
-        logger.debug(message)
-
-
 def move_to_cpu(tensor_list):
     for tensor in tensor_list:
         tensor.data = tensor.data.cpu()
-
-
-@instrument_w_nvtx
-def get_all_parameters(sub_module, recurse=False):
-    return itertools.chain(sub_module.named_parameters(recurse=recurse),
-                           sub_module.ds_external_parameters())
-
-
-def iter_params(module: Module, recurse=False) -> Iterable[Parameter]:
-    return map(lambda pair: pair[1], get_all_parameters(module, recurse))
 
 
 #apply torch.autograd.Function that calls a backward_function to tensors in output
@@ -149,10 +135,11 @@ class ZeROOrderedDict(OrderedDict):
 
         if param.ds_status == ZeroParamStatus.NOT_AVAILABLE:
             if self._parent_module._parameters._in_forward:
-                print_rank_0(f'Registering external parameter from getter {key}',
-                             force=False)
                 register_external_parameter(FWD_MODULE_STACK[-1], param)
                 param.all_gather()
+                print_rank_0(
+                    f'Registering external parameter from getter {key} ds_id = {param.ds_id}',
+                    force=False)
 
         return param
 
@@ -167,329 +154,6 @@ def _inject_parameters(module, cls):
         for key, param in module._parameters.items():
             new_param[key] = param
         module._parameters = new_param
-
-
-class PartitionedParameterCoordinator:
-    """Handles partitioning and gathering of parameters."""
-    class __InflightParamRegistry(UserDict):
-        """registry for parameters in flight"""
-        def __setitem__(self,
-                        param: Parameter,
-                        handle: AllGatherCoalescedHandle) -> None:
-            if param in self.data:
-                raise RuntimeError(f"{param.ds_summary()} already in registry")
-            if param.ds_status != ZeroParamStatus.INFLIGHT:
-                raise RuntimeError(
-                    f"attempted to add non-inflight parameter to registry {param.ds_summary()}"
-                )
-            self.data[param] = handle
-
-    @dataclass
-    class __ParamInTrace:
-        param: Parameter
-        step_id_last_used_at: int
-
-    def __init__(
-        self,
-        prefetch_bucket_sz: int,
-        max_reuse_distance_in_numel: int,
-        max_available_parameters_in_numel: int,
-        allgather_stream: Stream,
-        prefetch_nvme: bool = False,
-    ) -> None:
-        # mapping of param -> handle for each param that is currently in flight
-        self.__inflight_param_registry = __class__.__InflightParamRegistry()
-        # keeps track of the number of submodules invoked so far.
-        self.__step_id: int = 0
-        # whether or not we have completed a trace of the entire network. This should
-        # always be true after the first forward pass + backward pass.
-        self.trace_complete: bool = False
-        # sequence of submodules/parameters in forward pass + backward pass
-        self.__submodule_order: Iterable[Module] = []
-        self.__param_order: Iterable[__class__.__ParamInTrace] = []
-        self.__most_recent_step_id_param_fetched_for = collections.defaultdict(
-            lambda: int(-1e10))
-        # number of available params, and max number of available params
-        self.__n_available_params: int = 0
-        self.__max_n_available_params: int = max_available_parameters_in_numel
-        # max distance between two use of the module beyond which module is released
-        self.__max_reuse_dist_in_numel: int = max_reuse_distance_in_numel
-        # queue for parameters to fetch. parameters will be popped off the left
-        # side of the dequeue as they are fetched
-        self.__param_queue: Deque[__class__.__ParamInTrace] = None
-        self.__prefetch_bucket_sz: int = prefetch_bucket_sz
-        self.__prefetch_nvme: bool = prefetch_nvme
-        self.hierarchy: int = 0
-
-        # stream that will be used for allgather operations
-        self.__allgather_stream: Stream = allgather_stream
-
-        # limit the number of fetch events that can be queued at once
-        # otherwise, what happens is memory is allocated by the host thread at the
-        # time of the call, but not used until later by the asynchronous cuda stream.
-        # allowing an infinite number of these to queue up causes a lot of memory
-        # pressure that then becomes detrimental to performance.
-        # this is a much less elegant way of fixing this vs something like using
-        # cudaMallocAsync/cudaFreeAsync. Choosing to not expose this to the user now
-        # because ideally in the future its replaced by an async allocation
-        # mechanism which doesn't require any configuration by the user.
-        self.__ongoing_fetch_events: Deque[Event] = collections.deque()
-        # TODO. make this configurable via JSON
-        self.__max_ongoing_fetch_events: int = 2
-
-    """Tracing and Tracking
-    TODO. consider performing trace before initializing PartitionedParameterCoordinator
-    and passing trace results into constructor. This way all the code in here can
-    just assume that the trace is complete and the results can be entirely
-    immutable.
-
-    Bookkeeping operations used to track where we are in the forward/backward pass
-    """
-
-    def record_trace(self, sub_module: Module) -> None:
-        """adds sub module to trace"""
-        if self.trace_complete:
-            raise RuntimeError(
-                "attempted to record trace when trace was already complete")
-
-        self.__submodule_order.append(sub_module)
-        for param in sorted(set(iter_params(sub_module)), key=lambda p: p.ds_id):
-            self.__param_order.append(
-                __class__.__ParamInTrace(param=param,
-                                         step_id_last_used_at=self.__step_id))
-
-    def reset_step(self) -> None:
-        """indicate that we have completed one fwd+bwd for the model"""
-        if self.__inflight_param_registry:
-            raise RuntimeError(
-                f"still have inflight params "
-                f"{[p.ds_summary for p in self.__inflight_param_registry.keys()]}")
-
-        if not self.trace_complete:
-            # make sure that recorded parameter and submodule orders are
-            # identical across ranks
-            assert_ints_same_as_other_ranks([m.id for m in self.__submodule_order])
-            assert_ints_same_as_other_ranks([p.param.ds_id for p in self.__param_order])
-            assert_ints_same_as_other_ranks(
-                [p.step_id_last_used_at for p in self.__param_order])
-
-            self.__submodule_order = tuple(self.__submodule_order)  # freeze
-            self.__param_order = tuple(self.__param_order)  # freeze
-            self.trace_complete = True
-            print_rank_0(f"completed trace: {[m.id for m in self.__submodule_order]}",
-                         force=False)
-
-        self.__param_queue = collections.deque(self.__param_order)  # reset fetch queue
-        self.__most_recent_step_id_param_fetched_for = collections.defaultdict(
-            lambda: int(-1e10))
-        self.__step_id = 0
-        self.__n_available_params = 0
-
-    """Fetch and Release
-    Fetching, prefetching, and releasing parameters
-    """
-
-    @instrument_w_nvtx
-    @torch.no_grad()
-    def fetch_sub_module(self, current_submodule: Module) -> None:
-        """This method does the following (in order):
-        1. kick off fetch for parameters in immediately required sub module
-        2. kick off fetch for next few parameters we will need later (prefetch)
-        3. block on parameters in immediately required sub module
-        """
-        debug_rank0(
-            f"{self.__step_id}: M{current_submodule.id}({type(current_submodule).__name__}) P{[p.ds_id for p in iter_params(current_submodule)]} "
-            + str({
-                "avail": f"{self.__n_available_params:.1e}",
-                "queue_sz": f"{len(self.__param_queue or [])}",
-                "inflight": [p.ds_id for p in self.__inflight_param_registry],
-            }))
-
-        params_to_fetch = frozenset(iter_params(current_submodule))
-
-        # kick off all gather for params in the immediately required submodule
-        for param in params_to_fetch:
-            debug_rank0(f"-fetch: {param.ds_summary()}")
-        self.__all_gather_params(params_to_fetch)
-
-        # wait for parameters in the immediately needed submodule to become available
-        for param in params_to_fetch:
-            param.ds_active_sub_modules.add(current_submodule.id)
-            debug_rank0(f"-wait: {param.ds_summary()}")
-            if param in self.__inflight_param_registry:
-                with torch.cuda.stream(self.__allgather_stream):
-                    while self.__ongoing_fetch_events and self.__ongoing_fetch_events[
-                            0].query():
-                        self.__ongoing_fetch_events.popleft()
-                    if len(self.__ongoing_fetch_events
-                           ) > self.__max_ongoing_fetch_events:
-                        self.__ongoing_fetch_events.popleft().synchronize()
-
-                    self.__inflight_param_registry.pop(param).wait()
-
-                    event = Event()
-                    event.record()
-                    self.__ongoing_fetch_events.append(event)
-
-            assert param.ds_status == ZeroParamStatus.AVAILABLE, param.ds_summary()
-        torch.cuda.current_stream().wait_stream(self.__allgather_stream)
-
-        # kick off parameter prefetches for upcoming modules
-        # don't prefetch if we dont have a completed model trace, or if we aren't
-        # training (throws off the tracing and don't want to prefetch modules for bwd)
-        if self.trace_complete and current_submodule.training:
-            # go through the parameters we need for the current module and pop them
-            # off the fetch queue so that they aren't prefetched later.
-            # if params have already been popped off the fetch queue by earlier
-            # prefetches we won't look for them here
-            discarded_from_prefetch_queue = set()
-            params_not_already_fetched = set(
-                filter(
-                    lambda p: self.__most_recent_step_id_param_fetched_for[p] < self.
-                    __step_id,
-                    params_to_fetch))
-            while self.__param_queue and len(discarded_from_prefetch_queue) < len(
-                    params_not_already_fetched):
-                param_in_trace = self.__param_queue.popleft()
-                self.__most_recent_step_id_param_fetched_for[
-                    param_in_trace.param] = param_in_trace.step_id_last_used_at
-                discarded_from_prefetch_queue.add(param_in_trace.param)
-            if discarded_from_prefetch_queue != params_not_already_fetched:
-                raise RuntimeError(
-                    f"tracing error at step {self.__step_id}: "
-                    f"expected the next {len(params_not_already_fetched)} parameters in the "
-                    f"parameter fetch queue to be {tuple(p.ds_summary() for p in params_not_already_fetched)} "
-                    f"but got {tuple(p.ds_summary() for p in discarded_from_prefetch_queue)}."
-                )
-
-            # kick off all gather for params in the next few submodules (prefetch)
-            max_params_to_prefetch = min(
-                self.__max_n_available_params - self.__n_available_params,
-                self.__prefetch_bucket_sz)
-            params_to_prefetch = set()
-            numel_prefetching = 0
-            while self.__param_queue and numel_prefetching < max_params_to_prefetch:
-                param_in_trace: __class__.__ParamInTrace = self.__param_queue.popleft()
-                self.__most_recent_step_id_param_fetched_for[
-                    param_in_trace.param] = param_in_trace.step_id_last_used_at
-                if param_in_trace.param not in params_to_prefetch:
-                    params_to_prefetch.add(param_in_trace.param)
-                    numel_prefetching += param_in_trace.param.ds_numel
-            for param in params_to_prefetch:
-                debug_rank0(f"-prefetch: {param.ds_summary()}")
-            self.__all_gather_params(params_to_prefetch)
-
-            if self.__prefetch_nvme:
-                self.__prefetch_nvme_param_partitions()
-
-        self.__step_id += 1
-
-    @instrument_w_nvtx
-    @torch.no_grad()
-    def release_sub_module(self, submodule: Module) -> None:
-        """release the parameters of a sub module, assuming they meet conditions to
-        be released."""
-        params_to_release = (self.__params_to_release(submodule,
-                                                      self.__step_id)
-                             if self.trace_complete else set(
-                                 p.ds_id for p in iter_params(submodule)))
-
-        for param in iter_params(submodule):
-            param.ds_active_sub_modules.discard(submodule.id)
-            if param.ds_id in params_to_release and not param.is_external_param:
-                self.__release_param(param)
-
-    @instrument_w_nvtx
-    @torch.no_grad()
-    def release_and_reset_all(self, module: Module) -> None:
-        """release all module parameters"""
-        for param in iter_params(module, recurse=True):
-            if param in self.__inflight_param_registry:
-                raise RuntimeError(f"param {param.ds_summary()} still in flight")
-
-            # TODO. make this throw if if there are still active submodules. currently
-            # there's a hook execution issue
-            param.ds_active_sub_modules.clear()
-            self.__release_param(param)
-
-        for param in iter_params(module, recurse=True):
-            if param.ds_status != ZeroParamStatus.NOT_AVAILABLE:
-                raise RuntimeError(f"{param.ds_summary()} expected to be released")
-
-    @instrument_w_nvtx
-    def __all_gather_params(self, params: Set[Parameter]) -> None:
-        """for each partitioned parameter, kick off an async allgather and store
-        the work handle for the in flight parameters."""
-        partitioned_params = []
-        for param in params:
-            if param.ds_status == ZeroParamStatus.NOT_AVAILABLE:
-                partitioned_params.append(param)
-                self.__n_available_params += param.ds_numel
-
-        if partitioned_params:
-            with torch.cuda.stream(self.__allgather_stream):
-                handle = partitioned_params[0].all_gather_coalesced(partitioned_params)
-
-            for param in partitioned_params:
-                assert param.ds_status == ZeroParamStatus.INFLIGHT, param.ds_summary()
-                self.__inflight_param_registry[param] = handle
-
-    @instrument_w_nvtx
-    def __release_param(self, param: Parameter) -> None:
-        if param.ds_status == ZeroParamStatus.AVAILABLE and not param.ds_active_sub_modules:
-            debug_rank0(f"-release: {param.ds_summary()}")
-            param.partition()
-            self.__n_available_params -= param.ds_numel
-
-    @instrument_w_nvtx
-    @functools.lru_cache(maxsize=None)
-    def __params_to_release(self,
-                            submodule_to_release: Module,
-                            step_id: int) -> Set[int]:
-        if not self.trace_complete:
-            raise RuntimeError("expected trace to be complete")
-
-        params_to_release = set(p.ds_id for p in iter_params(submodule_to_release)
-                                if not p.ds_persist)
-
-        # examine all modules within `max_reuse_dist_in_numel` of the current step,
-        # if we see any of the candidate parameters to be released reoccur while
-        # doing this, remove them from the set of parameters to release.
-        params_traversed = 0
-        for module in self.__submodule_order[step_id:]:
-            if params_traversed > self.__max_reuse_dist_in_numel:
-                break
-            for param in iter_params(module):
-                params_to_release.discard(param.ds_id)
-                params_traversed += param.ds_numel
-
-        return params_to_release
-
-    @instrument_w_nvtx
-    def __prefetch_nvme_param_partitions(self) -> None:
-        """swap in parameter partitions from nvme for those parameters that will be used
-        after the ones that are already being prefetched into full parameters
-        """
-        if not self.trace_complete:
-            return
-
-        numel_in_flight = sum(param.ds_numel for param in self.__inflight_param_registry)
-
-        numel_considered = 0
-        swap_in_params = []
-        for param_in_trace in self.__param_queue:
-            param = param_in_trace.param
-            if param.nvme_swapper is None:
-                continue
-            if (numel_considered > 2 * numel_in_flight or len(swap_in_params) >=
-                    param.nvme_swapper.available_swap_in_buffers()):
-                break
-            if param.ds_tensor.status == PartitionedParamStatus.NOT_AVAILABLE:
-                swap_in_params.append(param)
-            numel_considered += param.ds_numel
-
-        if swap_in_params:
-            swap_in_params[0].nvme_swapper.swap_in(swap_in_params, async_op=True)
 
 
 class PreBackwardFunction(torch.autograd.Function):
@@ -655,18 +319,14 @@ class DeepSpeedZeroOptimizer_Stage3(object):
         ############################################################################
 
         see_memory_usage("Before Partitioned Parameter Coordinator", force=False)
-        self.param_coordinator = PartitionedParameterCoordinator(
-            prefetch_bucket_sz=int(prefetch_bucket_size),
-            max_reuse_distance_in_numel=int(max_reuse_distance),
-            max_available_parameters_in_numel=int(max_live_parameters),
-            allgather_stream=self.__allgather_stream,
-            prefetch_nvme=self.params_in_nvme_and_cpu,
-        )
+        self.param_coordinators = {}
+        self._prefetch_bucket_sz = int(prefetch_bucket_size)
+        self._max_reuse_distance_in_numel = int(max_reuse_distance)
+        self._max_available_parameters_in_numel = int(max_live_parameters)
         see_memory_usage("After Partitioned Parameter Coordinator", force=False)
 
         self.__n_caching_allocator_flushes = 0
 
-        #self.param_coordinator = PartitionedParameterCoordinator(comm_stream=torch.cuda.Stream())
         #-------------Stage 3 Setup-------------------#
         # parameters smaller than the threshold will be collectively gathered at the
         # end of the optimizer step and will be kept till the end of the backward pass
@@ -933,6 +593,19 @@ class DeepSpeedZeroOptimizer_Stage3(object):
             tensor.data = device_buffer.narrow(0, offset, tensor_numel)
 
         return device_buffer
+
+    def _get_param_coordinator(self, training):
+        if not training in self.param_coordinators:
+            self.param_coordinators[training] = PartitionedParameterCoordinator(
+                prefetch_bucket_sz=self._prefetch_bucket_sz,
+                max_reuse_distance_in_numel=self._max_reuse_distance_in_numel,
+                max_available_parameters_in_numel=self.
+                _max_available_parameters_in_numel,
+                allgather_stream=self.__allgather_stream,
+                prefetch_nvme=self.params_in_nvme_and_cpu,
+            )
+
+        return self.param_coordinators[training]
 
     def _configure_offloading(self, offload_optimizer_config, offload_param_config):
         ###################### offload optimizer setup ##################################
@@ -1370,7 +1043,7 @@ class DeepSpeedZeroOptimizer_Stage3(object):
         def _end_of_forward_hook(module, *args):
 
             if not torch._C.is_grad_enabled():
-                self.param_coordinator.reset_step()
+                self._get_param_coordinator(False).reset_step()
 
         #likely one of them should be enough but just to be safe
         self._register_hooks_recursively(self.module)
@@ -1433,16 +1106,16 @@ class DeepSpeedZeroOptimizer_Stage3(object):
                 if not any(id(item) in m._external_params for m in FWD_MODULE_STACK):
                     item.is_external_param = True
                     module_to_register = FWD_MODULE_STACK[-1]
-                    print_rank_0(
-                        f'Registering dangling parameter for module {module_to_register.__class__.__name__}.',
-                        force=False)
                     register_external_parameter(module_to_register, item)
+                    print_rank_0(
+                        f'Registering dangling parameter for module {module_to_register.__class__.__name__}, ds_id = {item.ds_id}.',
+                        force=False)
 
                     # It's possible that the parameter was already external to the completed module. If so, remove it the
                     # registration as it will be covered by the outer module instead.
                     if id(item) in module._external_params:
                         print_rank_0(
-                            f'  Unregistering nested dangling parameter from module {module.__class__.__name__}',
+                            f'  Unregistering nested dangling parameter from module {module.__class__.__name__}, ds_id = {item.ds_id}',
                             force=False)
                         unregister_external_parameter(module, item)
 
@@ -1522,10 +1195,7 @@ class DeepSpeedZeroOptimizer_Stage3(object):
         global FWD_MODULE_STACK
         FWD_MODULE_STACK.append(sub_module)
 
-        if not self.param_coordinator.trace_complete:
-            self.param_coordinator.record_trace(sub_module)
-
-        self.param_coordinator.fetch_sub_module(sub_module)
+        self._get_param_coordinator(sub_module.training).fetch_sub_module(sub_module)
         see_memory_usage(
             f"Before sub module function {sub_module.__class__.__name__} after fetch",
             force=False)
@@ -1536,7 +1206,11 @@ class DeepSpeedZeroOptimizer_Stage3(object):
             f"After sub module function {sub_module.__class__.__name__} {sub_module.id} before release",
             force=False)
 
-        self.param_coordinator.release_sub_module(sub_module)
+        param_coordinator = self._get_param_coordinator(sub_module.training)
+        if not param_coordinator.trace_complete:
+            param_coordinator.record_trace(sub_module, True)
+
+        param_coordinator.release_sub_module(sub_module)
 
         see_memory_usage(
             f"After sub module function {sub_module.__class__.__name__}  {sub_module.id} after release",
@@ -1544,16 +1218,19 @@ class DeepSpeedZeroOptimizer_Stage3(object):
 
     @torch.no_grad()
     def pre_sub_module_backward_function(self, sub_module):
-        if not self.param_coordinator.trace_complete:
-            self.param_coordinator.record_trace(sub_module)
-        self.param_coordinator.fetch_sub_module(sub_module)
+        param_coordinator = self._get_param_coordinator(sub_module.training)
+        if not param_coordinator.trace_complete:
+            param_coordinator.record_trace(sub_module, False)
+        param_coordinator.fetch_sub_module(sub_module)
 
     @torch.no_grad()
     def post_sub_module_backward_function(self, sub_module):
         see_memory_usage(
             f"After sub module backward function {sub_module.__class__.__name__} {sub_module.id} before release",
             force=False)
-        self.param_coordinator.release_sub_module(sub_module)
+
+        self._get_param_coordinator(sub_module.training).release_sub_module(sub_module)
+
         see_memory_usage(
             f"After sub module backward function {sub_module.__class__.__name__} {sub_module.id} after release",
             force=False)
@@ -2400,7 +2077,7 @@ class DeepSpeedZeroOptimizer_Stage3(object):
         see_memory_usage(f"In step before checking overflow", force=False)
 
         print_rank_0("Finished Tracing at Beginning of Step")
-        self.param_coordinator.hierarchy = 0
+        self._get_param_coordinator(True).hierarchy = 0
 
         print_rank_0("Finished Tracing at Beginning of Step")
 
@@ -2792,7 +2469,7 @@ class DeepSpeedZeroOptimizer_Stage3(object):
 
         self.loss_scaler.backward(loss.float(), retain_graph=retain_graph)
 
-        self.param_coordinator.reset_step()
+        self._get_param_coordinator(True).reset_step()
 
         if self.swap_optimizer:
             self.optimizer_swapper.post_backward()
@@ -2824,7 +2501,8 @@ class DeepSpeedZeroOptimizer_Stage3(object):
         """Partitioning Parameters that were not partitioned usually if parameters
         of modules whose input parameters do not require grad computation do not
         trigger post call and will therefore will remain unpartitioned"""
-        self.param_coordinator.release_and_reset_all(self.module)
+        self._get_param_coordinator(self.module.training).release_and_reset_all(
+            self.module)
         for param in iter_params(self.module, recurse=True):
             if param.ds_status != ZeroParamStatus.NOT_AVAILABLE:
                 raise RuntimeError(f"{param.ds_summary()} expected to be released")

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.17.13)
+    commonmarker (0.23.4)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.10)
     dnsruby (1.61.9)


### PR DESCRIPTION
Fix #1878. 

1. Record module trace after module execution to ensure all parameters are captured.
2. Maintain separate traces for training and inference (forward pass only)
3. Remove redundant trace coordinator resets.