### PR TITLE
Enabling CUDA-graph for the bert-type models

### DIFF
--- a/deepspeed/__init__.py
+++ b/deepspeed/__init__.py
@@ -236,7 +236,8 @@ def init_inference(model,
                    moe=False,
                    moe_experts=1,
                    moe_type='standard',
-                   args=None):
+                   args=None,
+                   enable_cuda_graph=True):
     """Initialize the DeepSpeed InferenceEngine.
 
     Arguments:
@@ -301,6 +302,7 @@ def init_inference(model,
                              moe,
                              moe_experts,
                              moe_type,
-                             args)
+                             args,
+                             enable_cuda_graph)
 
     return engine


### PR DESCRIPTION
This PR adds the CUDA_Graph feature at deepspeed-inference. This can be enabled by adding the flag `enable_cuda_graph` when calling `deepspeed.init_inference()`.
