### PR TITLE
Enable DeepSpeed inference on ROCm 

### DIFF
--- a/csrc/transformer/inference/csrc/apply_rotary_pos_emb.cu
+++ b/csrc/transformer/inference/csrc/apply_rotary_pos_emb.cu
@@ -1,6 +1,8 @@
 #include "custom_cuda_layers.h"
 
+#ifndef __HIP_PLATFORM_HCC__
 #include <cuda_profiler_api.h>
+#endif
 
 namespace cg = cooperative_groups;
 

--- a/csrc/transformer/inference/csrc/normalize.cu
+++ b/csrc/transformer/inference/csrc/normalize.cu
@@ -1,7 +1,9 @@
 #include <limits>
 #include "custom_cuda_layers.h"
 
+#ifndef __HIP_PLATFORM_HCC__
 #include <cuda_profiler_api.h>
+#endif
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>

--- a/csrc/transformer/inference/csrc/pt_binding.cpp
+++ b/csrc/transformer/inference/csrc/pt_binding.cpp
@@ -90,7 +90,11 @@ at::Tensor einsum_sec_sm_ecm(at::Tensor& Q, at::Tensor& W)
                    (T*)W.data_ptr(),
                    (T*)Q.data_ptr(),
                    (T*)O.data_ptr(),
+#ifdef __HIP_PLATFORM_HCC__
+                   rocblas_gemm_algo_standard);
+#else
                    CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+#endif
     return O;
 }
 
@@ -135,7 +139,11 @@ void attention_unfused(at::Tensor& prev_key_cont,
                                 seq_len * k,
                                 seq_len * soft_len,
                                 bsz * heads,
+#ifdef __HIP_PLATFORM_HCC__
+                                rocblas_gemm_algo_standard);
+#else
                                 CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+#endif
     attn_score = ds_softmax<T>(
         attn_score, attn_mask, triangular, recompute, local_attention, window_size, false);
     alpha = 1.0;
@@ -154,7 +162,11 @@ void attention_unfused(at::Tensor& prev_key_cont,
                                 seq_len * soft_len,
                                 seq_len * k,
                                 bsz * heads,
+#ifdef __HIP_PLATFORM_HCC__
+                                rocblas_gemm_algo_standard);
+#else
                                 CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+#endif
 }
 
 template <typename T>
@@ -288,7 +300,11 @@ at::Tensor qkv_unfused_cublas(at::Tensor& output,
                    (T*)weight.data_ptr(),
                    (T*)inp_norm.data_ptr(),
                    (T*)output.data_ptr(),
+#ifdef __HIP_PLATFORM_HCC__
+                   rocblas_gemm_algo_standard);
+#else
                    CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+#endif
     if (add_bias)
         launch_bias_add((T*)output.data_ptr(),
                         (T*)bias.data_ptr(),
@@ -362,7 +378,11 @@ void quantized_gemm(at::Tensor& output,
                    (T*)weight16.data_ptr(),
                    (T*)input.data_ptr(),
                    (T*)output.data_ptr(),
+#ifdef __HIP_PLATFORM_HCC__
+                   rocblas_gemm_algo_standard);
+#else
                    CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+#endif
 }
 
 template <typename T>
@@ -427,7 +447,11 @@ at::Tensor ds_linear_layer(at::Tensor& input, at::Tensor& weight, at::Tensor& bi
                    (T*)weight.data_ptr(),
                    (T*)input_cont.data_ptr(),
                    (T*)output.data_ptr(),
+#ifdef __HIP_PLATFORM_HCC__
+                   rocblas_gemm_algo_standard);
+#else
                    CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+#endif
 
     launch_bias_add((T*)output.data_ptr(),
                     (T*)bias.data_ptr(),
@@ -491,7 +515,11 @@ at::Tensor ds_vector_matmul(at::Tensor& input, at::Tensor& weight, bool async_op
                    (T*)weight.data_ptr(),
                    (T*)input_cont.data_ptr(),
                    (T*)output.data_ptr(),
+#ifdef __HIP_PLATFORM_HCC__
+                   rocblas_gemm_algo_standard);
+#else
                    CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+#endif
     return output;
 }
 
@@ -559,7 +587,11 @@ void mlp_unfused_cublas(at::Tensor& output,
                    (T*)weight.data_ptr(),
                    (T*)inp_norm.data_ptr(),
                    (T*)output.data_ptr(),
+#ifdef __HIP_PLATFORM_HCC__
+                   rocblas_gemm_algo_standard);
+#else
                    CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+#endif
     launch_bias_gelu((T*)output.data_ptr(),
                      (T*)bias.data_ptr(),
                      weight.size(1),
@@ -687,7 +719,11 @@ at::Tensor fused_gemm_gelu(at::Tensor& input,
                    (T*)weight.data_ptr(),
                    (T*)input_cont.data_ptr(),
                    (T*)intermediate.data_ptr(),
+#ifdef __HIP_PLATFORM_HCC__
+                   rocblas_gemm_algo_standard);
+#else
                    CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+#endif
     launch_bias_gelu((T*)intermediate.data_ptr(),
                      (T*)bias.data_ptr(),
                      weight.size(1),
@@ -705,7 +741,11 @@ at::Tensor fused_gemm_gelu(at::Tensor& input,
                    (T*)weight_out.data_ptr(),
                    (T*)intermediate.data_ptr(),
                    (T*)output.data_ptr(),
+#ifdef __HIP_PLATFORM_HCC__
+                   rocblas_gemm_algo_standard);
+#else
                    CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+#endif
     // cudaEventRecord(Context::Instance().GetCompEvent(2),
     //                Context::Instance().GetCurrentStream(true));
     return output;

--- a/csrc/transformer/inference/csrc/softmax.cu
+++ b/csrc/transformer/inference/csrc/softmax.cu
@@ -1,7 +1,9 @@
 #include <limits>
 #include "custom_cuda_layers.h"
 
+#ifndef __HIP_PLATFORM_HCC__
 #include <cuda_profiler_api.h>
+#endif
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>

--- a/csrc/transformer/inference/includes/context.h
+++ b/csrc/transformer/inference/includes/context.h
@@ -49,11 +49,18 @@ public:
             std::cerr << message << std::endl;
             throw std::runtime_error(message);
         }
+	#ifndef __HIP_PLATFORM_HCC__
         cublasSetMathMode(_cublasHandle, CUBLAS_TENSOR_OP_MATH);
-        cudaEventCreate(&_comp1_event, (cudaEventDisableTiming | cudaEventBlockingSync));
+	cudaEventCreate(&_comp1_event, (cudaEventDisableTiming | cudaEventBlockingSync));
         cudaEventCreate(&_comp2_event, (cudaEventDisableTiming | cudaEventBlockingSync));
         cudaEventCreate(&_comp_event, (cudaEventDisableTiming | cudaEventBlockingSync));
         cudaEventCreate(&_comm_event, (cudaEventDisableTiming | cudaEventBlockingSync));
+        #else
+	cudaEventCreate(&_comp1_event);
+        cudaEventCreate(&_comp2_event);
+        cudaEventCreate(&_comp_event);
+        cudaEventCreate(&_comm_event);
+        #endif
     }
 
     virtual ~Context()

--- a/csrc/transformer/inference/includes/cublas_wrappers.h
+++ b/csrc/transformer/inference/includes/cublas_wrappers.h
@@ -5,9 +5,25 @@
 #include <cuda.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#ifndef __HIP_PLATFORM_HCC__
 #include <mma.h>
+#endif
 #include <stdio.h>
 
+#ifdef __HIP_PLATFORM_HCC__
+int cublas_gemm_ex(rocblas_handle handle,
+                   rocblas_operation transa,
+                   rocblas_operation transb,
+                   int m,
+                   int n,
+                   int k,
+                   const float* alpha,
+                   const float* beta,
+                   const float* A,
+                   const float* B,
+                   float* C,
+                   rocblas_gemm_algo algo)
+#else
 int cublas_gemm_ex(cublasHandle_t handle,
                    cublasOperation_t transa,
                    cublasOperation_t transb,
@@ -20,7 +36,34 @@ int cublas_gemm_ex(cublasHandle_t handle,
                    const float* B,
                    float* C,
                    cublasGemmAlgo_t algo)
+#endif
 {
+#ifdef __HIP_PLATFORM_HCC__
+    rocblas_status status = rocblas_gemm_ex(handle,
+                                            transa,
+                                            transb,
+                                            m,
+                                            n,
+                                            k,
+                                            (const void*)alpha,
+                                            (const void*)A,
+                                            rocblas_datatype_f32_r,
+                                            (transa == rocblas_operation_none) ? m : k,
+                                            (const void*)B,
+                                            rocblas_datatype_f32_r,
+                                            (transb == rocblas_operation_none) ? k : n,
+                                            (const void*)beta,
+                                            C,
+                                            rocblas_datatype_f32_r,
+                                            m,
+                                            C,
+                                            rocblas_datatype_f32_r,
+                                            m,
+                                            rocblas_datatype_f32_r,
+                                            algo,
+                                            0,
+                                            0);
+#else
     cublasStatus_t status = cublasGemmEx(handle,
                                          transa,
                                          transb,
@@ -40,8 +83,13 @@ int cublas_gemm_ex(cublasHandle_t handle,
                                          m,
                                          CUDA_R_32F,
                                          algo);
+#endif
 
+#ifdef __HIP_PLATFORM_HCC__
+    if (status != rocblas_status_success) {
+#else
     if (status != CUBLAS_STATUS_SUCCESS) {
+#endif
         fprintf(stderr,
                 "!!!! kernel execution error. (m: %d, n: %d, k: %d, error: %d) \n",
                 m,
@@ -53,6 +101,20 @@ int cublas_gemm_ex(cublasHandle_t handle,
     return 0;
 }
 
+#ifdef __HIP_PLATFORM_HCC__
+int cublas_gemm_ex(rocblas_handle handle,
+                   rocblas_operation transa,
+                   rocblas_operation transb,
+                   int m,
+                   int n,
+                   int k,
+                   const float* alpha,
+                   const float* beta,
+                   const __half* A,
+                   const __half* B,
+                   __half* C,
+                   rocblas_gemm_algo algo)
+#else
 int cublas_gemm_ex(cublasHandle_t handle,
                    cublasOperation_t transa,
                    cublasOperation_t transb,
@@ -65,7 +127,34 @@ int cublas_gemm_ex(cublasHandle_t handle,
                    const __half* B,
                    __half* C,
                    cublasGemmAlgo_t algo)
+#endif
 {
+#ifdef __HIP_PLATFORM_HCC__
+    rocblas_status status = rocblas_gemm_ex(handle,
+                                            transa,
+                                            transb,
+                                            m,
+                                            n,
+                                            k,
+                                            (const void*)alpha,
+                                            (const void*)A,
+                                            rocblas_datatype_f16_r,
+                                            (transa == rocblas_operation_none) ? m : k,
+                                            (const void*)B,
+                                            rocblas_datatype_f16_r,
+                                            (transb == rocblas_operation_none) ? k : n,
+                                            (const void*)beta,
+                                            (void*)C,
+                                            rocblas_datatype_f16_r,
+                                            m,
+                                            (void*)C,
+                                            rocblas_datatype_f16_r,
+                                            m,
+                                            rocblas_datatype_f32_r,
+                                            algo,
+                                            0,
+                                            0);
+#else
     cublasStatus_t status = cublasGemmEx(handle,
                                          transa,
                                          transb,
@@ -85,8 +174,13 @@ int cublas_gemm_ex(cublasHandle_t handle,
                                          m,
                                          CUDA_R_32F,
                                          algo);
+#endif
 
+#ifdef __HIP_PLATFORM_HCC__
+    if (status != rocblas_status_success) {
+#else
     if (status != CUBLAS_STATUS_SUCCESS) {
+#endif
         fprintf(stderr,
                 "!!!! kernel execution error. (m: %d, n: %d, k: %d, error: %d) \n",
                 m,
@@ -98,6 +192,24 @@ int cublas_gemm_ex(cublasHandle_t handle,
     return 0;
 }
 
+#ifdef __HIP_PLATFORM_HCC__
+int cublas_strided_batched_gemm(rocblas_handle handle,
+                                int m,
+                                int n,
+                                int k,
+                                const float* alpha,
+                                const float* beta,
+                                const float* A,
+                                const float* B,
+                                float* C,
+                                rocblas_operation op_A,
+                                rocblas_operation op_B,
+                                int stride_A,
+                                int stride_B,
+                                int stride_C,
+                                int batch,
+                                rocblas_gemm_algo algo)
+#else
 int cublas_strided_batched_gemm(cublasHandle_t handle,
                                 int m,
                                 int n,
@@ -114,7 +226,40 @@ int cublas_strided_batched_gemm(cublasHandle_t handle,
                                 int stride_C,
                                 int batch,
                                 cublasGemmAlgo_t algo)
+#endif
 {
+#ifdef __HIP_PLATFORM_HCC__
+    rocblas_status status =
+        rocblas_gemm_strided_batched_ex(handle,
+                                        op_A,
+                                        op_B,
+                                        m,
+                                        n,
+                                        k,
+                                        alpha,
+                                        A,
+                                        rocblas_datatype_f32_r,
+                                        (op_A == rocblas_operation_none) ? m : k,
+                                        stride_A,
+                                        B,
+                                        rocblas_datatype_f32_r,
+                                        (op_B == rocblas_operation_none) ? k : n,
+                                        stride_B,
+                                        beta,
+                                        C,
+                                        rocblas_datatype_f32_r,
+                                        m,
+                                        stride_C,
+                                        C,
+                                        rocblas_datatype_f32_r,
+                                        m,
+                                        stride_C,
+                                        batch,
+                                        rocblas_datatype_f32_r,
+                                        algo,
+                                        0,
+                                        0);
+#else
     cublasStatus_t status = cublasGemmStridedBatchedEx(handle,
                                                        op_A,
                                                        op_B,
@@ -138,8 +283,13 @@ int cublas_strided_batched_gemm(cublasHandle_t handle,
                                                        batch,
                                                        CUDA_R_32F,
                                                        algo);
+#endif
 
+#ifdef __HIP_PLATFORM_HCC__
+    if (status != rocblas_status_success) {
+#else
     if (status != CUBLAS_STATUS_SUCCESS) {
+#endif
         fprintf(stderr,
                 "!!!! kernel execution error. (batch: %d, m: %d, n: %d, k: %d, error: %d) \n",
                 batch,
@@ -152,6 +302,24 @@ int cublas_strided_batched_gemm(cublasHandle_t handle,
     return 0;
 }
 
+#ifdef __HIP_PLATFORM_HCC__
+int cublas_strided_batched_gemm(rocblas_handle handle,
+                                int m,
+                                int n,
+                                int k,
+                                const float* alpha,
+                                const float* beta,
+                                const __half* A,
+                                const __half* B,
+                                __half* C,
+                                rocblas_operation op_A,
+                                rocblas_operation op_B,
+                                int stride_A,
+                                int stride_B,
+                                int stride_C,
+                                int batch,
+                                rocblas_gemm_algo algo)
+#else
 int cublas_strided_batched_gemm(cublasHandle_t handle,
                                 int m,
                                 int n,
@@ -168,7 +336,40 @@ int cublas_strided_batched_gemm(cublasHandle_t handle,
                                 int stride_C,
                                 int batch,
                                 cublasGemmAlgo_t algo)
+#endif
 {
+#ifdef __HIP_PLATFORM_HCC__
+    rocblas_status status =
+        rocblas_gemm_strided_batched_ex(handle,
+                                        op_A,
+                                        op_B,
+                                        m,
+                                        n,
+                                        k,
+                                        alpha,
+                                        A,
+                                        rocblas_datatype_f16_r,
+                                        (op_A == rocblas_operation_none) ? m : k,
+                                        stride_A,
+                                        B,
+                                        rocblas_datatype_f16_r,
+                                        (op_B == rocblas_operation_none) ? k : n,
+                                        stride_B,
+                                        beta,
+                                        C,
+                                        rocblas_datatype_f16_r,
+                                        m,
+                                        stride_C,
+                                        C,
+                                        rocblas_datatype_f16_r,
+                                        m,
+                                        stride_C,
+                                        batch,
+                                        rocblas_datatype_f32_r,
+                                        algo,
+                                        0,
+                                        0);
+#else
     cublasStatus_t status = cublasGemmStridedBatchedEx(handle,
                                                        op_A,
                                                        op_B,
@@ -192,8 +393,13 @@ int cublas_strided_batched_gemm(cublasHandle_t handle,
                                                        batch,
                                                        CUDA_R_32F,
                                                        algo);
+#endif
 
+#ifdef __HIP_PLATFORM_HCC__
+    if (status != rocblas_status_success) {
+#else
     if (status != CUBLAS_STATUS_SUCCESS) {
+#endif
         fprintf(stderr,
                 "!!!! kernel execution error. (m: %d, n: %d, k: %d, error: %d) \n",
                 m,


### PR DESCRIPTION
This code is required to enable DeepSpeed inference examples on ROCm devices.

CC @jithunnair-amd @jeffdaily 