### PR TITLE
[pipe] prevent deadlock with multiple evals sequence

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -445,6 +445,10 @@ class PipelineEngine(DeepSpeedEngine):
         sched = schedule.InferenceSchedule(micro_batches=self.micro_batches,
                                            stages=self.num_stages,
                                            stage_id=self.stage_id)
+        
+        # prevent dead-lock with multiple evals sequence
+        dist.barrier()
+        
         with torch.no_grad():
             self._exec_schedule(sched)
 

--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -448,7 +448,7 @@ class PipelineEngine(DeepSpeedEngine):
         
         # prevent dead-lock with multiple evals sequence
         dist.barrier()
-        
+
         with torch.no_grad():
             self._exec_schedule(sched)
 

--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -445,7 +445,7 @@ class PipelineEngine(DeepSpeedEngine):
         sched = schedule.InferenceSchedule(micro_batches=self.micro_batches,
                                            stages=self.num_stages,
                                            stage_id=self.stage_id)
-        
+
         # prevent dead-lock with multiple evals sequence
         dist.barrier()
 


### PR DESCRIPTION
This PR solves a race condition that leads to deadlocks at random times at eval@pipe.

Here is the diagnostics with tracebacks: https://github.com/bigscience-workshop/bigscience/blob/master/train/tr11-176B-ml/chronicles.md#2022-04-30-hanging-at-eval

The suspect code is:

https://github.com/microsoft/DeepSpeed/blob/a3b90030fd2bea119ea0d4b521057fd84a48705f/deepspeed/runtime/pipe/engine.py#L448-L455

I'm not 100% sure this is the best placement of the barrier but it solves the problem.

e.g. placing it 3 ops below after:

https://github.com/microsoft/DeepSpeed/blob/a3b90030fd2bea119ea0d4b521057fd84a48705f/deepspeed/runtime/pipe/engine.py#L455

didn't help.

So it's possible that some desyncing happening after L455 and before L448 when it comes in for a 2nd eval in a row.


@tjruwase, @jeffra 