### PR TITLE
Fix DeepspeedDataLoader length

### DIFF
--- a/deepspeed/runtime/dataloader.py
+++ b/deepspeed/runtime/dataloader.py
@@ -68,7 +68,7 @@ class DeepSpeedDataLoader(object):
         self.device_count = device_count
         self.batch_size = batch_size
         self.pin_memory = pin_memory
-        self.len = len(self.data_sampler)
+        self.len = int(len(self.data_sampler) / batch_size)
         self.data = None
         self.dataloader_drop_last = dataloader_drop_last
 

--- a/deepspeed/runtime/dataloader.py
+++ b/deepspeed/runtime/dataloader.py
@@ -68,7 +68,7 @@ class DeepSpeedDataLoader(object):
         self.device_count = device_count
         self.batch_size = batch_size
         self.pin_memory = pin_memory
-        self.len = int(len(self.data_sampler) / batch_size)
+        self.len = len(self.data_sampler)
         self.data = None
         self.dataloader_drop_last = dataloader_drop_last
 
@@ -100,6 +100,8 @@ class DeepSpeedDataLoader(object):
                                          collate_fn=self.collate_fn,
                                          num_workers=self.num_local_io_workers,
                                          drop_last=self.dataloader_drop_last)
+        self.len = len(self.dataloader)
+
         self.data = (x for x in self.dataloader)
 
         return self.dataloader

--- a/deepspeed/runtime/dataloader.py
+++ b/deepspeed/runtime/dataloader.py
@@ -72,6 +72,13 @@ class DeepSpeedDataLoader(object):
         self.data = None
         self.dataloader_drop_last = dataloader_drop_last
 
+        if self.batch_size is not None:
+            from math import ceil
+            if self.dataloader_drop_last:
+                self.len = self.len // self.batch_size
+            else:
+                self.len = ceil(self.len / self.batch_size)
+
     def __iter__(self):
         self._create_dataloader()
         return self
@@ -100,8 +107,6 @@ class DeepSpeedDataLoader(object):
                                          collate_fn=self.collate_fn,
                                          num_workers=self.num_local_io_workers,
                                          drop_last=self.dataloader_drop_last)
-        self.len = len(self.dataloader)
-
         self.data = (x for x in self.dataloader)
 
         return self.dataloader


### PR DESCRIPTION
```len(DeepspeedDataLoader)``` is currently equal to ```len(data_sampler) = len(dataset) / data_parallel_world_size```.

But, ```len(DataLoader)``` is equal to ```len(dataloader) =  len(data_sampler) / batch_size```.