### PR TITLE
Fix typo in timer.py

### DIFF
--- a/deepspeed/utils/timer.py
+++ b/deepspeed/utils/timer.py
@@ -44,7 +44,7 @@ class SynchronizedWallClockTimer:
 
         def start(self):
             """Start the timer."""
-            assert not self.started_, f"{self.name} timer has already been started"
+            assert not self.started_, f"{self.name_} timer has already been started"
             self.start_event = torch.cuda.Event(enable_timing=True)
             self.start_event.record()
             self.started_ = True


### PR DESCRIPTION
Small typo introduced in https://github.com/microsoft/DeepSpeed/commit/fee73135980e78f8be7e1a3ff556751623ef6aaa causes assertion to fail at https://github.com/microsoft/DeepSpeed/blob/master/deepspeed/utils/timer.py#L47