### PR TITLE
fix attention_mask is overwritten by dummy tensor at DeepSpeedSelfAttentionFunction

### DIFF
--- a/deepspeed/ops/transformer/transformer.py
+++ b/deepspeed/ops/transformer/transformer.py
@@ -186,7 +186,7 @@ class DeepSpeedTransformerFunction(Function):
                               1)
             input_mask = torch.cat((input_mask, torch.zeros((inp_size[0], input_mask.shape[1], input_mask.shape[2], \
                                             (16 - (inp_size[1] % 16))), device=input_mask.device, dtype=input_mask.dtype)), 3)
-            input_mask = torch.where(input_mask > 0.0, input_mask, -1e4)
+            input_mask = torch.where(input_mask > 0.0, 0.0, -1e4)
 
         (output,
          inp_norm,

--- a/deepspeed/ops/transformer/transformer.py
+++ b/deepspeed/ops/transformer/transformer.py
@@ -184,8 +184,9 @@ class DeepSpeedTransformerFunction(Function):
                                            device=input.device,
                                            dtype=input.dtype)),
                               1)
-            input_mask = torch.cat((input_mask, torch.ones((inp_size[0], input_mask.shape[1], input_mask.shape[2], \
-                                            (16 - (inp_size[1] % 16))), device=input_mask.device, dtype=input_mask.dtype) * -10000), 3)
+            input_mask = torch.cat((input_mask, torch.zeros((inp_size[0], input_mask.shape[1], input_mask.shape[2], \
+                                            (16 - (inp_size[1] % 16))), device=input_mask.device, dtype=input_mask.dtype)), 3)
+            input_mask = torch.where(input_mask > 0.0, input_mask, -1e4)
 
         (output,
          inp_norm,


### PR DESCRIPTION
## What changed

Fix attention_mask issue at replaced DeepSpeedTransformer #1912

- Fix input_mask ignoring issue casued by dummy input 
- Fix attention_mask 0.0 value was not replaced to -1e4 at DeepSpeedTransformerFunction

## Description

Even though attention_mask is given, the current implementation simply ignores the attention_mask input.
So padded tokens are applied to softmax calculation. Which is not intended logic.

You can compare the result of HuggingFace and DeepSpeed generation when the padded inputs are given.
Huggingface model.generate and DeepSpeed inference engine's model.generate showed a different result.

This is caused by the attention_mask ignoring and wrong negative bias value replacement.

## Related issue

resolve https://github.com/microsoft/DeepSpeed/issues/1912
I think this PR could fix the https://github.com/microsoft/DeepSpeed/issues/1797


## Reproduce

Compare the running result with master branch of Deepspeed and this PR.

```python3
import os
import deepspeed
import argparse
import torch
from transformers import GPT2Config, GPT2LMHeadModel

# fmt: off
parser = argparse.ArgumentParser()
parser.add_argument("--local_rank", type=int, help="Deepspeed MPI local rank")
# fmt: on


def main():
    device = torch.device("cuda")
    input_ids = [1, 2, 3, 4, 5]
    padding = [0] * 8
    input_ids = torch.tensor([padding + input_ids], dtype=torch.long, device=device)
    print(input_ids)

    model_config = GPT2Config.from_json_file("<config.json>")
    model = GPT2LMHeadModel(model_config)
    model = model.to(device)
    model.eval()

    generate_kwargs = {
        "pad_token_id": 0,
        "min_length": 30,
        "max_length": 40,
        "do_sample": False,
        "early_stopping": False,
    }
    with torch.inference_mode():
        hf_generated_ids = model.generate(input_ids, **generate_kwargs)
        hf_generated_text = tokenizer.decode(hf_generated_ids.tolist()[0], skip_special_tokens=False)

        print("======deepspeed======")
        model = deepspeed.init_inference(
            model=model,
            mp_size=int(os.getenv("WORLD_SIZE", "1")),
            dtype=torch.float16,
            replace_method="auto",
            replace_with_kernel_inject=True,
        )
        deepspeed_generated_ids = model.generate(input_ids, **generate_kwargs)
        deepspeed_generated_text = tokenizer.decode(deepspeed_generated_ids.tolist()[0], skip_special_tokens=False)

        print(hf_generated_ids)
        print(deepspeed_generated_ids)
        print()
        print(hf_generated_text)
        print(deepspeed_generated_text)


if __name__ == "__main__":
    main()
```

## Acknowledgment 

worked with @ckw1140

cc @jeffra 