### PR TITLE
GatheredParameters - accept a tuple of params

### DIFF
--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -11,6 +11,7 @@ from typing import Callable, Iterable
 from enum import Enum
 import functools
 import itertools
+import collections.abc
 from typing import List
 
 import torch
@@ -1615,7 +1616,7 @@ class GatheredParameters:
         if not enabled:
             return
 
-        if not isinstance(params, list):
+        if not isinstance(params, collections.abc.Iterable):
             params = [params]
 
         # enable if at least one is zero-param, otherwise a noop

--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -1615,7 +1615,7 @@ class GatheredParameters:
         if not enabled:
             return
 
-        if not (isinstance(params, list) or isinstance(params, tuple):
+        if not (isinstance(params, list) or isinstance(params, tuple)):
             params = [params]
 
         # enable if at least one is zero-param, otherwise a noop

--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -11,7 +11,6 @@ from typing import Callable, Iterable
 from enum import Enum
 import functools
 import itertools
-import collections.abc
 from typing import List
 
 import torch
@@ -1534,7 +1533,7 @@ class GatheredParameters:
         again upon exit.
 
         Args:
-            params (``torch.nn.Parameter``): A single parameter or a list of parameters to collect.
+            params (``torch.nn.Parameter``): A single parameter or a list or a tuple of parameters to collect.
                 It's assumed that all parameters are zero params.
             modifier_rank (int, optional): If specified, this rank's parameter will be
                 broadcasted on exit from the context. This argument is required if ``params`` are
@@ -1616,7 +1615,7 @@ class GatheredParameters:
         if not enabled:
             return
 
-        if not isinstance(params, collections.abc.Iterable):
+        if not (isinstance(params, list) or isinstance(params, tuple):
             params = [params]
 
         # enable if at least one is zero-param, otherwise a noop


### PR DESCRIPTION
Currently passing a tuple of params to `GatheredParameters` silently fails. So extending to support tuples.

I first tried using any iterable, but pytorch's single tensor is an iterable so that approach fails.

@jeffra, @tjruwase