### PR TITLE
Improve ds_report output for HIP/ROCm

### DIFF
--- a/deepspeed/env_report.py
+++ b/deepspeed/env_report.py
@@ -80,10 +80,6 @@ def nvcc_version():
 def debug_report():
     max_dots = 33
 
-    hip_version = 'unknown'
-    if hasattr(torch.version, 'hip'):
-        hip_version = torch.version.hip
-
     report = [
         ("torch install path",
          torch.__path__),
@@ -92,16 +88,16 @@ def debug_report():
         ("torch cuda version",
          torch.version.cuda),
         ("torch hip version",
-         hip_version),
+         torch.version.hip),
         ("nvcc version",
-         nvcc_version()),
+         (None if torch.version.hip else nvcc_version())),
         ("deepspeed install path",
          deepspeed.__path__),
         ("deepspeed info",
          f"{deepspeed.__version__}, {deepspeed.__git_hash__}, {deepspeed.__git_branch__}"
          ),
         ("deepspeed wheel compiled w.",
-         f"torch {torch_info['version']}, cuda {torch_info['cuda_version']}, hip {torch_info['hip_version']}"
+         f"torch {torch_info['version']}, " + (f"hip {torch_info['hip_version'}" if torch.version.hip else f"cuda {torch_info['cuda_version']}")
          ),
     ]
     print("DeepSpeed general environment info:")

--- a/deepspeed/env_report.py
+++ b/deepspeed/env_report.py
@@ -83,7 +83,7 @@ def debug_report():
     hip_version = None
     if hasattr(torch.version, 'hip'):
         hip_version = torch.version.hip
-    
+
     report = [
         ("torch install path",
          torch.__path__),

--- a/deepspeed/env_report.py
+++ b/deepspeed/env_report.py
@@ -97,7 +97,7 @@ def debug_report():
          f"{deepspeed.__version__}, {deepspeed.__git_hash__}, {deepspeed.__git_branch__}"
          ),
         ("deepspeed wheel compiled w.",
-         f"torch {torch_info['version']}, " + (f"hip {torch_info['hip_version'}" if torch.version.hip else f"cuda {torch_info['cuda_version']}")
+         f"torch {torch_info['version']}, " + (f"hip {torch_info['hip_version']}" if torch.version.hip else f"cuda {torch_info['cuda_version']}")
          ),
     ]
     print("DeepSpeed general environment info:")

--- a/deepspeed/env_report.py
+++ b/deepspeed/env_report.py
@@ -80,6 +80,10 @@ def nvcc_version():
 def debug_report():
     max_dots = 33
 
+    hip_version = None
+    if hasattr(torch.version, 'hip'):
+        hip_version = torch.version.hip
+    
     report = [
         ("torch install path",
          torch.__path__),
@@ -88,9 +92,9 @@ def debug_report():
         ("torch cuda version",
          torch.version.cuda),
         ("torch hip version",
-         torch.version.hip),
+         hip_version),
         ("nvcc version",
-         (None if torch.version.hip else nvcc_version())),
+         (None if hip_version else nvcc_version())),
         ("deepspeed install path",
          deepspeed.__path__),
         ("deepspeed info",
@@ -99,7 +103,7 @@ def debug_report():
         ("deepspeed wheel compiled w.",
          f"torch {torch_info['version']}, " +
          (f"hip {torch_info['hip_version']}"
-          if torch.version.hip else f"cuda {torch_info['cuda_version']}")),
+          if hip_version else f"cuda {torch_info['cuda_version']}")),
     ]
     print("DeepSpeed general environment info:")
     for name, value in report:

--- a/deepspeed/env_report.py
+++ b/deepspeed/env_report.py
@@ -97,8 +97,9 @@ def debug_report():
          f"{deepspeed.__version__}, {deepspeed.__git_hash__}, {deepspeed.__git_branch__}"
          ),
         ("deepspeed wheel compiled w.",
-         f"torch {torch_info['version']}, " + (f"hip {torch_info['hip_version']}" if torch.version.hip else f"cuda {torch_info['cuda_version']}")
-         ),
+         f"torch {torch_info['version']}, ",
+         (f"hip {torch_info['hip_version']}"
+          if torch.version.hip else f"cuda {torch_info['cuda_version']}")),
     ]
     print("DeepSpeed general environment info:")
     for name, value in report:

--- a/deepspeed/env_report.py
+++ b/deepspeed/env_report.py
@@ -97,7 +97,7 @@ def debug_report():
          f"{deepspeed.__version__}, {deepspeed.__git_hash__}, {deepspeed.__git_branch__}"
          ),
         ("deepspeed wheel compiled w.",
-         f"torch {torch_info['version']}, ",
+         f"torch {torch_info['version']}, " +
          (f"hip {torch_info['hip_version']}"
           if torch.version.hip else f"cuda {torch_info['cuda_version']}")),
     ]


### PR DESCRIPTION
`ds_report` on systems with AMD GPUs would show an error message for `nvcc` which was irrelevant for HIP/ROCm installs. Also removed unnecessary information about dependencies used to build the deepspeed wheel on both HIP and CUDA installs:

**Previous:**
```
torch version .................... 1.10.0a0+git539d476
torch cuda version ............... None
torch hip version ................ 5.1.20531-cacfa990
nvcc version .....................  [FAIL] cannot find CUDA_HOME via torch.utils.cpp_extension.CUDA_HOME=None
deepspeed install path ........... ['/opt/conda/lib/python3.7/site-packages/deepspeed']
deepspeed info ................... 0.6.2+ef17c89, ef17c89, master
deepspeed wheel compiled w. ...... torch 1.10, cuda 0.0, hip 5.1
```
_Note the `FAIL` in `nvcc version` and the `cuda 0.0` in `deepspeed wheel compiled w.`_

**Now:**
```
torch version .................... 1.10.0a0+git539d476
torch cuda version ............... None
torch hip version ................ 5.1.20531-cacfa990
nvcc version ..................... None
deepspeed install path ........... ['/opt/conda/lib/python3.7/site-packages/deepspeed']
deepspeed info ................... 0.6.2+ef17c89, ef17c89, master
deepspeed wheel compiled w. ...... torch 1.10, hip 5.1
```