### PR TITLE
[build] explicitly add op_builder to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include *.txt README.md
 recursive-include requirements *.txt
 recursive-include deepspeed *.cpp *.h *.cu *.hip *.tr *.cuh *.cc *.json
 recursive-include csrc *.cpp *.h *.cu *.tr *.cuh *.cc
+recursive-include op_builder *.py


### PR DESCRIPTION
@mrwyattii and I debugged the build issues w. 0.6.2 and narrowed it down to this weird issue where sometimes `op_builder` is not included in the sdist build. It's still not clear why this is needed but this solution does reliably fix the issue it seems.