### PR TITLE
[bug] Fix time log error in PipelineEngine

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -357,7 +357,7 @@ class PipelineEngine(DeepSpeedEngine):
 
         if self.global_steps % self.steps_per_print() == 0:
             if self.global_rank == 0:
-                elapsed = self.timers('train_batch').elapsed(reset=True)
+                elapsed = self.timers('train_batch').elapsed(reset=True) / 1000.0
                 iter_time = elapsed / self.steps_per_print()
                 tput = self.train_batch_size() / iter_time
                 print(f'steps: {self.global_steps} '


### PR DESCRIPTION
In `engine.py` line 360 to 366, the codes want to print something in seconds:

```python
  elapsed = self.timers('train_batch').elapsed(reset=True)
  iter_time = elapsed / self.steps_per_print()
  tput = self.train_batch_size() / iter_time
  print(f'steps: {self.global_steps} '
        f'loss: {self.agg_train_loss:0.4f} '
        f'iter time (s): {iter_time:0.3f} '
        f'samples/sec: {tput:0.3f}')
```

But in timer, it get elapsed time by `_get_elapsed_msec` method which returns time in msec.
```python
def elapsed(self, reset=True):
"""Calculate the elapsed time."""
    started_ = self.started_
    # If the timing in progress, end it first.
    if self.started_:
        self.stop()
    # Get the elapsed time.
    elapsed_ = self._get_elapsed_msec()
    # Reset the elapsed time
    if reset:
        self.reset()
    # If timing was in progress, set it back.
    if started_:
        self.start()
    return elapsed_
```

