### PR TITLE
[PLEASE DONT MERGE] device/runtime abstraction for cuda/xpu co-exist

### DIFF
--- a/deepspeed/accelerator/__init__.py
+++ b/deepspeed/accelerator/__init__.py
@@ -1,0 +1,1 @@
+from .device import literal_device, on_accel_device

--- a/deepspeed/accelerator/device.py
+++ b/deepspeed/accelerator/device.py
@@ -1,0 +1,57 @@
+import torch
+global device_type
+
+# TODO detect device on host and check whether device type is the same with device_string
+# TODO set device_type to None if no GPU device installed on host
+def set_device_type(device_string):
+    global device_type
+
+    if device_string == 'cuda' or device_string == 'xpu':
+        device_type = device_string
+    else:
+        print("Warning: unrecognized device type, default to 'cuda' device")
+        device_type = 'cuda'
+
+# TODO throw exception when device_type == None
+def literal_device(ordinal=None):
+    global device_type
+
+    if ordinal == None:
+        return device_type
+    else:
+        return "{}:{}".format(device_type, ordinal)
+
+'''
+Check whether the tensor is on the designated device type
+'''
+def on_accel_device(tensor):
+    global device_type
+
+    device_str = str(tensor.device)
+    if device_str.startswith('{}:'.format(device_type)):
+        return True
+    else:
+        return False
+
+# because xpu may not be imported, catch all possible errors
+try:
+    import intel_extension_for_pytorch as ipex
+    import torch_ccl
+    if torch.xpu.is_available():
+        device = 'xpu'
+    else:
+        device = ''
+except AttributeError:
+    device = ''
+except ModuleNotFoundError:
+    device = ''
+
+if device == '':
+    # TODO disable this to workaround a CUDA issue that CUDA cannot be
+    #      initialized before torch.multiprocessing, otherwise CUDA will fail
+    #      in subprocess
+    #if torch.cuda.is_available():
+    #    set_device_type('cuda')
+    set_device_type('cuda')
+else:
+    set_device_type(device)

--- a/deepspeed/accelerator/device.py
+++ b/deepspeed/accelerator/device.py
@@ -1,6 +1,7 @@
 import torch
 global device_type
 
+
 # TODO detect device on host and check whether device type is the same with device_string
 # TODO set device_type to None if no GPU device installed on host
 def set_device_type(device_string):
@@ -12,6 +13,7 @@ def set_device_type(device_string):
         print("Warning: unrecognized device type, default to 'cuda' device")
         device_type = 'cuda'
 
+
 # TODO throw exception when device_type == None
 def literal_device(ordinal=None):
     global device_type
@@ -21,9 +23,12 @@ def literal_device(ordinal=None):
     else:
         return "{}:{}".format(device_type, ordinal)
 
+
 '''
 Check whether the tensor is on the designated device type
 '''
+
+
 def on_accel_device(tensor):
     global device_type
 
@@ -32,6 +37,7 @@ def on_accel_device(tensor):
         return True
     else:
         return False
+
 
 # because xpu may not be imported, catch all possible errors
 try:

--- a/deepspeed/accelerator/runtime.py
+++ b/deepspeed/accelerator/runtime.py
@@ -1,0 +1,242 @@
+import torch
+from deepspeed.accelerator import literal_device
+
+def simple_accel_runtime_api(method):
+    def wrapper(*args, **kwargs):
+        device = literal_device()
+        # check device type against white list
+        assert device == 'cuda' or device == 'xpu'
+        # check method.__name__ against white list
+        assert (method.__name__ == 'set_device'
+            or method.__name__ == 'device'
+            or method.__name__ == 'device_count'
+            or method.__name__ == 'current_device'
+            or method.__name__ == 'synchronize'
+            or method.__name__ == 'get_rng_state'
+            or method.__name__ == 'current_stream'
+            or method.__name__ == 'current_stream'
+            or method.__name__ == 'memory_allocated'
+            or method.__name__ == 'max_memory_allocated'
+            or method.__name__ == 'max_memory_cached'
+            or method.__name__ == 'reset_max_memory_allocated'
+            or method.__name__ == 'reset_max_memory_cached'
+            or method.__name__ == 'empty_cache'
+            or method.__name__ == 'Event'
+            or method.__name__ == 'Stream'
+            or method.__name__ == 'stream'
+            or method.__name__ == 'DoubleTensor'
+            or method.__name__ == 'FloatTensor'
+            or method.__name__ == 'HalfTensor'
+            or method.__name__ == 'BFloat16Tensor'
+            or method.__name__ == 'IntTensor'
+            or method.__name__ == 'ByteTensor'
+            or method.__name__ == 'is_available'
+            or method.__name__ == 'manual_seed'
+            or method.__name__ == 'manual_seed_all'
+            or method.__name__ == '_lazy_call'
+            or method.__name__ == 'initial_seed')
+        return eval("torch.{}.{}".format(device, method.__name__))(*args, **kwargs)
+    return wrapper
+
+@simple_accel_runtime_api
+def set_device(rank): pass
+
+@simple_accel_runtime_api
+def device(device): pass
+
+@simple_accel_runtime_api
+def device_count(): pass
+
+@simple_accel_runtime_api
+def current_device(): pass
+
+@simple_accel_runtime_api
+def synchronize(): pass
+
+@simple_accel_runtime_api
+def get_rng_state(): pass
+
+@simple_accel_runtime_api
+def current_stream(): pass
+
+@simple_accel_runtime_api
+def memory_allocated(): pass
+
+@simple_accel_runtime_api
+def max_memory_allocated(): pass
+
+@simple_accel_runtime_api
+def max_memory_cached(): pass
+
+@simple_accel_runtime_api
+def reset_max_memory_allocated(): pass
+
+@simple_accel_runtime_api
+def reset_max_memory_cached(): pass
+
+@simple_accel_runtime_api
+def empty_cache(): pass
+
+@simple_accel_runtime_api
+def Event(): pass
+
+@simple_accel_runtime_api
+def Stream(): pass
+
+@simple_accel_runtime_api
+def stream(): pass
+
+@simple_accel_runtime_api
+def DoubleTensor(data): pass
+
+@simple_accel_runtime_api
+def FloatTensor(data): pass
+
+@simple_accel_runtime_api
+def HalfTensor(data): pass
+
+@simple_accel_runtime_api
+def BFloat16Tensor(data): pass
+
+@simple_accel_runtime_api
+def IntTensor(data): pass
+
+@simple_accel_runtime_api
+def ByteTensor(data): pass
+
+@simple_accel_runtime_api
+def is_available(data): pass
+
+@simple_accel_runtime_api
+def manual_seed(seed): pass
+
+@simple_accel_runtime_api
+def manual_seed_all(seed): pass
+
+@simple_accel_runtime_api
+def initial_seed(): pass
+
+@simple_accel_runtime_api
+def _lazy_call(cb): pass
+
+# APIs below does not have simple implementation
+
+def memory_stats():
+    device = literal_device()
+    if device == 'cuda':
+        if hasattr(torch.cuda, "memory_stats"):
+            return torch.cuda.memory_stats()
+        else:
+            return None
+    else:
+        assert device == 'xpu'
+        return torch.xpu.memory_stats()
+
+def reset_peak_memory_stats():
+    device = literal_device()
+    if device == 'cuda':
+        if hasattr(torch.cuda, "reset_peak_memory_stats"):  # pytorch 1.4+
+            torch.cuda.reset_peak_memory_stats()
+    else:
+        assert device == 'xpu'
+        torch.xpu.reset_peak_memory_stats()
+
+def default_generator(idx):
+    device = literal_device()
+    if device == 'cuda':
+        return torch.cuda.default_generators[idx]
+    else:
+        assert device == 'xpu'
+        torch.xpu.default_generators[idx]
+
+def is_fp16_supported():
+    device = literal_device()
+    if device == 'cuda':
+        major, _ = torch.cuda.get_device_capability()
+        if major >= 7:
+            return True
+        else:
+            return False
+    elif device == 'xpu':
+        return True
+    else:
+        return False
+
+def is_bf16_supported():
+    device = literal_device()
+    if device == 'cuda':
+        return torch.cuda.is_bf16_supported()
+    elif device == 'xpu':
+        return True
+    else:
+        return False
+
+def memory_reserved():
+    device = literal_device()
+    if device == 'cuda':
+        if hasattr(torch.cuda, "memory_reserved"):
+            return torch.cuda.memory_reserved
+        else:
+            return torch.cuda.memory_allocated
+    else:
+        assert device == 'xpu'
+        return torch.xpu.memory_reserved()
+
+def max_memory_reserved():
+    device = literal_device()
+    if device == 'cuda':
+        if hasattr(torch.cuda, "max_memory_reserved"):
+            return torch.cuda.max_memory_reserved
+        else:
+            return torch.cuda.memory_cached()
+    else:
+        assert device == 'xpu'
+        return torch.xpu.max_memory_reserved()
+
+def memory_cached():
+    device == literal_device()
+    if device == 'cuda':
+        return torch.cuda.memory_cached()
+    else:
+        assert device == 'xpu'
+        return torch.xpu.memory_reserved()
+
+def max_memory_cached():
+    device == literal_device()
+    if device == 'cuda':
+        return torch.cuda.max_memory_cached()
+    else:
+        assert device == 'xpu'
+        return torch.xpu.max_memory_reserved()
+
+def total_memory():
+    device = literal_device()
+    # Assume all device has same amount of memory
+    if device == 'cuda':
+        return torch.cuda.get_device_properties(0).total_memory
+    else:
+        return torch.xpu.get_device_properties(0).total_memory
+
+def default_stream():
+    device = literal_device()
+    if device == 'cuda':
+        return torch.cuda.default_stream()
+    else:
+        assert device == 'xpu'
+        return torch.xpu.current_stream()
+
+def range_push(msg):
+    device = literal_device()
+    if device == 'cuda':
+        torch.cuda.nvtx.range_push(msg)
+    else:
+        assert device == 'xpu'
+        torch.xpu.itt.range_push(msg)
+
+def range_pop():
+    device = literal_device()
+    if device == 'cuda':
+        torch.cuda.nvtx.range_pop()
+    else:
+        assert device == 'xpu'
+        torch.xpu.itt.range_pop()

--- a/deepspeed/accelerator/runtime.py
+++ b/deepspeed/accelerator/runtime.py
@@ -1,125 +1,174 @@
 import torch
 from deepspeed.accelerator import literal_device
 
+
 def simple_accel_runtime_api(method):
     def wrapper(*args, **kwargs):
         device = literal_device()
         # check device type against white list
         assert device == 'cuda' or device == 'xpu'
         # check method.__name__ against white list
-        assert (method.__name__ == 'set_device'
-            or method.__name__ == 'device'
-            or method.__name__ == 'device_count'
-            or method.__name__ == 'current_device'
-            or method.__name__ == 'synchronize'
-            or method.__name__ == 'get_rng_state'
-            or method.__name__ == 'current_stream'
-            or method.__name__ == 'current_stream'
-            or method.__name__ == 'memory_allocated'
-            or method.__name__ == 'max_memory_allocated'
-            or method.__name__ == 'max_memory_cached'
-            or method.__name__ == 'reset_max_memory_allocated'
-            or method.__name__ == 'reset_max_memory_cached'
-            or method.__name__ == 'empty_cache'
-            or method.__name__ == 'Event'
-            or method.__name__ == 'Stream'
-            or method.__name__ == 'stream'
-            or method.__name__ == 'DoubleTensor'
-            or method.__name__ == 'FloatTensor'
-            or method.__name__ == 'HalfTensor'
-            or method.__name__ == 'BFloat16Tensor'
-            or method.__name__ == 'IntTensor'
-            or method.__name__ == 'ByteTensor'
-            or method.__name__ == 'is_available'
-            or method.__name__ == 'manual_seed'
-            or method.__name__ == 'manual_seed_all'
-            or method.__name__ == '_lazy_call'
-            or method.__name__ == 'initial_seed')
+        assert (method.__name__ == 'set_device' or method.__name__ == 'device'
+                or method.__name__ == 'device_count'
+                or method.__name__ == 'current_device'
+                or method.__name__ == 'synchronize' or method.__name__ == 'get_rng_state'
+                or method.__name__ == 'current_stream'
+                or method.__name__ == 'current_stream'
+                or method.__name__ == 'memory_allocated'
+                or method.__name__ == 'max_memory_allocated'
+                or method.__name__ == 'max_memory_cached'
+                or method.__name__ == 'reset_max_memory_allocated'
+                or method.__name__ == 'reset_max_memory_cached'
+                or method.__name__ == 'empty_cache' or method.__name__ == 'Event'
+                or method.__name__ == 'Stream' or method.__name__ == 'stream'
+                or method.__name__ == 'DoubleTensor' or method.__name__ == 'FloatTensor'
+                or method.__name__ == 'HalfTensor' or method.__name__ == 'BFloat16Tensor'
+                or method.__name__ == 'IntTensor' or method.__name__ == 'ByteTensor'
+                or method.__name__ == 'is_available' or method.__name__ == 'manual_seed'
+                or method.__name__ == 'manual_seed_all'
+                or method.__name__ == '_lazy_call' or method.__name__ == 'initial_seed')
         return eval("torch.{}.{}".format(device, method.__name__))(*args, **kwargs)
+
     return wrapper
 
-@simple_accel_runtime_api
-def set_device(rank): pass
 
 @simple_accel_runtime_api
-def device(device): pass
+def set_device(rank):
+    pass
+
 
 @simple_accel_runtime_api
-def device_count(): pass
+def device(device):
+    pass
+
 
 @simple_accel_runtime_api
-def current_device(): pass
+def device_count():
+    pass
+
 
 @simple_accel_runtime_api
-def synchronize(): pass
+def current_device():
+    pass
+
 
 @simple_accel_runtime_api
-def get_rng_state(): pass
+def synchronize():
+    pass
+
 
 @simple_accel_runtime_api
-def current_stream(): pass
+def get_rng_state():
+    pass
+
 
 @simple_accel_runtime_api
-def memory_allocated(): pass
+def current_stream():
+    pass
+
 
 @simple_accel_runtime_api
-def max_memory_allocated(): pass
+def memory_allocated():
+    pass
+
 
 @simple_accel_runtime_api
-def max_memory_cached(): pass
+def max_memory_allocated():
+    pass
+
 
 @simple_accel_runtime_api
-def reset_max_memory_allocated(): pass
+def max_memory_cached():
+    pass
+
 
 @simple_accel_runtime_api
-def reset_max_memory_cached(): pass
+def reset_max_memory_allocated():
+    pass
+
 
 @simple_accel_runtime_api
-def empty_cache(): pass
+def reset_max_memory_cached():
+    pass
+
 
 @simple_accel_runtime_api
-def Event(): pass
+def empty_cache():
+    pass
+
 
 @simple_accel_runtime_api
-def Stream(): pass
+def Event():
+    pass
+
 
 @simple_accel_runtime_api
-def stream(): pass
+def Stream():
+    pass
+
 
 @simple_accel_runtime_api
-def DoubleTensor(data): pass
+def stream():
+    pass
+
 
 @simple_accel_runtime_api
-def FloatTensor(data): pass
+def DoubleTensor(data):
+    pass
+
 
 @simple_accel_runtime_api
-def HalfTensor(data): pass
+def FloatTensor(data):
+    pass
+
 
 @simple_accel_runtime_api
-def BFloat16Tensor(data): pass
+def HalfTensor(data):
+    pass
+
 
 @simple_accel_runtime_api
-def IntTensor(data): pass
+def BFloat16Tensor(data):
+    pass
+
 
 @simple_accel_runtime_api
-def ByteTensor(data): pass
+def IntTensor(data):
+    pass
+
 
 @simple_accel_runtime_api
-def is_available(data): pass
+def ByteTensor(data):
+    pass
+
 
 @simple_accel_runtime_api
-def manual_seed(seed): pass
+def is_available(data):
+    pass
+
 
 @simple_accel_runtime_api
-def manual_seed_all(seed): pass
+def manual_seed(seed):
+    pass
+
 
 @simple_accel_runtime_api
-def initial_seed(): pass
+def manual_seed_all(seed):
+    pass
+
 
 @simple_accel_runtime_api
-def _lazy_call(cb): pass
+def initial_seed():
+    pass
+
+
+@simple_accel_runtime_api
+def _lazy_call(cb):
+    pass
+
 
 # APIs below does not have simple implementation
+
 
 def memory_stats():
     device = literal_device()
@@ -132,6 +181,7 @@ def memory_stats():
         assert device == 'xpu'
         return torch.xpu.memory_stats()
 
+
 def reset_peak_memory_stats():
     device = literal_device()
     if device == 'cuda':
@@ -141,6 +191,7 @@ def reset_peak_memory_stats():
         assert device == 'xpu'
         torch.xpu.reset_peak_memory_stats()
 
+
 def default_generator(idx):
     device = literal_device()
     if device == 'cuda':
@@ -148,6 +199,7 @@ def default_generator(idx):
     else:
         assert device == 'xpu'
         torch.xpu.default_generators[idx]
+
 
 def is_fp16_supported():
     device = literal_device()
@@ -162,6 +214,7 @@ def is_fp16_supported():
     else:
         return False
 
+
 def is_bf16_supported():
     device = literal_device()
     if device == 'cuda':
@@ -170,6 +223,7 @@ def is_bf16_supported():
         return True
     else:
         return False
+
 
 def memory_reserved():
     device = literal_device()
@@ -182,6 +236,7 @@ def memory_reserved():
         assert device == 'xpu'
         return torch.xpu.memory_reserved()
 
+
 def max_memory_reserved():
     device = literal_device()
     if device == 'cuda':
@@ -193,6 +248,7 @@ def max_memory_reserved():
         assert device == 'xpu'
         return torch.xpu.max_memory_reserved()
 
+
 def memory_cached():
     device == literal_device()
     if device == 'cuda':
@@ -200,6 +256,7 @@ def memory_cached():
     else:
         assert device == 'xpu'
         return torch.xpu.memory_reserved()
+
 
 def max_memory_cached():
     device == literal_device()
@@ -209,6 +266,7 @@ def max_memory_cached():
         assert device == 'xpu'
         return torch.xpu.max_memory_reserved()
 
+
 def total_memory():
     device = literal_device()
     # Assume all device has same amount of memory
@@ -216,6 +274,7 @@ def total_memory():
         return torch.cuda.get_device_properties(0).total_memory
     else:
         return torch.xpu.get_device_properties(0).total_memory
+
 
 def default_stream():
     device = literal_device()
@@ -225,6 +284,7 @@ def default_stream():
         assert device == 'xpu'
         return torch.xpu.current_stream()
 
+
 def range_push(msg):
     device = literal_device()
     if device == 'cuda':
@@ -232,6 +292,7 @@ def range_push(msg):
     else:
         assert device == 'xpu'
         torch.xpu.itt.range_push(msg)
+
 
 def range_pop():
     device = literal_device()

--- a/deepspeed/autotuning/autotuner.py
+++ b/deepspeed/autotuning/autotuner.py
@@ -19,6 +19,7 @@ from .constants import *
 from .scheduler import ResourceManager, run_experiment
 from .tuner import GridSearchTuner, RandomTuner, ModelBasedTuner
 from .utils import *
+from deepspeed.accelerator import runtime as accel_runtime
 
 try:
     from tabulate import tabulate
@@ -252,7 +253,7 @@ class Autotuner:
             return False
 
     def get_gpu_memory_info(self):
-        return torch.cuda.get_device_properties(0).total_memory
+        return accel_runtime.total_memory()
 
     def get_activation_memory_per_gpu(self):
         if self.model_info and "activation_mem_per_gpu" in self.model_info:

--- a/deepspeed/inference/engine.py
+++ b/deepspeed/inference/engine.py
@@ -357,12 +357,12 @@ class InferenceEngine(Module):
 
     def _create_cuda_graph(self, *inputs, **kwargs):
         # warmup to create the workspace and cublas handle
-        cuda_stream = torch.cuda.Stream()
-        cuda_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(cuda_stream):
+        cuda_stream = accel_runtime.Stream()
+        cuda_stream.wait_stream(accel_runtime.current_stream())
+        with accel_runtime.stream(cuda_stream):
             for i in range(3):
                 ret = self.module(*inputs, **kwargs)
-        torch.cuda.current_stream().wait_stream(cuda_stream)
+        accel_runtime.current_stream().wait_stream(cuda_stream)
 
         # create cuda_graph and assign static_inputs and static_outputs
         self._cuda_graphs = torch.cuda.CUDAGraph()

--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -15,14 +15,13 @@ import subprocess
 import collections
 from copy import deepcopy
 
-import torch.cuda
-
 from .multinode_runner import PDSHRunner, OpenMPIRunner, MVAPICHRunner
 from .constants import PDSH_LAUNCHER, OPENMPI_LAUNCHER, MVAPICH_LAUNCHER
 from ..constants import TORCH_DISTRIBUTED_DEFAULT_PORT
 from ..utils import logger
 
 from ..autotuning import Autotuner
+from deepspeed.accelerator import runtime as accel_runtime
 
 DLTS_HOSTFILE = "/job/hostfile"
 EXPORT_ENVS = ["NCCL", "PYTHON", "MV2", "UCX"]
@@ -340,7 +339,7 @@ def main(args=None):
     multi_node_exec = True
     if not resource_pool:
         resource_pool = {}
-        device_count = torch.cuda.device_count()
+        device_count = accel_runtime.device_count()
         if device_count == 0:
             raise RuntimeError("Unable to proceed, no GPU resources available")
         resource_pool['localhost'] = device_count

--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -443,7 +443,8 @@ def replace_transformer_layer(orig_layer_impl,
                         accel_runtime.current_device())
                     new_module.res_mlp.output_b.data = _res_4hh_b.to(
                         accel_runtime.current_device())
-                    new_module.res_coef.data = _res_coef.to(accel_runtime.current_device())
+                    new_module.res_coef.data = _res_coef.to(
+                        accel_runtime.current_device())
             else:
                 mpl_block.inter_w.data = mp_replace.copy(mpl_block.inter_w, _h4h_w)
                 mpl_block.inter_b.data = mp_replace.copy(mpl_block.inter_b, _h4h_b)
@@ -452,11 +453,13 @@ def replace_transformer_layer(orig_layer_impl,
                 if attn_nw is None:
                     new_module.mlp.attn_nw = attn_nw
                 else:
-                    new_module.mlp.attn_nw.data = attn_nw.to(accel_runtime.current_device())
+                    new_module.mlp.attn_nw.data = attn_nw.to(
+                        accel_runtime.current_device())
                 if attn_nb is None:
                     new_module.mlp.attn_nb = attn_nb
                 else:
-                    new_module.mlp.attn_nb.data = attn_nb.to(accel_runtime.current_device())
+                    new_module.mlp.attn_nb.data = attn_nb.to(
+                        accel_runtime.current_device())
             new_module.norm_w.data = input_nw.to(accel_runtime.current_device())
             new_module.norm_b.data = input_nb.to(accel_runtime.current_device())
         else:
@@ -515,7 +518,8 @@ def replace_transformer_layer(orig_layer_impl,
                         child.weight.data.shape[-1],
                         child.weight.data.shape[-2])
                 data = mp_replace.copy(new_weight,
-                                       child.weight.data).to(accel_runtime.current_device())
+                                       child.weight.data).to(
+                                           accel_runtime.current_device())
                 return LinearAllreduce(data, child.bias if child.bias is None else \
                             child.bias.to(accel_runtime.current_device()), mp_group)
             else:

--- a/deepspeed/ops/adam/fused_adam.py
+++ b/deepspeed/ops/adam/fused_adam.py
@@ -11,6 +11,7 @@ from .multi_tensor_apply import MultiTensorApply
 
 multi_tensor_applier = MultiTensorApply(2048 * 32)
 from ..op_builder import FusedAdamBuilder
+from deepspeed.accelerator import runtime as accel_runtime
 
 
 class FusedAdam(torch.optim.Optimizer):
@@ -72,7 +73,7 @@ class FusedAdam(torch.optim.Optimizer):
 
         fused_adam_cuda = FusedAdamBuilder().load()
         # Skip buffer
-        self._dummy_overflow_buf = torch.cuda.IntTensor([0])
+        self._dummy_overflow_buf = accel_runtime.IntTensor([0])
         self.multi_tensor_adam = fused_adam_cuda.multi_tensor_adam
 
     def zero_grad(self):

--- a/deepspeed/ops/sparse_attention/matmul.py
+++ b/deepspeed/ops/sparse_attention/matmul.py
@@ -8,6 +8,7 @@ import math
 import triton
 import triton.language as tl
 import triton._C.libtriton as libtriton
+from deepspeed.accelerator import on_accel_device
 
 
 @triton.jit
@@ -950,7 +951,7 @@ class MatMul:
             raise ValueError(
                 f"Inputs must be on the same device; got {a.device} for tensor A "
                 f"and {b.device} for tensor B")
-        if not a.is_cuda:
+        if not on_accel_device(a):
             raise ValueError("Only GPU devices are supported for now")
 
         # When autocast is enabled, torch.matmul autocasts to float16, so we do the same here

--- a/deepspeed/ops/transformer/transformer.py
+++ b/deepspeed/ops/transformer/transformer.py
@@ -7,6 +7,7 @@ import importlib
 import torch
 from torch import nn
 from torch.autograd import Function
+from deepspeed.accelerator import runtime as accel_runtime
 
 from ..op_builder import TransformerBuilder, StochasticTransformerBuilder
 
@@ -482,7 +483,7 @@ class DeepSpeedTransformerLayer(nn.Module):
         print("DeepSpeed Transformer config is ", self.config.__dict__)
 
         if self.config.local_rank >= 0:
-            torch.cuda.set_device(self.config.local_rank)
+            accel_runtime.set_device(self.config.local_rank)
 
         if initial_weights is None and initial_biases is None:
             self.attn_qkvw = nn.Parameter(

--- a/deepspeed/profiling/flops_profiler/profiler.py
+++ b/deepspeed/profiling/flops_profiler/profiler.py
@@ -6,6 +6,7 @@ from functools import partial
 from typing import Callable, List, Optional, Tuple
 from collections import OrderedDict
 import numpy as np
+from deepspeed.accelerator import runtime as accel_runtime
 
 Tensor = torch.Tensor
 
@@ -95,14 +96,14 @@ class FlopsProfiler(object):
             module.__post_hook_handle__ = module.register_forward_hook(post_hook)
 
             def start_time_hook(module, input):
-                torch.cuda.synchronize()
+                accel_runtime.synchronize()
                 module.__start_time__ = time.time()
 
             module.__start_time_hook_handle__ = module.register_forward_pre_hook(
                 start_time_hook)
 
             def end_time_hook(module, input, output):
-                torch.cuda.synchronize()
+                accel_runtime.synchronize()
                 module.__duration__ += time.time() - module.__start_time__
 
             module.__end_time_hook_handle__ = module.register_forward_hook(end_time_hook)

--- a/deepspeed/runtime/activation_checkpointing/checkpointing.py
+++ b/deepspeed/runtime/activation_checkpointing/checkpointing.py
@@ -20,12 +20,13 @@ import torch.distributed as dist
 
 import mmap
 from torch import _C
-from torch.cuda import _lazy_call, device as device_ctx_manager
 
 from deepspeed.runtime.config import DeepSpeedConfig
 from deepspeed.utils import logger
 from deepspeed.runtime.utils import copy_to_device, move_to_device, see_memory_usage, bwc_tensor_model_parallel_rank
 from deepspeed.utils.timer import SynchronizedWallClockTimer as Timers
+from deepspeed.accelerator import literal_device
+from deepspeed.accelerator import runtime as accel_runtime
 
 # DeepSpeed Checkpointing Enabled or Disabled
 deepspeed_checkpointing_enabled = False
@@ -98,25 +99,25 @@ def _set_cuda_rng_state(new_state, device=-1):
     if hasattr(_C, '_cuda_setRNGState') and callable(_C._cuda_setRNGState):
         # older PyTorch
         def cb():
-            with device_ctx_manager(device):
+            with accel_runtime.device(device):
                 _C._cuda_setRNGState(new_state)
     else:
         # newer PyTorch
         if device == -1:
-            device = torch.device('cuda')
+            device = torch.device(literal_device())
         elif isinstance(device, str):
             device = torch.device(device)
         elif isinstance(device, int):
-            device = torch.device('cuda', device)
+            device = torch.device(literal_device(), device)
 
         def cb():
             idx = device.index
             if idx is None:
-                idx = torch.cuda.current_device()
-            default_generator = torch.cuda.default_generators[idx]
+                idx = accel_runtime.current_device()
+            default_generator = accel_runtime.default_generator(idx)
             default_generator.set_state(new_state)
 
-    _lazy_call(cb)
+    accel_runtime._lazy_call(cb)
 
 
 class CudaRNGStatesTracker:
@@ -158,10 +159,10 @@ class CudaRNGStatesTracker:
         if name in self.states_:
             raise Exception('cuda rng state {} already exists'.format(name))
         # Get the current rng state.
-        orig_rng_state = torch.cuda.get_rng_state()
+        orig_rng_state = accel_runtime.get_rng_state()
         # Set the new state and store it.
-        torch.cuda.manual_seed(seed)
-        self.states_[name] = torch.cuda.get_rng_state()
+        accel_runtime.manual_seed(seed)
+        self.states_[name] = accel_runtime.get_rng_state()
         # Reset rng state to what it was.
         _set_cuda_rng_state(orig_rng_state)
 
@@ -173,7 +174,7 @@ class CudaRNGStatesTracker:
         if name not in self.states_:
             raise Exception('cuda rng state {} is not added'.format(name))
         # Store current rng state.
-        orig_cuda_rng_state = torch.cuda.get_rng_state()
+        orig_cuda_rng_state = accel_runtime.get_rng_state()
         # Set rng state to the desired one
         _set_cuda_rng_state(self.states_[name])
         # Do the stuff we wanted to do.
@@ -181,7 +182,7 @@ class CudaRNGStatesTracker:
             yield
         finally:
             # Update the current rng state for later use.
-            self.states_[name] = torch.cuda.get_rng_state()
+            self.states_[name] = accel_runtime.get_rng_state()
             # And set the state to the original state we started with.
             _set_cuda_rng_state(orig_cuda_rng_state)
 
@@ -199,7 +200,7 @@ def model_parallel_cuda_manual_seed(seed):
     """Initialize model parallel cuda seed.
 
     This function should be called after the model parallel is
-    initialized. Also, no torch.cuda.manual_seed should be called
+    initialized. Also, no accel_runtime.manual_seed should be called
     after this function. Basically, this is replacement for that
     function.
     Two set of RNG states are tracked:
@@ -235,7 +236,7 @@ def model_parallel_cuda_manual_seed(seed):
         )
     _CUDA_RNG_STATE_TRACKER.reset()
     # Set the default state.
-    torch.cuda.manual_seed(data_parallel_seed)
+    accel_runtime.manual_seed(data_parallel_seed)
     # and model parallel state.
     _CUDA_RNG_STATE_TRACKER.add(_MODEL_PARALLEL_RNG_TRACKER_NAME, model_parallel_seed)
 
@@ -511,7 +512,7 @@ class CheckpointFunction(torch.autograd.Function):
             ctx.tensor_flags = tensor_flags
 
         if SYNCHRONIZE:
-            torch.cuda.synchronize()
+            accel_runtime.synchronize()
 
         if timers is None and PROFILE_TIME:
             timers = Timers()
@@ -554,8 +555,8 @@ class CheckpointFunction(torch.autograd.Function):
                 logger.info(f"----Synchronization {SYNCHRONIZE}")
                 logger.info(f"----Profiling time in checkpointing {PROFILE_TIME}")
 
-            cuda_device = torch.cuda.current_device()
-            transport_stream = torch.cuda.Stream(device=cuda_device)
+            cuda_device = accel_runtime.current_device()
+            transport_stream = accel_runtime.Stream(device=cuda_device)
 
         if PARTITION_ACTIVATIONS:
             inputs = partition_activations(args,
@@ -573,7 +574,7 @@ class CheckpointFunction(torch.autograd.Function):
 
         # Copy the rng states.
         ctx.fwd_cpu_rng_state = torch.get_rng_state()
-        ctx.fwd_cuda_rng_state = torch.cuda.get_rng_state()
+        ctx.fwd_cuda_rng_state = accel_runtime.get_rng_state()
         ctx.fwd_cuda_rng_state_tracker = get_cuda_rng_tracker().get_states()
 
         see_memory_usage("Before running forward on the layer", force=False)
@@ -601,7 +602,7 @@ class CheckpointFunction(torch.autograd.Function):
             timers('forward').stop()
             timers.log(['forward'])
         if SYNCHRONIZE:
-            torch.cuda.synchronize()
+            accel_runtime.synchronize()
 
         # Tensors returned from forward() may not be differentiable.
         if torch.is_tensor(outputs):
@@ -628,7 +629,7 @@ class CheckpointFunction(torch.autograd.Function):
         # so that they can be garbage collected once the checkpoints
         # have been used
         if SYNCHRONIZE:
-            torch.cuda.synchronize()
+            accel_runtime.synchronize()
         if PROFILE_TIME:
             timers('backward').start()
 
@@ -654,7 +655,7 @@ class CheckpointFunction(torch.autograd.Function):
         global cuda_device, transport_stream, PARTITION_ACTIVATIONS
 
         if PARTITION_ACTIVATIONS:
-            # with torch.cuda.stream(transport_stream):
+            # with accel_runtime.stream(transport_stream):
             inputs = gather_partitioned_activations(
                 ctx.deepspeed_saved_tensors,
                 device=cuda_device if CPU_CHECKPOINT else None)
@@ -675,7 +676,7 @@ class CheckpointFunction(torch.autograd.Function):
 
         # Store the current states.
         bwd_cpu_rng_state = torch.get_rng_state()
-        bwd_cuda_rng_state = torch.cuda.get_rng_state()
+        bwd_cuda_rng_state = accel_runtime.get_rng_state()
         bwd_cuda_rng_state_tracker = get_cuda_rng_tracker().get_states()
 
         # Set the states to what it used to be before the forward pass.
@@ -684,7 +685,7 @@ class CheckpointFunction(torch.autograd.Function):
         get_cuda_rng_tracker().set_states(ctx.fwd_cuda_rng_state_tracker)
 
         # if PARTITION_ACTIVATIONS:
-        #     current_stream=torch.cuda.current_stream()
+        #     current_stream=accel_runtime.current_stream()
         #     current_stream.wait_stream(transport_stream)
 
         see_memory_usage("In backward checkpointing code before forward", force=False)
@@ -729,7 +730,7 @@ class CheckpointFunction(torch.autograd.Function):
             timers('backward').stop()
             timers.log(['backward'])
         if SYNCHRONIZE:
-            torch.cuda.synchronize()
+            accel_runtime.synchronize()
         ret_list = [None, None]  # first None for ctx
         for inp in detached_inputs:
             if torch.is_tensor(inp):
@@ -856,7 +857,7 @@ def configure(
         checkpoint_in_cpu: Optional: Moves the activation checkpoint to CPU. Only works with
             partition_activation. Default is false. Will overwrite deepspeed_config if provided
 
-        synchronize: Optional: Performs torch.cuda.synchronize() at the beginning and end of
+        synchronize: Optional: Performs accel_runtime.synchronize() at the beginning and end of
             each call to deepspeed.checkpointing.checkpoint for both forward and backward pass.
             By default false. Will overwrite deepspeed_config if provided
 

--- a/deepspeed/runtime/comm/nccl.py
+++ b/deepspeed/runtime/comm/nccl.py
@@ -102,7 +102,8 @@ class NcclBackend(object):
         recvbuf_scale = [
             torch.zeros(1,
                         dtype=worker_scale.dtype,
-                        device=torch.device(literal_device(local_rank))) for i in range(self.size)
+                        device=torch.device(literal_device(local_rank)))
+            for i in range(self.size)
         ]
 
         # communication phase 1

--- a/deepspeed/runtime/comm/nccl.py
+++ b/deepspeed/runtime/comm/nccl.py
@@ -9,6 +9,7 @@ import cupy
 import numpy as np
 
 from deepspeed.runtime.compression.cupy import CupyBackend
+from deepspeed.accelerator import literal_device
 
 
 class NcclBackend(object):
@@ -101,7 +102,7 @@ class NcclBackend(object):
         recvbuf_scale = [
             torch.zeros(1,
                         dtype=worker_scale.dtype,
-                        device=torch.device(local_rank)) for i in range(self.size)
+                        device=torch.device(literal_device(local_rank))) for i in range(self.size)
         ]
 
         # communication phase 1

--- a/deepspeed/runtime/dataloader.py
+++ b/deepspeed/runtime/dataloader.py
@@ -5,6 +5,7 @@ Copyright 2019 The Microsoft DeepSpeed Team
 import torch
 from torch.utils.data import DataLoader, RandomSampler
 from torch.utils.data.distributed import DistributedSampler
+from deepspeed.accelerator import runtime as accel_runtime
 
 
 class RepeatingLoader:
@@ -55,7 +56,7 @@ class DeepSpeedDataLoader(object):
         else:
             if data_sampler is None:
                 data_sampler = RandomSampler(dataset)
-            device_count = torch.cuda.device_count()
+            device_count = accel_runtime.device_count()
             batch_size *= device_count
 
         if num_local_io_workers is None:

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -70,6 +70,9 @@ from ..git_version_info import version
 from deepspeed.profiling.flops_profiler.profiler import FlopsProfiler
 from deepspeed.utils.logging import print_json_dist
 
+from deepspeed.accelerator import literal_device
+from deepspeed.accelerator import runtime as accel_runtime
+
 MEMORY_OPT_ALLREDUCE_SIZE = 500000000
 
 DeepSpeedOptimizerCallable = \
@@ -87,11 +90,12 @@ except ImportError:
 
 
 def split_half_float_double_sparse(tensors):
+    device_type = literal_device()
     supported_types = [
-        "torch.cuda.HalfTensor",
-        "torch.cuda.FloatTensor",
-        "torch.cuda.DoubleTensor",
-        "torch.cuda.BFloat16Tensor",
+        "torch.{}.HalfTensor".format(device_type),
+        "torch.{}.FloatTensor".format(device_type),
+        "torch.{}.DoubleTensor".format(device_type),
+        "torch.{}.BFloat16Tensor".format(device_type),
         SparseTensor.type()
     ]
 
@@ -838,14 +842,14 @@ class DeepSpeedEngine(Module):
             args,
             'device_rank') else self.local_rank
         if device_rank >= 0:
-            torch.cuda.set_device(device_rank)
-            self.device = torch.device("cuda", device_rank)
+            accel_runtime.set_device(device_rank)
+            self.device = torch.device(literal_device(), device_rank)
             self.world_size = dist.get_world_size()
             self.global_rank = dist.get_rank()
         else:
             self.world_size = 1
             self.global_rank = 0
-            self.device = torch.device("cuda")
+            self.device = torch.device(literal_device())
 
     # Configure based on command line arguments
     def _configure_with_arguments(self, args, mpu):

--- a/deepspeed/runtime/fp16/fused_optimizer.py
+++ b/deepspeed/runtime/fp16/fused_optimizer.py
@@ -14,6 +14,7 @@ from deepspeed.runtime.fp16.loss_scaler import INITIAL_LOSS_SCALE, SCALE_WINDOW,
 from deepspeed.utils import groups, logger, log_dist
 from deepspeed.checkpoint.constants import OPTIMIZER_STATE_DICT, CLIP_GRAD
 import torch.distributed as dist
+from deepspeed.accelerator import runtime as accel_runtime
 
 
 class FP16_Optimizer(DeepSpeedOptimizer):
@@ -41,8 +42,8 @@ class FP16_Optimizer(DeepSpeedOptimizer):
         self.deepspeed = deepspeed
         self.has_moe_layers = has_moe_layers
         self.using_pipeline = self.deepspeed.pipeline_parallelism
-        if not torch.cuda.is_available:
-            raise SystemError("Cannot use fp16 without CUDA.")
+        if not accel_runtime.is_fp16_supported():
+            raise SystemError("No accelerator or accelerator does not support FP16.")
         self.optimizer = init_optimizer
 
         # param flattened by groups
@@ -457,7 +458,7 @@ class FP16_Optimizer(DeepSpeedOptimizer):
         will call ``model.load_state_dict()`` before
         ``fp16_optimizer_instance.load_state_dict()`` is called.
         Example::
-            model = torch.nn.Linear(D_in, D_out).cuda().half()
+            model = torch.nn.Linear(D_in, D_out).to(literal_device()).half()
             optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
             optimizer = FP16_Optimizer(optimizer, static_loss_scale = 128.0)
             ...

--- a/deepspeed/runtime/fp16/onebit/adam.py
+++ b/deepspeed/runtime/fp16/onebit/adam.py
@@ -9,6 +9,7 @@ import time
 import torch.distributed as dist
 
 from deepspeed.utils.logging import logger
+from deepspeed.accelerator import runtime as accel_runtime
 
 
 class OnebitAdam(torch.optim.Optimizer):
@@ -178,12 +179,12 @@ class OnebitAdam(torch.optim.Optimizer):
                                                             (self.size * self.divider)))
                     state['server_chunk_size'] = state[
                         'corrected_tensor_size'] // self.size
-                    torch.cuda.empty_cache()
+                    accel_runtime.empty_cache()
                     state['worker_error'] = torch.zeros(state['corrected_tensor_size'],
                                                         device=p.device)
                     state['server_error'] = torch.zeros(state['server_chunk_size'],
                                                         device=p.device)
-                    torch.cuda.empty_cache()
+                    accel_runtime.empty_cache()
                     self.adam_freeze_key = True
                     if not self.initialize and torch.distributed.get_rank() == 0:
                         print("Cupy Buffers Initialized Successfully.")

--- a/deepspeed/runtime/fp16/onebit/lamb.py
+++ b/deepspeed/runtime/fp16/onebit/lamb.py
@@ -6,6 +6,7 @@ import torch
 import numpy as np
 import torch.distributed as dist
 from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
+from deepspeed.accelerator import runtime as accel_runtime
 
 
 class OnebitLamb(torch.optim.Optimizer):
@@ -283,7 +284,7 @@ class OnebitLamb(torch.optim.Optimizer):
                 p.data = q.data
 
         if self.initialize and len(self.worker_errors) == 0:
-            torch.cuda.empty_cache()
+            accel_runtime.empty_cache()
             for i in range(len(self.exp_avg_flat)):
                 self.worker_errors.append(
                     torch.zeros(self.corrected_tensor_sizes[i],
@@ -291,20 +292,20 @@ class OnebitLamb(torch.optim.Optimizer):
                 self.server_errors.append(
                     torch.zeros(self.server_chunk_sizes[i],
                                 device=self.exp_avg_flat[i].device))
-            torch.cuda.empty_cache()
+            accel_runtime.empty_cache()
 
         if self.lamb_freeze_key:
             if self.size > 1:
                 for i in range(len(self.exp_avg_flat)):
                     if not self.initialize:
-                        torch.cuda.empty_cache()
+                        accel_runtime.empty_cache()
                         self.worker_errors.append(
                             torch.zeros(self.corrected_tensor_sizes[i],
                                         device=self.exp_avg_flat[i].device))
                         self.server_errors.append(
                             torch.zeros(self.server_chunk_sizes[i],
                                         device=self.exp_avg_flat[i].device))
-                        torch.cuda.empty_cache()
+                        accel_runtime.empty_cache()
                         if torch.distributed.get_rank() == 0:
                             print("Cupy Buffers Initialized Successfully.")
 

--- a/deepspeed/runtime/fp16/onebit/zoadam.py
+++ b/deepspeed/runtime/fp16/onebit/zoadam.py
@@ -9,6 +9,7 @@ import time
 import torch.distributed as dist
 
 from deepspeed.utils.logging import logger
+from deepspeed.accelerator import runtime as accel_runtime
 
 
 class ZeroOneAdam(torch.optim.Optimizer):
@@ -189,14 +190,14 @@ class ZeroOneAdam(torch.optim.Optimizer):
                                                             (self.size * self.divider)))
                     state['server_chunk_size'] = state[
                         'corrected_tensor_size'] // self.size
-                    torch.cuda.empty_cache()
+                    accel_runtime.empty_cache()
                     state['worker_error'] = torch.zeros(state['corrected_tensor_size'],
                                                         device=p.device)
                     state['server_error'] = torch.zeros(state['server_chunk_size'],
                                                         device=p.device)
                     # Accumulation of momentum, i.e., the u variable in the 0/1 Adam paper
                     state['momentum_accumulator'] = torch.zeros_like(p.data)
-                    torch.cuda.empty_cache()
+                    accel_runtime.empty_cache()
                     # self.freeze_key = True
                     if not self.initialize and torch.distributed.get_rank() == 0:
                         print("Cupy Buffers Initialized Successfully.")

--- a/deepspeed/runtime/fp16/unfused_optimizer.py
+++ b/deepspeed/runtime/fp16/unfused_optimizer.py
@@ -14,6 +14,7 @@ from deepspeed.runtime.utils import get_global_norm, CheckOverflow, get_weight_n
 from deepspeed.runtime.fp16.loss_scaler import INITIAL_LOSS_SCALE, SCALE_WINDOW, MIN_LOSS_SCALE
 from deepspeed.utils import logger
 from deepspeed.checkpoint.constants import OPTIMIZER_STATE_DICT
+from deepspeed.accelerator import runtime as accel_runtime
 
 
 class FP16_UnfusedOptimizer(DeepSpeedOptimizer):
@@ -39,8 +40,8 @@ class FP16_UnfusedOptimizer(DeepSpeedOptimizer):
         if torch.distributed.get_rank() == 0:
             logger.info(f'Fused Lamb Legacy : {self.fused_lamb_legacy} ')
 
-        if not torch.cuda.is_available:
-            raise SystemError("Cannot use fp16 without CUDA.")
+        if not accel_runtime.is_fp16_supported():
+            raise SystemError("No accelerator or accelerator does not support FP16.")
         self.optimizer = init_optimizer
 
         # param groups
@@ -386,7 +387,7 @@ class FP16_UnfusedOptimizer(DeepSpeedOptimizer):
         will call ``model.load_state_dict()`` before
         ``fp16_optimizer_instance.load_state_dict()`` is called.
         Example::
-            model = torch.nn.Linear(D_in, D_out).cuda().half()
+            model = torch.nn.Linear(D_in, D_out).to(literal_device()).half()
             optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
             optimizer = FP16_Optimizer(optimizer, static_loss_scale = 128.0)
             ...
@@ -431,13 +432,13 @@ class FP16_UnfusedOptimizer(DeepSpeedOptimizer):
             for param in group:
                 param.grad = torch.zeros(param.size(),
                                          dtype=param.dtype,
-                                         device=torch.cuda.current_device())
+                                         device=accel_runtime.current_device())
 
         for i, group in enumerate(self.fp32_groups):
             for param in group:
                 param.grad = torch.zeros(param.size(),
                                          dtype=param.dtype,
-                                         device=torch.cuda.current_device())
+                                         device=accel_runtime.current_device())
 
         self.optimizer.step()
 

--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -16,6 +16,7 @@ import torch.distributed as dist
 
 from deepspeed.utils.logging import logger
 from deepspeed.utils.timer import SynchronizedWallClockTimer, ThroughputTimer
+from deepspeed.accelerator import runtime as accel_runtime
 
 from deepspeed.inference.engine import InferenceEngine
 from ..engine import DeepSpeedEngine, MEMORY_OPT_ALLREDUCE_SIZE
@@ -1282,14 +1283,14 @@ class PipelineEngine(DeepSpeedEngine):
         if print_rank != -1 and rank != print_rank:
             return
 
-        torch.cuda.synchronize()
+        accel_runtime.synchronize()
 
         if reset_max:
-            torch.cuda.reset_max_memory_cached()
-            torch.cuda.reset_max_memory_allocated()
+            accel_runtime.reset_max_memory_cached()
+            accel_runtime.reset_max_memory_allocated()
 
-        new_alloced = torch.cuda.memory_allocated()
-        new_cached = torch.cuda.memory_cached()
+        new_alloced = accel_runtime.memory_allocated()
+        new_cached = accel_runtime.memory_cached()
 
         delta_alloced = new_alloced - mem_alloced
         delta_cached = new_cached - mem_cached
@@ -1297,8 +1298,8 @@ class PipelineEngine(DeepSpeedEngine):
         mem_cached = new_cached
         mem_alloced = new_alloced
 
-        max_alloced = torch.cuda.max_memory_allocated()
-        max_cached = torch.cuda.max_memory_cached()
+        max_alloced = accel_runtime.max_memory_allocated()
+        max_cached = accel_runtime.max_memory_cached()
 
         # convert to GB for printing
         new_alloced /= 1024**3

--- a/deepspeed/runtime/pipe/module.py
+++ b/deepspeed/runtime/pipe/module.py
@@ -16,6 +16,7 @@ from .. import utils as ds_utils
 from ..activation_checkpointing import checkpointing
 from .topology import PipeDataParallelTopology, PipelineParallelGrid
 from deepspeed.runtime.state_dict_factory import SDLoaderFactory
+from deepspeed.accelerator import literal_device
 
 
 class PipelineError(Exception):
@@ -194,12 +195,12 @@ class PipelineModule(nn.Module):
         self.tied_weight_attrs = {}
 
         # Offset the random seed by the stage ID.
-        #newseed = torch.cuda.initial_seed() + self._grid.get_stage_id()
+        #newseed = accel_runtime.initial_seed() + self._grid.get_stage_id()
         #ds_utils.set_random_seed(newseed)
 
-        #with torch.random.fork_rng(devices=[torch.cuda.current_device()]):
+        #with torch.random.fork_rng(devices=[accel_runtime.current_device()]):
         self._build()
-        self.to(f'cuda:{self.local_rank}')
+        self.to(literal_device(self.local_rank))
 
         self.tied_comms = self._index_tied_modules()
         self._synchronize_tied_weights()

--- a/deepspeed/runtime/pipe/p2p.py
+++ b/deepspeed/runtime/pipe/p2p.py
@@ -11,6 +11,7 @@ import torch.distributed as dist
 # To query whether we have send/recv support
 from packaging.version import Version
 from deepspeed.git_version_info import torch_info
+from deepspeed.accelerator import runtime as accel_runtime
 
 _groups = None
 _grid = None
@@ -92,7 +93,7 @@ def wait():
         op.wait()
     _async = []
 
-    torch.cuda.synchronize()
+    accel_runtime.synchronize()
 
 
 def send_obj(msg: typing.Any, dest: int):
@@ -110,10 +111,10 @@ def send_obj(msg: typing.Any, dest: int):
     # serialize the message
     msg = pickle.dumps(msg)
     # construct a tensor to send
-    msg = torch.ByteTensor(torch.ByteStorage.from_buffer(msg)).cuda()
+    msg = torch.ByteTensor(torch.ByteStorage.from_buffer(msg)).to(literal_device())
 
     # Send meta and message
-    length_tensor = torch.tensor([len(msg)], dtype=torch.long).cuda()
+    length_tensor = torch.tensor([len(msg)], dtype=torch.long).to(literal_device())
     dist.send(length_tensor, dst=dest)
     dist.send(msg, dst=dest)
 
@@ -128,11 +129,11 @@ def recv_obj(sender: int) -> typing.Any:
         sender (int): The rank sending the message.
     """
     # Get message meta
-    length = torch.tensor([0], dtype=torch.long).cuda()
+    length = torch.tensor([0], dtype=torch.long).to(literal_device())
     dist.recv(length, src=sender)
 
     # Receive and deserialize
-    msg = torch.empty(length.item(), dtype=torch.uint8).cuda()
+    msg = torch.empty(length.item(), dtype=torch.uint8).to(literal_device())
     dist.recv(msg, src=sender)
 
     msg = pickle.loads(msg.cpu().numpy().tobytes())
@@ -140,7 +141,7 @@ def recv_obj(sender: int) -> typing.Any:
     def _to(x):
         """Recursively move to the current device."""
         if torch.is_tensor(x):
-            return x.cuda()
+            return x.to(literal_device())
         if isinstance(x, (tuple, list)):
             ret = [_to(x_) for x_ in x]
             if isinstance(x, tuple):

--- a/deepspeed/runtime/quantize.py
+++ b/deepspeed/runtime/quantize.py
@@ -86,7 +86,7 @@ class Quantizer(object):
     def sr_quantize(self, input_flat, input_g, scale):
         # Random number generator (Uniform)
         p = accel_runtime.FloatTensor(input_flat.size(),
-                                   device=input_flat.device).uniform_()
+                                      device=input_flat.device).uniform_()
         p = torch.split(p, p.size(0) // self.q_groups)
         add_s = torch.zeros_like(input_flat)
         add_s = torch.split(add_s, add_s.size(0) // self.q_groups)

--- a/deepspeed/runtime/quantize.py
+++ b/deepspeed/runtime/quantize.py
@@ -3,6 +3,7 @@ import math
 from deepspeed.utils import log_dist
 from deepspeed.utils import logger
 from deepspeed.ops.quantizer import ds_quantizer
+from deepspeed.accelerator import runtime as accel_runtime
 
 # number of 2-dimensional parameters in a layer
 # this is set for transformer-based models
@@ -84,7 +85,7 @@ class Quantizer(object):
 
     def sr_quantize(self, input_flat, input_g, scale):
         # Random number generator (Uniform)
-        p = torch.cuda.FloatTensor(input_flat.size(),
+        p = accel_runtime.FloatTensor(input_flat.size(),
                                    device=input_flat.device).uniform_()
         p = torch.split(p, p.size(0) // self.q_groups)
         add_s = torch.zeros_like(input_flat)

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -22,16 +22,10 @@ import torch.distributed as dist
 from deepspeed.utils import groups, logger
 from deepspeed.runtime.constants import PIPE_REPLICATED
 from numpy import prod
+from deepspeed.accelerator import runtime as accel_runtime
 
-# pt-1.9 deprecations
-if hasattr(torch.cuda, "memory_reserved"):
-    torch_memory_reserved = torch.cuda.memory_reserved
-else:
-    torch_memory_reserved = torch.cuda.memory_allocated
-if hasattr(torch.cuda, "max_memory_reserved"):
-    torch_max_memory_reserved = torch.cuda.max_memory_reserved
-else:
-    torch_max_memory_reserved = torch.cuda.memory_cached
+torch_memory_reserved = accel_runtime.memory_reserved()
+torch_max_memory_reserved = accel_runtime.max_memory_reserved()
 
 
 class DummyOptim():
@@ -191,7 +185,7 @@ class CheckOverflow(object):
     def check_using_norm(self, norm_group, reduce_overflow=True):
         # TODO: I don't think reduce_overflow is needed if mpu is None
         overflow = -1 in norm_group
-        overflow_gpu = torch.cuda.FloatTensor([overflow])
+        overflow_gpu = accel_runtime.FloatTensor([overflow])
         if self.has_moe_params:
             # In this case, we need to do an all_reduce across
             # the expert_parallel_group, so that if there was
@@ -242,7 +236,7 @@ class CheckOverflow(object):
         overflow = self.has_overflow_serial(params)
         # Since each model parallel GPU carries only part of the model,
         # make sure overflow flag is synced across all the model parallel GPUs
-        overflow_gpu = torch.cuda.ByteTensor([overflow])
+        overflow_gpu = accel_runtime.ByteTensor([overflow])
         # torch.distributed.all_reduce(overflow_gpu,
         #                             op=torch.distributed.ReduceOp.MAX,
         #                             group=mpu.get_model_parallel_group())
@@ -353,7 +347,7 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2, mpu=None):
     norm_type = float(norm_type)
     if norm_type == inf:
         total_norm = max(p.grad.data.abs().max() for p in parameters)
-        total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+        total_norm_cuda = accel_runtime.FloatTensor([float(total_norm)])
         # Take max across all GPUs.
         if mpu is not None:
             torch.distributed.all_reduce(total_norm_cuda,
@@ -373,7 +367,7 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2, mpu=None):
                 total_norm += param_norm.item()**norm_type
 
         # Sum across all model parallel GPUs.
-        total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+        total_norm_cuda = accel_runtime.FloatTensor([float(total_norm)])
         if mpu is not None:
             torch.distributed.all_reduce(total_norm_cuda,
                                          op=torch.distributed.ReduceOp.SUM,
@@ -384,7 +378,7 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2, mpu=None):
     pg = groups._get_data_parallel_group()
     scaled_norm = total_norm * 1.0 / float(dist.get_world_size(group=pg))
 
-    scaled_norm_tensor = torch.cuda.FloatTensor([float(scaled_norm)])
+    scaled_norm_tensor = accel_runtime.FloatTensor([float(scaled_norm)])
     dist.all_reduce(scaled_norm_tensor, group=pg)
     total_norm = scaled_norm_tensor.item()
 
@@ -419,7 +413,7 @@ def get_grad_norm(parameters, norm_type=2, mpu=None):
     norm_type = float(norm_type)
     if norm_type == inf:
         total_norm = max(p.grad.data.abs().max() for p in parameters)
-        total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+        total_norm_cuda = accel_runtime.FloatTensor([float(total_norm)])
         # Take max across all GPUs.
         if mpu is not None:
             torch.distributed.all_reduce(total_norm_cuda,
@@ -443,7 +437,7 @@ def get_grad_norm(parameters, norm_type=2, mpu=None):
             total_norm += param_norm.item()**norm_type
 
         # Sum across all model parallel GPUs.
-        total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+        total_norm_cuda = accel_runtime.FloatTensor([float(total_norm)])
         if mpu is not None:
             torch.distributed.all_reduce(total_norm_cuda,
                                          op=torch.distributed.ReduceOp.SUM,
@@ -489,7 +483,7 @@ def get_grad_zeros(parameters, mpu=None):
         total_zeros += count_zeros.item()
 
     # Sum across all model parallel GPUs.
-    total_zeros_cuda = torch.cuda.FloatTensor([float(total_zeros)])
+    total_zeros_cuda = accel_runtime.FloatTensor([float(total_zeros)])
     if mpu is not None:
         torch.distributed.all_reduce(total_zeros_cuda,
                                      op=torch.distributed.ReduceOp.SUM,
@@ -522,7 +516,7 @@ def get_weight_norm(parameters, norm_type=2, mpu=None):
     norm_type = float(norm_type)
     if norm_type == inf:
         total_norm = max(p.data.abs().max() for p in parameters)
-        total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+        total_norm_cuda = accel_runtime.FloatTensor([float(total_norm)])
         # Take max across all GPUs.
         if mpu is not None:
             torch.distributed.all_reduce(total_norm_cuda,
@@ -546,7 +540,7 @@ def get_weight_norm(parameters, norm_type=2, mpu=None):
             total_norm += param_norm**norm_type
 
         # Sum across all model parallel GPUs.
-        total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+        total_norm_cuda = accel_runtime.FloatTensor([float(total_norm)])
         if mpu is not None:
             torch.distributed.all_reduce(total_norm_cuda,
                                          op=torch.distributed.ReduceOp.SUM,
@@ -774,14 +768,14 @@ def memory_status(msg, print_rank=-1, reset_max=False):
     if print_rank != -1 and rank != print_rank:
         return
 
-    torch.cuda.synchronize()
+    accel_runtime.synchronize()
 
     if reset_max:
-        torch.cuda.reset_max_memory_cached()
-        torch.cuda.reset_max_memory_allocated()
+        accel_runtime.reset_max_memory_cached()
+        accel_runtime.reset_max_memory_allocated()
 
-    new_alloced = torch.cuda.memory_allocated()
-    new_cached = torch.cuda.memory_cached()
+    new_alloced = accel_runtime.memory_allocated()
+    new_cached = accel_runtime.memory_cached()
 
     delta_alloced = new_alloced - mem_alloced
     delta_cached = new_cached - mem_cached
@@ -789,8 +783,8 @@ def memory_status(msg, print_rank=-1, reset_max=False):
     mem_cached = new_cached
     mem_alloced = new_alloced
 
-    max_alloced = torch.cuda.max_memory_allocated()
-    max_cached = torch.cuda.max_memory_cached()
+    max_alloced = accel_runtime.max_memory_allocated()
+    max_cached = accel_runtime.max_memory_cached()
 
     # convert to GB for printing
     new_alloced /= 1024**3
@@ -803,7 +797,7 @@ def memory_status(msg, print_rank=-1, reset_max=False):
     print(
         f'RANK={rank} MEMSTATS',
         msg,
-        f'device={torch.cuda.current_device()} '
+        f'device={accel_runtime.current_device()} '
         f'current alloc={new_alloced:0.4f}GB (delta={delta_alloced:0.4f}GB max={max_alloced:0.4f}GB) '
         f'current cache={new_cached:0.4f}GB (delta={delta_cached:0.4f}GB max={max_cached:0.4f}GB)'
     )
@@ -812,7 +806,7 @@ def memory_status(msg, print_rank=-1, reset_max=False):
 def get_ma_status():
     if torch.distributed.is_initialized() and not torch.distributed.get_rank() == 0:
         return 0
-    return torch.cuda.memory_allocated()
+    return accel_runtime.memory_allocated()
 
 
 def see_memory_usage(message, force=False):
@@ -827,8 +821,8 @@ def see_memory_usage(message, force=False):
     # Print message except when distributed but not rank 0
     logger.info(message)
     logger.info(
-        f"MA {round(torch.cuda.memory_allocated() / (1024 * 1024 * 1024),2 )} GB \
-        Max_MA {round(torch.cuda.max_memory_allocated() / (1024 * 1024 * 1024),2)} GB \
+        f"MA {round(accel_runtime.memory_allocated() / (1024 * 1024 * 1024),2 )} GB \
+        Max_MA {round(accel_runtime.max_memory_allocated() / (1024 * 1024 * 1024),2)} GB \
         CA {round(torch_memory_reserved() / (1024 * 1024 * 1024),2)} GB \
         Max_CA {round(torch_max_memory_reserved() / (1024 * 1024 * 1024))} GB ")
 
@@ -838,8 +832,7 @@ def see_memory_usage(message, force=False):
         f'CPU Virtual Memory:  used = {used_GB} GB, percent = {vm_stats.percent}%')
 
     # get the peak memory to report correct data, so reset the counter for the next call
-    if hasattr(torch.cuda, "reset_peak_memory_stats"):  # pytorch 1.4+
-        torch.cuda.reset_peak_memory_stats()
+    accel_runtime.reset_peak_memory_stats()
 
 
 def call_to_str(base, *args, **kwargs):

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -906,7 +906,7 @@ def get_global_norm_of_tensors(input_tensors, norm_type=2, mpu=None):
     norm_type = float(norm_type)
     if norm_type == inf:
         total_norm = max(t.data.abs().max() for t in input_tensors)
-        total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+        total_norm_cuda = accel_runtime.FloatTensor([float(total_norm)])
         if mpu is not None:
             torch.distributed.all_reduce(total_norm_cuda,
                                          op=torch.distributed.ReduceOp.MAX,
@@ -915,7 +915,7 @@ def get_global_norm_of_tensors(input_tensors, norm_type=2, mpu=None):
     else:
         total_norm = sum(
             [t.data.float().norm(norm_type).item()**norm_type for t in input_tensors])
-        total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+        total_norm_cuda = accel_runtime.FloatTensor([float(total_norm)])
         if mpu is not None:
             torch.distributed.all_reduce(total_norm_cuda,
                                          op=torch.distributed.ReduceOp.SUM,

--- a/deepspeed/runtime/weight_quantizer.py
+++ b/deepspeed/runtime/weight_quantizer.py
@@ -45,9 +45,9 @@ class WeightQuantization(object):
             q_scale.append(data_scale)
             value_list[index] = data_int
             index += 1
-        q_scale = (1 / torch.cat(q_scale,
-                                 dim=merge_dim).to(
-                                     accel_runtime.current_device()).view(-1).unsqueeze(0))
+        q_scale = (1 / torch.cat(
+            q_scale,
+            dim=merge_dim).to(accel_runtime.current_device()).view(-1).unsqueeze(0))
         if "mlp.dense_4h_to_h.weight" in key:
             self.mlp4hh_scales.append(q_scale)
         elif "mlp.dense_h_to_4h.weight" in key:
@@ -135,9 +135,9 @@ class WeightQuantization(object):
                 else:
                     data_quantized, data_scale = self.quantize_data(keys[key], quantize_bits, groups)
                 keys[key].copy_(data_quantized)
-                layer_scales.append(
-                    (1 /
-                     data_scale.to(accel_runtime.current_device()).view(-1).unsqueeze(0)))
+                layer_scales.append((
+                    1 /
+                    data_scale.to(accel_runtime.current_device()).view(-1).unsqueeze(0)))
             all_scales.append(self.merge_layer_scales(layer_scales))
             return layer
 

--- a/deepspeed/runtime/weight_quantizer.py
+++ b/deepspeed/runtime/weight_quantizer.py
@@ -1,5 +1,6 @@
 import torch
 from ..module_inject.replace_policy import HFBertLayerPolicy, replace_policies
+from deepspeed.accelerator import runtime as accel_runtime
 
 
 class WeightQuantization(object):
@@ -46,7 +47,7 @@ class WeightQuantization(object):
             index += 1
         q_scale = (1 / torch.cat(q_scale,
                                  dim=merge_dim).to(
-                                     torch.cuda.current_device()).view(-1).unsqueeze(0))
+                                     accel_runtime.current_device()).view(-1).unsqueeze(0))
         if "mlp.dense_4h_to_h.weight" in key:
             self.mlp4hh_scales.append(q_scale)
         elif "mlp.dense_h_to_4h.weight" in key:
@@ -63,7 +64,7 @@ class WeightQuantization(object):
             torch.cat((s,
                        torch.zeros((1,
                                     max_dim - s.shape[-1]),
-                                   device=torch.cuda.current_device())),
+                                   device=accel_runtime.current_device())),
                       dim=-1) if s.shape[-1] < max_dim else s for s in layer_scales
         ]
         return torch.cat(layer_scales).unsqueeze(0)
@@ -136,7 +137,7 @@ class WeightQuantization(object):
                 keys[key].copy_(data_quantized)
                 layer_scales.append(
                     (1 /
-                     data_scale.to(torch.cuda.current_device()).view(-1).unsqueeze(0)))
+                     data_scale.to(accel_runtime.current_device()).view(-1).unsqueeze(0)))
             all_scales.append(self.merge_layer_scales(layer_scales))
             return layer
 

--- a/deepspeed/runtime/zero/linear.py
+++ b/deepspeed/runtime/zero/linear.py
@@ -18,6 +18,7 @@ from torch.nn.parameter import Parameter
 from torch.nn import init
 from torch.nn.modules.module import Module
 from deepspeed.runtime.utils import noop_decorator
+from deepspeed.accelerator import literal_device
 
 tensor_map = {}
 
@@ -28,8 +29,13 @@ def print_rank_0(message, debug=False, force=False):
 
 
 try:
-    autocast_custom_fwd = torch.cuda.amp.custom_fwd
-    autocast_custom_bwd = torch.cuda.amp.custom_bwd
+    device = literal_device()
+    if device == 'cuda':
+        autocast_custom_fwd = torch.cuda.amp.custom_fwd
+        autocast_custom_bwd = torch.cuda.amp.custom_bwd
+    else:
+        autocast_custom_fwd = noop_decorator
+        autocast_custom_bwd = noop_decorator
 except (ImportError, AttributeError) as exp:
     autocast_custom_fwd = noop_decorator
     autocast_custom_bwd = noop_decorator

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -2034,7 +2034,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             for g, p in zip(gradients, params):
                 if is_model_parallel_parameter(p) or (self.model_parallel_rank == 0):
                     grad_norms.append(
-                        g.to(literal_device,
+                        g.to(literal_device(),
                              non_blocking=True).double().norm(2))
 
             # Sum across all model parallel GPUs.

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -2033,7 +2033,9 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             grad_norms = []
             for g, p in zip(gradients, params):
                 if is_model_parallel_parameter(p) or (self.model_parallel_rank == 0):
-                    grad_norms.append(g.to(literal_device, non_blocking=True).double().norm(2))
+                    grad_norms.append(
+                        g.to(literal_device,
+                             non_blocking=True).double().norm(2))
 
             # Sum across all model parallel GPUs.
             total_norm_cuda = torch.sum(torch.pow(torch.stack(grad_norms), 2))
@@ -2173,7 +2175,8 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         # release all the gradient since we have already created a necessary copy in dp_grad_partition
         self.zero_grad()
 
-        for grad in filter(lambda g: on_accel_device(g), self.averaged_gradients[sub_group_id]):
+        for grad in filter(lambda g: on_accel_device(g),
+                           self.averaged_gradients[sub_group_id]):
             grad.record_stream(accel_runtime.current_stream())
 
         self.averaged_gradients[sub_group_id] = None

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -12,15 +12,15 @@ from collections import OrderedDict, UserDict
 import itertools
 from typing import Deque, Dict, Iterable, Set, Tuple
 import torch
+
 import deepspeed
+import deepspeed.accelerator.runtime as accel_runtime
 if deepspeed.accelerator.literal_device() == 'cuda':
-    Event = torch.cuda.Event
-    Stream = torch.cuda.Stream
+    from torch.cuda import Event, Stream
 else:
     assert deepspeed.accelerator.literal_device() == 'xpu'
     import intel_extension_for_pytorch as ipex
-    Event = torch.xpu.Event
-    Stream = torch.xpu.Stream
+    from torch.xpu import Event, Stream
 
 from torch.nn import Module, Parameter
 import torch.distributed as dist
@@ -582,7 +582,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             self.__ipg_bucket_flat_buffer: Tensor = torch.empty(
                 self.reduce_bucket_size,
                 dtype=self.dtype,
-                device=torch.cuda.current_device())
+                device=accel_runtime.current_device())
 
         grad_partitions_flat_buffer = None
         self.__param_id_to_grad_partition: Dict[int, Tensor] = {}

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -12,7 +12,16 @@ from collections import OrderedDict, UserDict
 import itertools
 from typing import Deque, Dict, Iterable, Set, Tuple
 import torch
-from torch.cuda import Event, Stream
+import deepspeed
+if deepspeed.accelerator.literal_device() == 'cuda':
+    Event = torch.cuda.Event
+    Stream = torch.cuda.Stream
+else:
+    assert deepspeed.accelerator.literal_device() == 'xpu'
+    import intel_extension_for_pytorch as ipex
+    Event = torch.xpu.Event
+    Stream = torch.xpu.Stream
+
 from torch.nn import Module, Parameter
 import torch.distributed as dist
 import math
@@ -36,6 +45,8 @@ from deepspeed.runtime.swap_tensor.partitioned_param_swapper import PartitionedP
 from deepspeed.runtime.swap_tensor.partitioned_optimizer_swapper import PartitionedOptimizerSwapper
 from deepspeed.runtime.swap_tensor.pipelined_optimizer_swapper import PipelinedOptimizerSwapper
 from deepspeed.checkpoint.constants import OPTIMIZER_STATE_DICT, FP32_FLAT_GROUPS, PARTITION_COUNT, ZERO_STAGE
+from deepspeed.accelerator import on_accel_device
+from deepspeed.accelerator import runtime as accel_runtime
 
 # Toggle this to true to enable correctness test
 # with gradient partitioning and without
@@ -283,8 +294,8 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         # - assume all params requires grad
         # - flat by groups, not keeping state. TODO: remove state explicitly?
         # - master grad and unflat master weight never exist. TODO: a way to save out unflat master?
-        if not torch.cuda.is_available:
-            raise SystemError("Cannot use fp16 without CUDA.")
+        if not accel_runtime.is_available():
+            raise SystemError("Cannot use fp16 without accelerator.")
         self.optimizer = init_optimizer
         self.using_real_optimizer = not isinstance(self.optimizer, DummyOptim)
 
@@ -326,19 +337,19 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         self.__inf_or_nan_tracker: Tensor = torch.zeros(
             1,
             dtype=torch.bool,
-            device=torch.cuda.current_device(),
+            device=accel_runtime.current_device(),
             requires_grad=False)
 
         self.deepspeed_adam_offload = (self.offload_optimizer
                                        and type(init_optimizer) == DeepSpeedCPUAdam)
 
-        self.device = torch.cuda.current_device(
+        self.device = accel_runtime.current_device(
         ) if not self.offload_optimizer else OFFLOAD_CPU_DEVICE
         ### streams used for overlapping computation with communication
-        self.__allgather_stream = Stream(
-        ) if overlap_comm else torch.cuda.default_stream()
-        self.__reduce_and_partition_stream = Stream(
-        ) if overlap_comm else torch.cuda.default_stream()
+        self.__allgather_stream = accel_runtime.Stream(
+        ) if overlap_comm else accel_runtime.default_stream()
+        self.__reduce_and_partition_stream = accel_runtime.Stream(
+        ) if overlap_comm else accel_runtime.default_stream()
 
         ############################################################################
 
@@ -629,7 +640,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             offset += tensor_numel
 
         gc.collect()
-        torch.cuda.empty_cache()
+        accel_runtime.empty_cache()
 
         # copy tensors (now flattened and contiguous) back to GPU
         device_buffer = cpu_buffer.to(orig_device)
@@ -1547,19 +1558,19 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
     @instrument_w_nvtx
     @torch.no_grad()
     def __add_grad_to_ipg_bucket(self, param: Parameter) -> None:
-        self.__reduce_and_partition_stream.wait_stream(torch.cuda.default_stream())
+        self.__reduce_and_partition_stream.wait_stream(accel_runtime.default_stream())
 
         if self.contiguous_gradients and self.elements_in_ipg_bucket + param.grad.numel(
         ) < self.reduce_bucket_size:
             # move the gradient to a contiguous buffer
-            with torch.cuda.stream(self.__reduce_and_partition_stream):
+            with accel_runtime.stream(self.__reduce_and_partition_stream):
                 # move the parameter's gradient to the contiguous flat buffer
                 new_grad_tensor = self.__ipg_bucket_flat_buffer.narrow(
                     0,
                     self.elements_in_ipg_bucket,
                     param.grad.numel()).view_as(param.grad)
                 new_grad_tensor.copy_(param.grad, non_blocking=True)
-                param.grad.record_stream(torch.cuda.current_stream())
+                param.grad.record_stream(accel_runtime.current_stream())
                 param.grad.data = new_grad_tensor
 
         self.__params_in_ipg_bucket.append(param)
@@ -1586,7 +1597,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         if len(self.__param_reduce_events) > self.__max_param_reduce_events:
             self.__param_reduce_events.popleft().synchronize()
 
-        with torch.cuda.stream(self.__reduce_and_partition_stream):
+        with accel_runtime.stream(self.__reduce_and_partition_stream):
             if safe_mode:
                 assert_ints_same_as_other_ranks(
                     [p.ds_id for p in self.__params_in_ipg_bucket])
@@ -1596,7 +1607,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
 
             self.__params_in_ipg_bucket.clear()
 
-            event = Event()
+            event = accel_runtime.Event()
             event.record()
             self.__param_reduce_events.append(event)
 
@@ -1660,7 +1671,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         self.norm_for_param_grads[param_id] = self._constant_buffered_norm2(param.grad)
 
     def async_inplace_copy_grad_to_fp32_buffer_from_gpu(self, param, fp32_grad_tensor):
-        with torch.cuda.stream(self.copy_grad_stream):
+        with accel_runtime.stream(self.copy_grad_stream):
             param_id = self.get_param_id(param)
             src_tensor = param.grad.view(-1).float()
             #print(f"src_tensor {src_tensor.size()} and fp32 grad {fp32_grad_tensor.size()}")
@@ -1678,7 +1689,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
                     total_norm += param_norm.item()**2
 
         # Sum across all model parallel GPUs.
-        total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+        total_norm_cuda = accel_runtime.FloatTensor([float(total_norm)])
 
         torch.distributed.all_reduce(total_norm_cuda,
                                      op=torch.distributed.ReduceOp.SUM,
@@ -1715,7 +1726,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
                 # ensure grad buffer is a CUDA buffer to speed up the next few
                 # operations and so it can be used asynchronously
                 grad_buffer = grad_buffer.to(grad_partition.device, non_blocking=True)
-            elif grad_buffer.is_cuda:
+            elif on_accel_device(grad_buffer):
                 grad_buffer.add_(grad_partition)
             else:
                 # if dst is CPU, copy first to src device, do the addition
@@ -1762,7 +1773,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
                         fp32_grad_tensor.copy_(grad_buffer)
 
             # free the gradient
-            param.grad.record_stream(torch.cuda.current_stream())
+            param.grad.record_stream(accel_runtime.current_stream())
             param.grad = None
 
         if self.offload_optimizer and self.swap_optimizer:
@@ -1877,7 +1888,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
 
     # if rank is specified do a reduction instead of an allreduce
     def allreduce_and_copy(self, small_bucket, rank=None, log=None):
-        with torch.cuda.stream(self.reduction_stream):
+        with accel_runtime.stream(self.reduction_stream):
             allreduced = self.allreduce_bucket(small_bucket, rank=rank, log=log)
             if rank is None or rank == dist.get_rank(group=self.dp_process_group):
                 for buf, synced in zip(small_bucket, self.unflatten(allreduced, small_bucket)):
@@ -1968,8 +1979,8 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         for group in self.fp16_groups:
             for p in group:
                 if set_grads_to_None:
-                    if p.grad is not None and p.grad.is_cuda:
-                        p.grad.record_stream(torch.cuda.current_stream())
+                    if p.grad is not None and on_accel_device(p.grad):
+                        p.grad.record_stream(accel_runtime.current_stream())
                     p.grad = None
                 else:
                     if p.grad is not None:
@@ -2007,7 +2018,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         norm_type = float(norm_type)
         if norm_type == inf:
             total_norm = max(g.data.abs().max() for g in gradients)
-            total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+            total_norm_cuda = accel_runtime.FloatTensor([float(total_norm)])
             torch.distributed.all_reduce(total_norm_cuda,
                                          op=torch.distributed.ReduceOp.MAX,
                                          group=self.dp_process_group)
@@ -2022,7 +2033,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             grad_norms = []
             for g, p in zip(gradients, params):
                 if is_model_parallel_parameter(p) or (self.model_parallel_rank == 0):
-                    grad_norms.append(g.cuda(non_blocking=True).double().norm(2))
+                    grad_norms.append(g.to(literal_device, non_blocking=True).double().norm(2))
 
             # Sum across all model parallel GPUs.
             total_norm_cuda = torch.sum(torch.pow(torch.stack(grad_norms), 2))
@@ -2162,8 +2173,8 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         # release all the gradient since we have already created a necessary copy in dp_grad_partition
         self.zero_grad()
 
-        for grad in filter(lambda g: g.is_cuda, self.averaged_gradients[sub_group_id]):
-            grad.record_stream(torch.cuda.current_stream())
+        for grad in filter(lambda g: on_accel_device(g), self.averaged_gradients[sub_group_id]):
+            grad.record_stream(accel_runtime.current_stream())
 
         self.averaged_gradients[sub_group_id] = None
 
@@ -2383,9 +2394,8 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         self._post_step(timer_names)
 
         # warn user about caching allocator flushes
-        alloc_retries = torch.cuda.memory_stats()["num_alloc_retries"] if hasattr(
-            torch.cuda,
-            "memory_stats") else 0
+        memory_stats = accel_runtime.memory_stats()
+        alloc_retries = memory_stats["num_alloc_retries"] if memory_stats != None else 0
         if alloc_retries > self.__n_caching_allocator_flushes:
             if dist.get_rank() == 0:
                 logger.warning(
@@ -2394,7 +2404,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
                     "performance. if this is happening frequently consider adjusting "
                     "settings to reduce memory consumption. If you are unable to "
                     "make the cache flushes go away consider adding "
-                    "torch.cuda.empty_cache() calls in your training loop to ensure "
+                    "accel_runtime.empty_cache() calls in your training loop to ensure "
                     "that all ranks flush their caches at the same time",
                     alloc_retries - self.__n_caching_allocator_flushes)
             self.__n_caching_allocator_flushes = alloc_retries
@@ -2465,13 +2475,13 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
     @instrument_w_nvtx
     def has_overflow(self, partition_gradients=True):
         if partition_gradients:
-            with torch.cuda.stream(self.__reduce_and_partition_stream):
+            with accel_runtime.stream(self.__reduce_and_partition_stream):
                 self.local_overflow = bool(self.__inf_or_nan_tracker.item())
                 self.__inf_or_nan_tracker.zero_()
 
             overflow = self.local_overflow
             #overflow = self.has_overflow_partitioned_grads_serial()
-            overflow_gpu = torch.cuda.ByteTensor([overflow])
+            overflow_gpu = accel_runtime.ByteTensor([overflow])
             torch.distributed.all_reduce(overflow_gpu,
                                          op=torch.distributed.ReduceOp.MAX,
                                          group=self.dp_process_group)
@@ -2483,7 +2493,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
                     params.append(param)
 
             overflow = self.has_overflow_serial(params, is_grad_list=partition_gradients)
-            overflow_gpu = torch.cuda.ByteTensor([overflow])
+            overflow_gpu = accel_runtime.ByteTensor([overflow])
 
         # Since each model parallel GPU carries only part of the model,
         # make sure overflow flag is synced across all the model parallel GPUs
@@ -2829,7 +2839,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         will call ``model.load_state_dict()`` before
         ``fp16_optimizer_instance.load_state_dict()`` is called.
         Example::
-            model = torch.nn.Linear(D_in, D_out).cuda().half()
+            model = torch.nn.Linear(D_in, D_out).to(literal_device()).half()
             optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
             optimizer = FP16_Optimizer(optimizer, static_loss_scale = 128.0)
             ...

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -25,6 +25,10 @@ from deepspeed.utils import logger
 from deepspeed.moe.utils import is_moe_param
 from deepspeed.git_version_info import version
 from deepspeed.runtime.constants import PIPE_REPLICATED
+
+from deepspeed.accelerator import literal_device
+from deepspeed.accelerator import runtime as accel_runtime
+
 from deepspeed.checkpoint.constants import (DS_VERSION,
                                             PARTITION_COUNT,
                                             SINGLE_PARTITION_OF_FP32_GROUPS,
@@ -42,11 +46,12 @@ def input(msg):
 
 
 def split_half_float_double(tensors):
+    device_type = literal_device()
     dtypes = [
-        "torch.cuda.HalfTensor",
-        "torch.cuda.FloatTensor",
-        "torch.cuda.DoubleTensor",
-        "torch.cuda.BFloat16Tensor"
+        "torch.{}.HalfTensor".format(device_type),
+        "torch.{}.FloatTensor".format(device_type),
+        "torch.{}.DoubleTensor".format(device_type),
+        "torch.{}.BFloat16Tensor".format(device_type)
     ]
     buckets = []
     for i, dtype in enumerate(dtypes):
@@ -145,7 +150,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         # - assume all params requires grad
         # - flat by groups, not keeping state. TODO: remove state explicitly?
         # - master grad and unflat master weight never exist. TODO: a way to save out unflat master?
-        if not torch.cuda.is_available:
+        if not accel_runtime.is_available():
             raise SystemError("Cannot use fp16 without CUDA.")
         self.optimizer = init_optimizer
 
@@ -167,7 +172,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         self.deepspeed_adam_offload = cpu_offload
 
-        self.device = torch.cuda.current_device() if not self.cpu_offload else 'cpu'
+        self.device = accel_runtime.current_device() if not self.cpu_offload else 'cpu'
 
         self.dp_process_group = dp_process_group
 
@@ -317,8 +322,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 self.flatten_dense_tensors_aligned(
                     self.round_robin_bit16_groups[i],
                     self.nccl_start_alignment_factor *
-                    dist.get_world_size(group=self.real_dp_process_group[i])).cuda(
-                        torch.cuda.current_device()))
+                    dist.get_world_size(group=self.real_dp_process_group[i])).to(literal_device(
+                        accel_runtime.current_device())))
             see_memory_usage(f"After flattening and moving param group {i} to GPU",
                              force=False)
 
@@ -384,10 +389,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.reduce_bucket_size = int(reduce_bucket_size)
         self.allgather_bucket_size = int(allgather_bucket_size)
 
-        self.reduction_event = torch.cuda.Event(enable_timing=False, blocking=False)
-        self.reduction_stream = torch.cuda.Stream()
-        self.cpu_computation_stream = torch.cuda.Stream()
-        self.copy_grad_stream = torch.cuda.Stream()
+        self.reduction_event = accel_runtime.Event(enable_timing=False, blocking=False)
+        self.reduction_stream = accel_runtime.Stream()
+        self.cpu_computation_stream = accel_runtime.Stream()
+        self.copy_grad_stream = accel_runtime.Stream()
         self.callback_queued = False
 
         self.param_dict = {}
@@ -438,7 +443,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 dtype=self.dtype).pin_memory()
             self.temp_grad_buffer_for_gpu_offload = torch.zeros(
                 largest_param_numel,
-                device=torch.cuda.current_device(),
+                device=accel_runtime.current_device(),
                 dtype=self.dtype)
             for i, params_group in enumerate(self.bit16_groups):
                 self.get_grad_position(i,
@@ -607,7 +612,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             self.ipg_buffer = []
             buf_0 = torch.empty(int(self.reduce_bucket_size),
                                 dtype=self.dtype,
-                                device=torch.cuda.current_device())
+                                device=accel_runtime.current_device())
             self.ipg_buffer.append(buf_0)
             self.ipg_index = 0
 
@@ -668,7 +673,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             self.params_already_reduced[i] = False
 
         if self.overlap_comm:
-            torch.cuda.synchronize()
+            accel_runtime.synchronize()
             # It is safe to clear previously reduced grads of other partitions
             self._clear_previous_reduced_grads()
 
@@ -681,14 +686,14 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                         self.first_offset[i],
                         self.partition_size[i],
                         dtype=self.dtype,
-                        device=torch.cuda.current_device(),
+                        device=accel_runtime.current_device(),
                         return_tensor_list=True)
                 else:
                     avg_new = self.get_flat_partition(self.params_in_partition[i],
                                                       self.first_offset[i],
                                                       self.partition_size[i],
                                                       dtype=self.dtype,
-                                                      device=torch.cuda.current_device(),
+                                                      device=accel_runtime.current_device(),
                                                       return_tensor_list=True)
 
                     for accumulated_grad, new_avg_grad in zip(self.averaged_gradients[i], avg_new):
@@ -882,12 +887,12 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     def average_tensor(self, tensor):
         if self.overlap_comm:
-            torch.cuda.synchronize()
+            accel_runtime.synchronize()
             stream = self.reduction_stream
         else:
-            stream = torch.cuda.current_stream()
+            stream = accel_runtime.current_stream()
 
-        with torch.cuda.stream(stream):
+        with accel_runtime.stream(stream):
             if not self.reduce_scatter:
                 self.gradient_reduction_w_predivide(tensor)
                 return
@@ -1140,7 +1145,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     """
 
         # Sum across all model parallel GPUs.
-        total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+        total_norm_cuda = accel_runtime.FloatTensor([float(total_norm)])
         torch.distributed.all_reduce(total_norm_cuda,
                                      op=torch.distributed.ReduceOp.SUM,
                                      group=self.dp_process_group)
@@ -1182,7 +1187,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             see_memory_usage(f"before copying {total_size} gradients into partition")
             self.grads_in_partition = torch.empty(int(total_size),
                                                   dtype=self.dtype,
-                                                  device=torch.cuda.current_device())
+                                                  device=accel_runtime.current_device())
             see_memory_usage(f"after copying {total_size} gradients into partition")
 
         # The allreduce buffer will be rewritten. Copy the gradients in partition to a new buffer
@@ -1216,13 +1221,13 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             stream = self.reduction_stream
         elif self.cpu_offload:
             # TODO: copy_grad_stream is disabled because of race with reduce. This hurts perf and should be fixed.
-            #            torch.cuda.synchronize()
+            #            accel_runtime.synchronize()
             #            stream = self.copy_grad_stream
-            stream = torch.cuda.current_stream()
+            stream = accel_runtime.current_stream()
         else:
-            stream = torch.cuda.current_stream()
+            stream = accel_runtime.current_stream()
 
-        with torch.cuda.stream(stream):
+        with accel_runtime.stream(stream):
             for _, param, param_id in self.params_in_ipg_bucket:
 
                 assert self.params_already_reduced[param_id] == False, \
@@ -1366,14 +1371,14 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     # if rank is specified do a reduction instead of an allreduce
     def allreduce_and_copy(self, small_bucket, rank=None, log=None):
         if self.overlap_comm:
-            torch.cuda.synchronize()
+            accel_runtime.synchronize()
             # It is safe to clear the previously reduced grads of other partitions
             self._clear_previous_reduced_grads()
             stream = self.reduction_stream
         else:
-            stream = torch.cuda.current_stream()
+            stream = accel_runtime.current_stream()
 
-        with torch.cuda.stream(stream):
+        with accel_runtime.stream(stream):
             allreduced = self.allreduce_bucket(small_bucket, rank=rank, log=log)
             if rank is None or rank == dist.get_rank(group=self.dp_process_group):
                 for buf, synced in zip(small_bucket, self.unflatten(allreduced, small_bucket)):
@@ -1513,7 +1518,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         norm_type = float(norm_type)
         if norm_type == inf:
             total_norm = max(g.data.abs().max() for g in gradients)
-            total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+            total_norm_cuda = accel_runtime.FloatTensor([float(total_norm)])
             torch.distributed.all_reduce(total_norm_cuda,
                                          op=torch.distributed.ReduceOp.MAX,
                                          group=self.dp_process_group)
@@ -1534,7 +1539,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     param_norm = g.data.double().norm(2)
                     total_norm += param_norm.item()**2
             # Sum across all model parallel GPUs.
-            total_norm_cuda = torch.cuda.FloatTensor([float(total_norm)])
+            total_norm_cuda = accel_runtime.FloatTensor([float(total_norm)])
             torch.distributed.all_reduce(total_norm_cuda,
                                          op=torch.distributed.ReduceOp.SUM,
                                          group=self.dp_process_group)
@@ -1838,7 +1843,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         if partition_gradients:
             overflow = self.local_overflow if self.cpu_offload else self.has_overflow_partitioned_grads_serial(
             )
-            overflow_gpu = torch.cuda.ByteTensor([overflow])
+            overflow_gpu = accel_runtime.ByteTensor([overflow])
             '''This will capture overflow across all data parallel and expert parallel process
             Since expert parallel process are a subset of data parallel process'''
             torch.distributed.all_reduce(overflow_gpu,
@@ -1852,7 +1857,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     params.append(param)
 
             overflow = self.has_overflow_serial(params, is_grad_list=partition_gradients)
-            overflow_gpu = torch.cuda.ByteTensor([overflow])
+            overflow_gpu = accel_runtime.ByteTensor([overflow])
 
         # Since each model parallel GPU carries only part of the model,
         # make sure overflow flag is synced across all the model parallel GPUs
@@ -1898,14 +1903,14 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             self.ipg_buffer = []
             buf_0 = torch.empty(int(self.reduce_bucket_size),
                                 dtype=self.dtype,
-                                device=torch.cuda.current_device())
+                                device=accel_runtime.current_device())
             self.ipg_buffer.append(buf_0)
 
             # Use double buffers to avoid data access conflict when overlap_comm is enabled.
             if self.overlap_comm:
                 buf_1 = torch.empty(int(self.reduce_bucket_size),
                                     dtype=self.dtype,
-                                    device=torch.cuda.current_device())
+                                    device=accel_runtime.current_device())
                 self.ipg_buffer.append(buf_1)
             self.ipg_index = 0
 
@@ -2146,7 +2151,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         will call ``model.load_state_dict()`` before
         ``fp16_optimizer_instance.load_state_dict()`` is called.
         Example::
-            model = torch.nn.Linear(D_in, D_out).cuda().half()
+            model = torch.nn.Linear(D_in, D_out).to(literal_device()).half()
             optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
             optimizer = FP16_Optimizer(optimizer, static_loss_scale = 128.0)
             ...

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -322,8 +322,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 self.flatten_dense_tensors_aligned(
                     self.round_robin_bit16_groups[i],
                     self.nccl_start_alignment_factor *
-                    dist.get_world_size(group=self.real_dp_process_group[i])).to(literal_device(
-                        accel_runtime.current_device())))
+                    dist.get_world_size(group=self.real_dp_process_group[i])).to(
+                        literal_device(accel_runtime.current_device())))
             see_memory_usage(f"After flattening and moving param group {i} to GPU",
                              force=False)
 
@@ -689,12 +689,13 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                         device=accel_runtime.current_device(),
                         return_tensor_list=True)
                 else:
-                    avg_new = self.get_flat_partition(self.params_in_partition[i],
-                                                      self.first_offset[i],
-                                                      self.partition_size[i],
-                                                      dtype=self.dtype,
-                                                      device=accel_runtime.current_device(),
-                                                      return_tensor_list=True)
+                    avg_new = self.get_flat_partition(
+                        self.params_in_partition[i],
+                        self.first_offset[i],
+                        self.partition_size[i],
+                        dtype=self.dtype,
+                        device=accel_runtime.current_device(),
+                        return_tensor_list=True)
 
                     for accumulated_grad, new_avg_grad in zip(self.averaged_gradients[i], avg_new):
                         accumulated_grad.add_(new_avg_grad)

--- a/deepspeed/runtime/zero/utils.py
+++ b/deepspeed/runtime/zero/utils.py
@@ -7,6 +7,7 @@ from deepspeed.utils import logger
 from deepspeed.ops.adam import DeepSpeedCPUAdam
 from deepspeed.ops.adam import FusedAdam
 from deepspeed.utils.nvtx import instrument_w_nvtx
+from deepspeed.accelerator import literal_device
 
 
 def _initialize_parameter_parallel_groups(parameter_parallel_size=None):
@@ -63,8 +64,8 @@ def get_lst_from_rank0(lst: List[int]) -> None:
     lst_tensor = torch.tensor(
         lst if dist.get_rank() == 0 else [-1] * len(lst),
         dtype=int,
-        # device=torch.cuda.current_device(),
-        device=torch.device('cuda:{}'.format(os.environ["LOCAL_RANK"])),
+        # device=accel_runtime.current_device(),
+        device=torch.device(literal_device(os.environ["LOCAL_RANK"])),
         requires_grad=False,
     )
     dist.broadcast(lst_tensor, src=0, async_op=False)

--- a/deepspeed/utils/nvtx.py
+++ b/deepspeed/utils/nvtx.py
@@ -6,8 +6,10 @@ from deepspeed.accelerator import runtime as accel_runtime
 def instrument_w_nvtx(func):
     """decorator that causes an NVTX range to be recorded for the duration of the
     function call."""
-    if ((literal_device() == 'cuda' and hasattr(torch.cuda.nvtx, "range_push")) or
-        (literal_device() == 'xpu' and hasattr(torch.xpu.itt, "range_push"))):
+    if ((literal_device() == 'cuda' and hasattr(torch.cuda.nvtx,
+                                                "range_push"))
+            or (literal_device() == 'xpu' and hasattr(torch.xpu.itt,
+                                                      "range_push"))):
 
         def wrapped_fn(*args, **kwargs):
             accel_runtime.range_push(func.__qualname__)

--- a/deepspeed/utils/nvtx.py
+++ b/deepspeed/utils/nvtx.py
@@ -6,7 +6,8 @@ from deepspeed.accelerator import runtime as accel_runtime
 def instrument_w_nvtx(func):
     """decorator that causes an NVTX range to be recorded for the duration of the
     function call."""
-    if literal_device() == 'cuda' and hasattr(torch.cuda.nvtx, "range"):
+    if ((literal_device() == 'cuda' and hasattr(torch.cuda.nvtx, "range_push")) or
+        (literal_device() == 'xpu' and hasattr(torch.xpu.itt, "range_push"))):
 
         def wrapped_fn(*args, **kwargs):
             accel_runtime.range_push(func.__qualname__)

--- a/deepspeed/utils/timer.py
+++ b/deepspeed/utils/timer.py
@@ -22,12 +22,12 @@ except ImportError:
 
 
 class CudaEventTimer(object):
-    def __init__(self, start_event: torch.cuda.Event, end_event: torch.cuda.Event):
+    def __init__(self, start_event: accel_runtime.Event, end_event: accel_runtime.Event):
         self.start_event = start_event
         self.end_event = end_event
 
     def get_elapsed_msec(self):
-        torch.cuda.current_stream().wait_event(self.end_event)
+        accel_runtime.current_stream().wait_event(self.end_event)
         self.end_event.synchronize()
         return self.start_event.elapsed_time(self.end_event)
 
@@ -46,14 +46,14 @@ class SynchronizedWallClockTimer:
         def start(self):
             """Start the timer."""
             assert not self.started_, f"{self.name_} timer has already been started"
-            self.start_event = torch.cuda.Event(enable_timing=True)
+            self.start_event = accel_runtime.Event(enable_timing=True)
             self.start_event.record()
             self.started_ = True
 
         def stop(self, reset=False, record=False):
             """Stop the timer."""
             assert self.started_, "timer is not started"
-            end_event = torch.cuda.Event(enable_timing=True)
+            end_event = accel_runtime.Event(enable_timing=True)
             end_event.record()
             self.event_timers.append(CudaEventTimer(self.start_event, end_event))
             self.start_event = None

--- a/deepspeed/utils/timer.py
+++ b/deepspeed/utils/timer.py
@@ -10,6 +10,7 @@ from numpy import mean
 from deepspeed.utils.logging import log_dist
 
 from deepspeed.utils import logger
+from deepspeed.accelerator import runtime as accel_runtime
 
 try:
     import psutil
@@ -99,14 +100,14 @@ class SynchronizedWallClockTimer:
 
     @staticmethod
     def memory_usage():
-        alloc = "mem_allocated: {:.4f} GB".format(torch.cuda.memory_allocated() /
+        alloc = "mem_allocated: {:.4f} GB".format(accel_runtime.memory_allocated() /
                                                   (1024 * 1024 * 1024))
         max_alloc = "max_mem_allocated: {:.4f} GB".format(
-            torch.cuda.max_memory_allocated() / (1024 * 1024 * 1024))
-        cache = "cache_allocated: {:.4f} GB".format(torch.cuda.memory_cached() /
+            accel_runtime.max_memory_allocated() / (1024 * 1024 * 1024))
+        cache = "cache_allocated: {:.4f} GB".format(accel_runtime.memory_cached() /
                                                     (1024 * 1024 * 1024))
         max_cache = "max_cache_allocated: {:.4f} GB".format(
-            torch.cuda.max_memory_cached() / (1024 * 1024 * 1024))
+            accel_runtime.max_memory_cached() / (1024 * 1024 * 1024))
         return " | {} | {} | {} | {}".format(alloc, max_alloc, cache, max_cache)
 
     def log(self, names, normalizer=1.0, reset=True, memory_breakdown=False, ranks=None):
@@ -174,7 +175,7 @@ class ThroughputTimer:
         self._init_timer()
         self.started = True
         if self.total_step_count >= self.start_step:
-            torch.cuda.synchronize()
+            accel_runtime.synchronize()
             self.start_time = time.time()
 
     def stop(self, report_speed=True):
@@ -184,7 +185,7 @@ class ThroughputTimer:
         self.total_step_count += 1
         self.local_step_count += 1
         if self.total_step_count > self.start_step:
-            torch.cuda.synchronize()
+            accel_runtime.synchronize()
             self.end_time = time.time()
             duration = self.end_time - self.start_time
             self.total_elapsed_time += duration
@@ -195,9 +196,9 @@ class ThroughputTimer:
                         .format(self.epoch_count,
                                 self.local_step_count,
                                 self.avg_samples_per_sec(),
-                                round(torch.cuda.memory_allocated() / 1024**3,
+                                round(accel_runtime.memory_allocated() / 1024**3,
                                       2),
-                                round(torch.cuda.max_memory_allocated() / 1024**3,
+                                round(accel_runtime.max_memory_allocated() / 1024**3,
                                       2)))
                 if self.monitor_memory:
                     virt_mem = psutil.virtual_memory()

--- a/docs/_tutorials/cifar-10.md
+++ b/docs/_tutorials/cifar-10.md
@@ -140,7 +140,7 @@ Here we initialize DeepSpeed with CIFAR-10 model (`net`), `args`, `parameters` a
 After initializing DeepSpeed, the original `device` and `optimizer` are removed:
 
 ```python
- #device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+ #device = torch.device(deepspeed.accelerator.literal_device(0) if torch.cuda.is_available() else "cpu")
  #net.to(device)
 
  #optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)

--- a/tests/accelerator/ds_config.json
+++ b/tests/accelerator/ds_config.json
@@ -1,0 +1,19 @@
+{
+  "train_batch_size": 1,
+  "gradient_accumulation_steps": 1,
+  "steps_per_print": 1,
+  "optimizer": {
+    "type": "Adam",
+    "params": {
+      "lr": 0.00015,
+      "weight_decay": 1e-2
+    }
+  },
+  "fp16": {
+    "enabled": false,
+    "loss_scale": 0,
+    "loss_scale_window": 1000,
+    "hysteresis": 2,
+    "min_loss_scale": 1
+  }
+}

--- a/tests/accelerator/test_ds_init.py
+++ b/tests/accelerator/test_ds_init.py
@@ -1,0 +1,43 @@
+import os
+import torch
+import deepspeed
+import deepspeed.accelerator as accel
+
+class OneLayerNet(torch.nn.Module):
+    def __init__(self, D_in, D_out):
+        """
+        In the constructor we instantiate two nn.Linear modules and assign them as
+        member variables.
+        """
+        super(OneLayerNet, self).__init__()
+        self.linear1 = torch.nn.Linear(D_in, D_out)
+
+    def forward(self, x):
+        """
+        In the forward function we accept a Variable of input data and we must return
+        a Variable of output data. We can use Modules defined in the constructor as
+        well as arbitrary operators on Variables.
+        """
+        h_relu = self.linear1(x).clamp(min=0)
+        y_pred = self.linear1(h_relu)
+        return y_pred
+
+def test_literal_device():
+    model = OneLayerNet(128, 128)
+
+    os.environ['RANK'] = '0'
+    os.environ['WORLD_SIZE'] = '1'
+    os.environ['MASTER_ADDR'] = '127.0.0.1'
+    os.environ['MASTER_PORT'] = '8088'
+    os.environ['LOCAL_RANK'] = '0'
+    if accel.literal_device() == 'cuda':
+        deepspeed.init_distributed('nccl')
+    else:
+        deepspeed.init_distributed('ccl')
+    deepspeed.initialize(model=model, config='ds_config.json')
+    string = accel.literal_device()  #'xpu' or 'cuda'
+    string0 = accel.literal_device(0) #'xpu:0' or 'cuda:0'
+    string1 = accel.literal_device(1) #'xpu:1' or 'cuda:1'
+    assert string == 'xpu' or string == 'cuda'
+    assert string0 == 'xpu:0' or string0 == 'cuda:0'
+    assert string1 == 'xpu:1' or string1 == 'cuda:1'

--- a/tests/accelerator/test_ds_init.py
+++ b/tests/accelerator/test_ds_init.py
@@ -3,6 +3,7 @@ import torch
 import deepspeed
 import deepspeed.accelerator as accel
 
+
 class OneLayerNet(torch.nn.Module):
     def __init__(self, D_in, D_out):
         """
@@ -22,6 +23,7 @@ class OneLayerNet(torch.nn.Module):
         y_pred = self.linear1(h_relu)
         return y_pred
 
+
 def test_literal_device():
     model = OneLayerNet(128, 128)
 
@@ -36,8 +38,8 @@ def test_literal_device():
         deepspeed.init_distributed('ccl')
     deepspeed.initialize(model=model, config='ds_config.json')
     string = accel.literal_device()  #'xpu' or 'cuda'
-    string0 = accel.literal_device(0) #'xpu:0' or 'cuda:0'
-    string1 = accel.literal_device(1) #'xpu:1' or 'cuda:1'
+    string0 = accel.literal_device(0)  #'xpu:0' or 'cuda:0'
+    string1 = accel.literal_device(1)  #'xpu:1' or 'cuda:1'
     assert string == 'xpu' or string == 'cuda'
     assert string0 == 'xpu:0' or string0 == 'cuda:0'
     assert string1 == 'xpu:1' or string1 == 'cuda:1'

--- a/tests/benchmarks/flatten_bench.py
+++ b/tests/benchmarks/flatten_bench.py
@@ -13,6 +13,7 @@ import gc
 import torch
 from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 from deepspeed.ops.op_builder import UtilsBuilder
+from deepspeed.accelerator import runtime as accel_runtime
 
 from apex_C import flatten as flatten_apex
 
@@ -24,11 +25,11 @@ torch.manual_seed(0)
 # emulate a small typical model weights
 x = [
     torch.rand((512,
-                512)).cuda(),
+                512)).to(literal_device()),
     torch.rand((512,
-                1024)).cuda(),
+                1024)).to(literal_device()),
     torch.rand((512,
-                30000)).cuda()
+                30000)).to(literal_device())
 ]
 t = x * 30
 
@@ -69,15 +70,15 @@ def cprofileme():
     print("py")
     cProfile.run("py()", sort=-1)
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
     print("cpp")
     cProfile.run("cpp()", sort=-1)
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
     print("apex")
     cProfile.run("apex()", sort=-1)
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
 
 
 #### timeit ####
@@ -89,13 +90,13 @@ def timeme():
     print("--------------- timeit -----------------")
     print(f'py  ={timeit.Timer("py()", globals=globals()).timeit(number=1)}')
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
     print(f'cpp ={timeit.Timer("cpp()", globals=globals()).timeit(number=1)}')
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
     print(f'apex={timeit.Timer("apex()", globals=globals()).timeit(number=1)}')
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
 
 
 #### line_profiler ####
@@ -109,15 +110,15 @@ def line_profileme():
     print("py")
     profile(py)()
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
     print("cpp")
     profile(cpp)()
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
     print("apex")
     profile(apex)()
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
 
 
 if __name__ == "__main__":

--- a/tests/benchmarks/unflatten_bench.py
+++ b/tests/benchmarks/unflatten_bench.py
@@ -12,6 +12,7 @@ import gc
 import torch
 from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 from deepspeed.ops.op_builder import UtilsBuilder
+from deepspeed.accelerator import runtime as accel_runtime
 
 from apex_C import flatten as flatten_apex
 from apex_C import unflatten as unflatten_apex
@@ -24,11 +25,11 @@ torch.manual_seed(0)
 # emulate a small typical model weights
 x = [
     torch.rand((512,
-                512)).cuda(),
+                512)).to(literal_device()),
     torch.rand((512,
-                1024)).cuda(),
+                1024)).to(literal_device()),
     torch.rand((512,
-                30000)).cuda()
+                30000)).to(literal_device())
 ]
 unflat_t = x * 30
 
@@ -78,15 +79,15 @@ def cprofileme():
     print("py")
     cProfile.run("py()", sort=-1)
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
     print("cpp")
     cProfile.run("cpp()", sort=-1)
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
     print("apex")
     cProfile.run("apex()", sort=-1)
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
 
 
 #### timeit ####
@@ -98,13 +99,13 @@ def timeme():
     print("--------------- timeit -----------------")
     print(f'py  ={timeit.Timer("py()", globals=globals()).timeit(number=1)}')
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
     print(f'cpp ={timeit.Timer("cpp()", globals=globals()).timeit(number=1)}')
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
     print(f'apex={timeit.Timer("apex()", globals=globals()).timeit(number=1)}')
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
 
 
 #### line_profiler ####
@@ -118,15 +119,15 @@ def line_profileme():
     print("py")
     profile(py)()
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
     print("cpp")
     profile(cpp)()
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
     print("apex")
     profile(apex)()
     gc.collect()
-    torch.cuda.empty_cache()
+    accel_runtime.empty_cache()
 
 
 if __name__ == "__main__":

--- a/tests/onebit/test_mpi_backend.py
+++ b/tests/onebit/test_mpi_backend.py
@@ -6,6 +6,8 @@ import numpy as np
 import deepspeed
 
 from deepspeed.runtime.comm.mpi import MpiBackend
+from deepspeed.accelerator import literal_device
+from deepspeed.accelerator import runtime as accel_runtime
 
 comm = MPI.COMM_WORLD
 size = comm.Get_size()
@@ -16,7 +18,7 @@ deepspeed.init_distributed(dist_backend='nccl')
 # Change cuda_aware to True to test out CUDA-Aware MPI communication
 backend = MpiBackend(cuda_aware=False)
 
-device = torch.device('cuda', rank % torch.cuda.device_count())
+device = torch.device(literal_device(), rank % accel_runtime.device_count())
 
 
 # A simulated compression function using torch.distributed
@@ -36,7 +38,7 @@ def torch_sim(a):
         [server_scale[i] * a_sign_list[i] for i in range(dist.get_world_size())])
     rank = dist.get_rank()
     server_error = a_list[rank] - server_scale[rank] * a_sign_list[rank]
-    torch.cuda.synchronize()
+    accel_runtime.synchronize()
     torch.distributed.barrier()
     return a_server_compressed, worker_error, server_error
 
@@ -57,8 +59,8 @@ worker_error = torch.zeros(right_tensor_size, device=device)
 server_error = torch.zeros(right_server_size, device=device)
 
 a_torch, worker_error_torch, server_error_torch = torch_sim(a)
-torch.cuda.empty_cache()
-local_rank = rank % torch.cuda.device_count()
+accel_runtime.empty_cache()
+local_rank = rank % accel_runtime.device_count()
 
 a_after = backend.compressed_allreduce(a, worker_error, server_error, local_rank)
 

--- a/tests/onebit/test_mpi_perf.py
+++ b/tests/onebit/test_mpi_perf.py
@@ -9,6 +9,8 @@ from deepspeed.runtime.comm.mpi import MpiBackend
 
 # Configure wall clock timer
 from deepspeed.utils.timer import SynchronizedWallClockTimer
+from deepspeed.accelerator import literal_device
+from deepspeed.accelerator import runtime as accel_runtime
 
 from statistics import mean
 
@@ -22,7 +24,7 @@ deepspeed.init_distributed(dist_backend='nccl')
 # Change cuda_aware to True to test out CUDA-Aware MPI communication
 backend = MpiBackend(cuda_aware=False)
 
-device = torch.device('cuda', rank % torch.cuda.device_count())
+device = torch.device(literal_device(), rank % accel_runtime.device_count())
 
 tensor_size = 300 * 2**20
 server_size = int(tensor_size / size)
@@ -42,7 +44,7 @@ server_error = torch.zeros(right_server_size, device=device)
 warmup = 10
 iters = 10
 
-local_rank = rank % torch.cuda.device_count()
+local_rank = rank % accel_runtime.device_count()
 
 # Warmup
 for i in range(warmup):

--- a/tests/onebit/test_nccl_backend.py
+++ b/tests/onebit/test_nccl_backend.py
@@ -7,6 +7,8 @@ import deepspeed
 import os
 
 from deepspeed.runtime.comm.nccl import NcclBackend
+from deepspeed.accelerator import literal_device
+from deepspeed.accelerator import runtime as accel_runtime
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--local_rank', type=int, default=-1)
@@ -15,8 +17,8 @@ args = parser.parse_args()
 deepspeed.init_distributed(dist_backend='nccl')
 args.local_rank = int(os.environ['LOCAL_RANK'])
 
-torch.cuda.set_device(args.local_rank)
-device = torch.device("cuda", args.local_rank)
+accel_runtime.set_device(args.local_rank)
+device = torch.device(literal_device(), args.local_rank)
 
 size = dist.get_world_size()
 rank = dist.get_rank()
@@ -42,7 +44,7 @@ def torch_sim(a):
         [server_scale[i] * a_sign_list[i] for i in range(dist.get_world_size())])
     rank = dist.get_rank()
     server_error = a_list[rank] - server_scale[rank] * a_sign_list[rank]
-    torch.cuda.synchronize()
+    accel_runtime.synchronize()
     torch.distributed.barrier()
     return a_server_compressed, worker_error, server_error
 
@@ -63,7 +65,7 @@ worker_error = torch.zeros(right_tensor_size, device=device)
 server_error = torch.zeros(right_server_size, device=device)
 
 a_torch, worker_error_torch, server_error_torch = torch_sim(a)
-torch.cuda.empty_cache()
+accel_runtime.empty_cache()
 
 a_after = backend.compressed_allreduce(a, worker_error, server_error, local_rank)
 

--- a/tests/onebit/test_nccl_perf.py
+++ b/tests/onebit/test_nccl_perf.py
@@ -8,6 +8,8 @@ import os
 
 from deepspeed.runtime.comm.nccl import NcclBackend
 from deepspeed.utils.timer import SynchronizedWallClockTimer
+from deepspeed.accelerator import literal_device
+from deepspeed.accelerator import runtime as accel_runtime
 from statistics import mean
 
 timers = SynchronizedWallClockTimer()
@@ -19,8 +21,8 @@ args = parser.parse_args()
 deepspeed.init_distributed(dist_backend='nccl')
 args.local_rank = int(os.environ['LOCAL_RANK'])
 
-torch.cuda.set_device(args.local_rank)
-device = torch.device("cuda", args.local_rank)
+accel_runtime.set_device(args.local_rank)
+device = torch.device(literal_device(), args.local_rank)
 
 size = dist.get_world_size()
 rank = dist.get_rank()

--- a/tests/perf/adam_test1.py
+++ b/tests/perf/adam_test1.py
@@ -6,9 +6,10 @@ import time
 device = 'cpu'
 model_size = 1 * 1024**3
 param = torch.nn.Parameter(torch.ones(model_size, device=device))
-param_fp16 = torch.nn.Parameter(torch.ones(model_size,
-                                           dtype=torch.half,
-                                           device=literal_device(0)))
+param_fp16 = torch.nn.Parameter(
+    torch.ones(model_size,
+               dtype=torch.half,
+               device=literal_device(0)))
 
 optimizer = DeepSpeedCPUAdam([param])
 #torch.set_num_threads(128)

--- a/tests/perf/adam_test1.py
+++ b/tests/perf/adam_test1.py
@@ -1,5 +1,6 @@
 import torch
 from deepspeed.ops.adam import DeepSpeedCPUAdam
+from deepspeed.accelerator import literal_device
 import time
 
 device = 'cpu'
@@ -7,7 +8,7 @@ model_size = 1 * 1024**3
 param = torch.nn.Parameter(torch.ones(model_size, device=device))
 param_fp16 = torch.nn.Parameter(torch.ones(model_size,
                                            dtype=torch.half,
-                                           device='cuda:0'))
+                                           device=literal_device(0)))
 
 optimizer = DeepSpeedCPUAdam([param])
 #torch.set_num_threads(128)

--- a/tests/small_model_debugging/test.py
+++ b/tests/small_model_debugging/test.py
@@ -43,7 +43,9 @@ y = model(tens)
 
 see_memory_usage("After forward")
 
-model.weight.data = torch.zeros(1, dtype=torch.half, device=torch.device(literal_device()))
+model.weight.data = torch.zeros(1,
+                                dtype=torch.half,
+                                device=torch.device(literal_device()))
 
 see_memory_usage("After weight zero")
 

--- a/tests/small_model_debugging/test.py
+++ b/tests/small_model_debugging/test.py
@@ -3,6 +3,8 @@ from deepspeed.pt.deepspeed_linear import LinearModuleForZeroStage3
 from deepspeed.pt.deepspeed_utils import see_memory_usage
 from deepspeed.pt.log_utils import logger
 import deepspeed
+from deepspeed.accelerator import literal_device
+from deepspeed.accelerator import runtime as accel_runtime
 
 
 def see_memory_usage(message):
@@ -11,37 +13,37 @@ def see_memory_usage(message):
     logger.info(message)
     logger.info(
         "Memory Allocated %s GigaBytes ",
-        torch.cuda.memory_allocated() / (1024 * 1024 * 1024),
+        accel_runtime.memory_allocated() / (1024 * 1024 * 1024),
     )
     logger.info(
         "Max Memory Allocated %s GigaBytes",
-        torch.cuda.max_memory_allocated() / (1024 * 1024 * 1024),
+        accel_runtime.max_memory_allocated() / (1024 * 1024 * 1024),
     )
     logger.info(
         "Cache Allocated %s GigaBytes",
-        torch.cuda.memory_cached() / (1024 * 1024 * 1024),
+        accel_runtime.memory_cached() / (1024 * 1024 * 1024),
     )
     logger.info(
         "Max cache Allocated %s GigaBytes",
-        torch.cuda.max_memory_cached() / (1024 * 1024 * 1024),
+        accel_runtime.max_memory_cached() / (1024 * 1024 * 1024),
     )
 
 
-tens = torch.rand(1024, 16384, dtype=torch.half, device=torch.device('cuda'))
+tens = torch.rand(1024, 16384, dtype=torch.half, device=torch.device(literal_device()))
 tens_back = tens.detach().clone()
 
 #linear_bk = torch.nn.functional.linear
 #torch.nn.functional.linear = deepspeed.pt.deepspeed_linear.LinearFunctionForZeroStage3.apply
 model = LinearModuleForZeroStage3(16384, 16384)
 
-model.cuda().half()
+model.to(literal_device()).half()
 
 see_memory_usage("Before forward")
 y = model(tens)
 
 see_memory_usage("After forward")
 
-model.weight.data = torch.zeros(1, dtype=torch.half, device=torch.device('cuda'))
+model.weight.data = torch.zeros(1, dtype=torch.half, device=torch.device(literal_device()))
 
 see_memory_usage("After weight zero")
 

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -45,11 +45,12 @@ def set_accelerator_visibile():
         # CUDA_VISIBLE_DEVICES is not set, discover it using accelerator specific command instead
         import subprocess
         if literal_device() == 'cuda':
-            is_rocm_pytorch = hasattr(torch.version, 'hip') and torch.version.hip is not None
+            is_rocm_pytorch = hasattr(torch.version,
+                                      'hip') and torch.version.hip is not None
             if is_rocm_pytorch:
                 rocm_smi = subprocess.check_output(['rocm-smi', '--showid'])
                 gpu_ids = filter(lambda s: 'GPU' in s,
-                                rocm_smi.decode('utf-8').strip().split('\n'))
+                                 rocm_smi.decode('utf-8').strip().split('\n'))
                 num_gpus = len(list(gpu_ids))
             else:
                 nvidia_smi = subprocess.check_output(['nvidia-smi', '--list-gpus'])

--- a/tests/unit/modeling.py
+++ b/tests/unit/modeling.py
@@ -758,10 +758,9 @@ class BertLMPredictionHead(nn.Module):
 
     def forward(self, hidden_states):
         hidden_states = self.transform(hidden_states)
-        accel_runtime.range_push(
-            "decoder input.size() = {}, weight.size() = {}".format(
-                hidden_states.size(),
-                self.decoder.weight.size()))
+        accel_runtime.range_push("decoder input.size() = {}, weight.size() = {}".format(
+            hidden_states.size(),
+            self.decoder.weight.size()))
         hidden_states = self.decoder(hidden_states) + self.bias
         accel_runtime.range_pop()
         return hidden_states

--- a/tests/unit/modelingpreln.py
+++ b/tests/unit/modelingpreln.py
@@ -42,6 +42,7 @@ from torch.nn.parameter import Parameter
 import torch.nn.functional as F
 import torch.nn.init as init
 import time
+from deepspeed.accelerator import runtime as accel_runtime
 
 #from numba import cuda
 
@@ -852,12 +853,12 @@ class BertLMPredictionHead(nn.Module):
 
     def forward(self, hidden_states):
         hidden_states = self.transform(hidden_states)
-        torch.cuda.nvtx.range_push(
+        accel_runtime.range_push(
             "decoder input.size() = {}, weight.size() = {}".format(
                 hidden_states.size(),
                 self.decoder.weight.size()))
         hidden_states = self.decoder(hidden_states) + self.bias
-        torch.cuda.nvtx.range_pop()
+        accel_runtime.range_pop()
         return hidden_states
 
 
@@ -987,7 +988,7 @@ class BertPreTrainedModel(nn.Module):
             weights_path = os.path.join(serialization_dir, WEIGHTS_NAME)
             state_dict = torch.load(
                 weights_path,
-                map_location='cpu' if not torch.cuda.is_available() else None)
+                map_location='cpu' if not accel_runtime.is_available() else None)
         if tempdir:
             # Clean up temp dir
             shutil.rmtree(tempdir)

--- a/tests/unit/modelingpreln.py
+++ b/tests/unit/modelingpreln.py
@@ -853,10 +853,9 @@ class BertLMPredictionHead(nn.Module):
 
     def forward(self, hidden_states):
         hidden_states = self.transform(hidden_states)
-        accel_runtime.range_push(
-            "decoder input.size() = {}, weight.size() = {}".format(
-                hidden_states.size(),
-                self.decoder.weight.size()))
+        accel_runtime.range_push("decoder input.size() = {}, weight.size() = {}".format(
+            hidden_states.size(),
+            self.decoder.weight.size()))
         hidden_states = self.decoder(hidden_states) + self.bias
         accel_runtime.range_pop()
         return hidden_states

--- a/tests/unit/simple_model.py
+++ b/tests/unit/simple_model.py
@@ -5,6 +5,7 @@ import torch
 
 from deepspeed.pipe import PipelineModule, LayerSpec
 from deepspeed.moe.layer import MoE
+from deepspeed.accelerator import runtime as accel_runtime
 
 
 class SimpleModel(torch.nn.Module):
@@ -263,7 +264,7 @@ def create_deepspeed_args():
     args.deepspeed = True
     if torch.distributed.is_initialized():
         # We assume up to one full node executing unit tests
-        assert torch.distributed.get_world_size() <= torch.cuda.device_count()
+        assert torch.distributed.get_world_size() <= accel_runtime.device_count()
         args.local_rank = torch.distributed.get_rank()
     return args
 

--- a/tests/unit/test_activation_checkpointing.py
+++ b/tests/unit/test_activation_checkpointing.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 import deepspeed
+from deepspeed.accelerator import literal_device
 
 ckpt = deepspeed.checkpointing.checkpoint
 
@@ -40,7 +41,7 @@ def _prep_inputs(*inputs):
     for inp in inputs:
         inp = deepcopy(inp)
         if torch.is_tensor(inp):
-            inp = inp.cuda()
+            inp = inp.to(literal_device())
         _inputs.append(inp)
 
     return tuple(_inputs)
@@ -64,7 +65,7 @@ def _match_outputs(ref, tgt):
 @distributed_test(world_size=1)
 def _test_activation_checkpoint(module, *inputs):
     # Move to device
-    module.cuda()
+    module.to(literal_device())
 
     # Get rid of dropouts until we fork the RNG between tests.
     module.eval()
@@ -87,7 +88,7 @@ def _test_activation_checkpoint(module, *inputs):
 @distributed_test(world_size=1)
 def _test_activation_checkpoint_ordering(module, expected_ordering, *inputs):
     # Move to device
-    module.cuda()
+    module.to(literal_device())
 
     # Get rid of dropouts until we fork the RNG between tests.
     module.eval()

--- a/tests/unit/test_aio.py
+++ b/tests/unit/test_aio.py
@@ -5,6 +5,7 @@ import torch
 import deepspeed
 import torch.distributed as dist
 from deepspeed.ops.aio import AsyncIOBuilder
+from deepspeed.accelerator import runtime as accel_runtime
 from .common import distributed_test
 
 MEGA_BYTE = 1024**2
@@ -33,7 +34,7 @@ def _get_test_file_and_buffer(tmpdir, ref_buffer, cuda_device, index=0):
     file_suffix = f'{dist.get_rank()}_{index}'
     test_file = os.path.join(tmpdir, f'_aio_write_random_{file_suffix}.pt')
     if cuda_device:
-        test_buffer = torch.cuda.ByteTensor(list(ref_buffer))
+        test_buffer = accel_runtime.ByteTensor(list(ref_buffer))
     else:
         test_buffer = torch.ByteTensor(list(ref_buffer)).pin_memory()
 

--- a/tests/unit/test_autocast.py
+++ b/tests/unit/test_autocast.py
@@ -2,9 +2,14 @@ import pytest
 import torch
 import deepspeed
 from deepspeed.runtime.zero.linear import LinearModuleForZeroStage3
+from deepspeed.accelerator import literal_device
 
 
 def _skip_autocast_test():
+
+    if literal_device() != 'cuda':
+        return False
+
     try:
         from torch.cuda.amp import custom_fwd, custom_bwd
     except (ImportError, AttributeError) as exp:
@@ -17,11 +22,11 @@ def _skip_autocast_test():
 def test_missing_amp_autocast(tmpdir, half_op):
     hidden_dim = 4
     if half_op:
-        input = torch.randn(hidden_dim).cuda().half()
-        ds_linear = LinearModuleForZeroStage3(hidden_dim, hidden_dim).cuda().half()
+        input = torch.randn(hidden_dim).to(literal_device()).half()
+        ds_linear = LinearModuleForZeroStage3(hidden_dim, hidden_dim).to(literal_device()).half()
     else:
-        input = torch.randn(hidden_dim).cuda()
-        ds_linear = LinearModuleForZeroStage3(hidden_dim, hidden_dim).cuda()
+        input = torch.randn(hidden_dim).to(literal_device())
+        ds_linear = LinearModuleForZeroStage3(hidden_dim, hidden_dim).to(literal_device())
 
     output = ds_linear(input)
     assert output.dtype == ds_linear.weight.dtype
@@ -34,11 +39,11 @@ def test_disable_autocast_linear(tmpdir, half_op):
 
     hidden_dim = 4
     if half_op:
-        input = torch.randn(hidden_dim).cuda().half()
-        ds_linear = LinearModuleForZeroStage3(hidden_dim, hidden_dim).cuda().half()
+        input = torch.randn(hidden_dim).to(literal_device()).half()
+        ds_linear = LinearModuleForZeroStage3(hidden_dim, hidden_dim).to(literal_device()).half()
     else:
-        input = torch.randn(hidden_dim).cuda()
-        ds_linear = LinearModuleForZeroStage3(hidden_dim, hidden_dim).cuda()
+        input = torch.randn(hidden_dim).to(literal_device())
+        ds_linear = LinearModuleForZeroStage3(hidden_dim, hidden_dim).to(literal_device())
 
     with torch.cuda.amp.autocast(False):
         output = ds_linear(input)
@@ -59,8 +64,8 @@ def test_autocast_linear(tmpdir, half_input, half_weight):
         pytest.skip("amp autocast is not available")
 
     hidden_dim = 4
-    input = torch.randn(hidden_dim).cuda()
-    ds_linear = LinearModuleForZeroStage3(hidden_dim, hidden_dim).cuda()
+    input = torch.randn(hidden_dim).to(literal_device())
+    ds_linear = LinearModuleForZeroStage3(hidden_dim, hidden_dim).to(literal_device())
 
     if half_input:
         input = input.half()

--- a/tests/unit/test_autocast.py
+++ b/tests/unit/test_autocast.py
@@ -23,10 +23,12 @@ def test_missing_amp_autocast(tmpdir, half_op):
     hidden_dim = 4
     if half_op:
         input = torch.randn(hidden_dim).to(literal_device()).half()
-        ds_linear = LinearModuleForZeroStage3(hidden_dim, hidden_dim).to(literal_device()).half()
+        ds_linear = LinearModuleForZeroStage3(hidden_dim,
+                                              hidden_dim).to(literal_device()).half()
     else:
         input = torch.randn(hidden_dim).to(literal_device())
-        ds_linear = LinearModuleForZeroStage3(hidden_dim, hidden_dim).to(literal_device())
+        ds_linear = LinearModuleForZeroStage3(hidden_dim,
+                                              hidden_dim).to(literal_device())
 
     output = ds_linear(input)
     assert output.dtype == ds_linear.weight.dtype
@@ -40,10 +42,12 @@ def test_disable_autocast_linear(tmpdir, half_op):
     hidden_dim = 4
     if half_op:
         input = torch.randn(hidden_dim).to(literal_device()).half()
-        ds_linear = LinearModuleForZeroStage3(hidden_dim, hidden_dim).to(literal_device()).half()
+        ds_linear = LinearModuleForZeroStage3(hidden_dim,
+                                              hidden_dim).to(literal_device()).half()
     else:
         input = torch.randn(hidden_dim).to(literal_device())
-        ds_linear = LinearModuleForZeroStage3(hidden_dim, hidden_dim).to(literal_device())
+        ds_linear = LinearModuleForZeroStage3(hidden_dim,
+                                              hidden_dim).to(literal_device())
 
     with torch.cuda.amp.autocast(False):
         output = ds_linear(input)

--- a/tests/unit/test_coalesced_collectives.py
+++ b/tests/unit/test_coalesced_collectives.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 import torch.distributed as dist
 from deepspeed.runtime.comm.coalesced_collectives import reduce_scatter_coalesced
+from deepspeed.accelerator import runtime as accel_runtime
 
 from .common import distributed_test
 
@@ -15,7 +16,7 @@ def test_reduce_scatter_coalesced_single_input():
                         ),
                        dist.get_rank(),
                        dtype=torch.half,
-                       device=torch.cuda.current_device())
+                       device=accel_runtime.current_device())
 
     (output, ) = reduce_scatter_coalesced([input], dist.group.WORLD)
 
@@ -25,7 +26,7 @@ def test_reduce_scatter_coalesced_single_input():
 
 @distributed_test(world_size=2)
 def test_reduce_scatter_coalesced_two_inputs():
-    tensor_kwargs = {"device": torch.cuda.current_device(), "dtype": torch.half}
+    tensor_kwargs = {"device": accel_runtime.current_device(), "dtype": torch.half}
     inputs = [
         dist.get_rank() * torch.arange(0,
                                        6,
@@ -51,7 +52,7 @@ def test_reduce_scatter_coalesced_two_inputs():
 
 @distributed_test(world_size=2)
 def test_reduce_scatter_coalesced_tensor_smaller_than_world_sz():
-    input = torch.zeros((1, ), dtype=torch.half, device=torch.cuda.current_device())
+    input = torch.zeros((1, ), dtype=torch.half, device=accel_runtime.current_device())
 
     (output, ) = reduce_scatter_coalesced([input], dist.group.WORLD)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,6 +5,7 @@ import json
 import argparse
 
 from deepspeed.runtime.zero.config import DeepSpeedZeroConfig
+from deepspeed.accelerator import runtime as accel_runtime
 
 from .common import distributed_test, get_test_path
 from .simple_model import SimpleModel, create_config_from_dict, random_dataloader
@@ -16,7 +17,7 @@ from deepspeed.runtime.config import DeepSpeedConfig, get_bfloat16_enabled
 
 
 def test_cuda():
-    assert (torch.cuda.is_available())
+    assert (accel_runtime.is_available())
 
 
 def test_check_version():

--- a/tests/unit/test_configurable_parallel.py
+++ b/tests/unit/test_configurable_parallel.py
@@ -78,7 +78,9 @@ class TestConfigurableMP:
             model = self.get_deepspeed_model(model, tmpdir)
 
             model.eval()
-            baseline = model(inputs[0].to(literal_device()), inputs[1].to(literal_device()), inputs[2].to(literal_device()))
+            baseline = model(inputs[0].to(literal_device()),
+                             inputs[1].to(literal_device()),
+                             inputs[2].to(literal_device()))
 
             tag = 'mp_1'
             state_dict = {}
@@ -112,7 +114,9 @@ class TestConfigurableMP:
 
             model.eval()
 
-            baseline = model(inputs[0].to(literal_device()), inputs[1].to(literal_device()), inputs[2].to(literal_device()))
+            baseline = model(inputs[0].to(literal_device()),
+                             inputs[1].to(literal_device()),
+                             inputs[2].to(literal_device()))
 
             tag = 'mp_2'
             state_dict = {}
@@ -124,7 +128,9 @@ class TestConfigurableMP:
                                   load_optimizer_states=False,
                                   load_lr_scheduler_states=False)
 
-            test = model(inputs[0].to(literal_device()), inputs[1].to(literal_device()), inputs[2].to(literal_device()))
+            test = model(inputs[0].to(literal_device()),
+                         inputs[1].to(literal_device()),
+                         inputs[2].to(literal_device()))
             assert torch.allclose(baseline, test, rtol=1.0, atol=1e-07), f"Baseline output {baseline} is not equal to save-then-load output {test}"
 
         inputs = self.get_inputs()
@@ -149,7 +155,9 @@ class TestConfigurableMP:
             model.eval()
 
             with torch.no_grad():
-                baseline = model(inputs[0].to(literal_device()), inputs[1].to(literal_device()), inputs[2].to(literal_device()))
+                baseline = model(inputs[0].to(literal_device()),
+                                 inputs[1].to(literal_device()),
+                                 inputs[2].to(literal_device()))
                 if dist.get_rank() == 0:
                     output.put(baseline.cpu())
 
@@ -178,7 +186,9 @@ class TestConfigurableMP:
                                       tag=tag,
                                       load_optimizer_states=False,
                                       load_lr_scheduler_states=False)
-                test = model(inputs[0].to(literal_device()), inputs[1].to(literal_device()), inputs[2].to(literal_device()))
+                test = model(inputs[0].to(literal_device()),
+                             inputs[1].to(literal_device()),
+                             inputs[2].to(literal_device()))
                 if dist.get_rank() == 0:
                     output.put(test.cpu())
             quit_event.wait()

--- a/tests/unit/test_configurable_parallel.py
+++ b/tests/unit/test_configurable_parallel.py
@@ -12,6 +12,8 @@ from .simple_model import args_from_dict, create_deepspeed_args
 from .megatron_model import get_gpt2_model, get_megatron_version
 from .megatron_model import MockGPT2ModelPipe as GPT2ModelPipe
 from deepspeed.utils import RepeatingLoader
+from deepspeed.accelerator import literal_device
+from deepspeed.accelerator import runtime as accel_runtime
 
 TORCH_MAJOR = int(torch.__version__.split('.')[0])
 TORCH_MINOR = int(torch.__version__.split('.')[1])
@@ -24,7 +26,7 @@ def reset_random(seed=1234):
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
+    accel_runtime.manual_seed_all(seed)
 
 
 class TestConfigurableMP:
@@ -76,7 +78,7 @@ class TestConfigurableMP:
             model = self.get_deepspeed_model(model, tmpdir)
 
             model.eval()
-            baseline = model(inputs[0].cuda(), inputs[1].cuda(), inputs[2].cuda())
+            baseline = model(inputs[0].to(literal_device()), inputs[1].to(literal_device()), inputs[2].to(literal_device()))
 
             tag = 'mp_1'
             state_dict = {}
@@ -110,7 +112,7 @@ class TestConfigurableMP:
 
             model.eval()
 
-            baseline = model(inputs[0].cuda(), inputs[1].cuda(), inputs[2].cuda())
+            baseline = model(inputs[0].to(literal_device()), inputs[1].to(literal_device()), inputs[2].to(literal_device()))
 
             tag = 'mp_2'
             state_dict = {}
@@ -122,7 +124,7 @@ class TestConfigurableMP:
                                   load_optimizer_states=False,
                                   load_lr_scheduler_states=False)
 
-            test = model(inputs[0].cuda(), inputs[1].cuda(), inputs[2].cuda())
+            test = model(inputs[0].to(literal_device()), inputs[1].to(literal_device()), inputs[2].to(literal_device()))
             assert torch.allclose(baseline, test, rtol=1.0, atol=1e-07), f"Baseline output {baseline} is not equal to save-then-load output {test}"
 
         inputs = self.get_inputs()
@@ -147,7 +149,7 @@ class TestConfigurableMP:
             model.eval()
 
             with torch.no_grad():
-                baseline = model(inputs[0].cuda(), inputs[1].cuda(), inputs[2].cuda())
+                baseline = model(inputs[0].to(literal_device()), inputs[1].to(literal_device()), inputs[2].to(literal_device()))
                 if dist.get_rank() == 0:
                     output.put(baseline.cpu())
 
@@ -176,7 +178,7 @@ class TestConfigurableMP:
                                       tag=tag,
                                       load_optimizer_states=False,
                                       load_lr_scheduler_states=False)
-                test = model(inputs[0].cuda(), inputs[1].cuda(), inputs[2].cuda())
+                test = model(inputs[0].to(literal_device()), inputs[1].to(literal_device()), inputs[2].to(literal_device()))
                 if dist.get_rank() == 0:
                     output.put(test.cpu())
             quit_event.wait()
@@ -247,7 +249,7 @@ class TestConfigurablePP:
         model, _, _,_ = deepspeed.initialize(model=model,
                                              model_parameters=model.parameters(),
                                              config=ds_config_dict)
-        return model.cuda()
+        return model.to(literal_device())
 
     def get_topology(self, mp, pp, world_size):
         assert world_size % (pp * mp) == 0
@@ -339,7 +341,7 @@ class TestConfigurablePP:
             model = self.get_deepspeed_model(gpt2_pipe_model, tmpdir)
 
             with torch.no_grad():
-                inputs = [x.cuda() for x in inputs]
+                inputs = [x.to(literal_device()) for x in inputs]
                 if model.is_first_stage() or model.is_last_stage():
                     loader = RepeatingLoader([(inputs[0], 0)])
                     data_iter = iter(loader)
@@ -385,7 +387,7 @@ class TestConfigurablePP:
                                       tag=tag,
                                       load_optimizer_states=False,
                                       load_lr_scheduler_states=False)
-                inputs = [x.cuda() for x in inputs]
+                inputs = [x.to(literal_device()) for x in inputs]
                 if model.is_first_stage() or model.is_last_stage():
                     loader = RepeatingLoader([(inputs[0], 0)])
                     data_iter = iter(loader)

--- a/tests/unit/test_cpu_adagrad.py
+++ b/tests/unit/test_cpu_adagrad.py
@@ -5,6 +5,7 @@ import pytest
 import deepspeed
 from deepspeed.ops.adagrad import DeepSpeedCPUAdagrad
 from deepspeed.ops.op_builder import CPUAdagradBuilder
+from deepspeed.accelerator import literal_device
 
 if not deepspeed.ops.__compatible_ops__[CPUAdagradBuilder.NAME]:
     pytest.skip("cpu-adagrad is not compatible")
@@ -127,7 +128,7 @@ def test_cpu_adagrad_opt_sparse_embedding(model_size, vocabulary_size, dim):
 
 def test_cpu_adam_gpu_error():
     model_size = 64
-    device = 'cuda:0'
+    device = literal_device(0)
     param = torch.nn.Parameter(torch.randn(model_size, device=device))
     optimizer = DeepSpeedCPUAdagrad([param])
 

--- a/tests/unit/test_cpu_adam.py
+++ b/tests/unit/test_cpu_adam.py
@@ -6,6 +6,7 @@ import pytest
 import copy
 
 import deepspeed
+from deepspeed.accelerator import literal_device
 from deepspeed.ops.adam import FusedAdam
 from deepspeed.ops.op_builder import CPUAdamBuilder
 
@@ -39,7 +40,7 @@ def test_cpu_adam_opt(model_size):
     torch.set_rng_state(rng_state)
     param1 = torch.nn.Parameter(torch.randn(model_size, device=device))
     torch.set_rng_state(rng_state)
-    param2_data = torch.randn(model_size, device=device).cuda()
+    param2_data = torch.randn(model_size, device=device).to(literal_device())
     param2 = torch.nn.Parameter(param2_data)
 
     optimizer1 = torch.optim.AdamW([param1])
@@ -52,7 +53,7 @@ def test_cpu_adam_opt(model_size):
         torch.set_rng_state(rng_state)
         param1.grad = torch.randn(model_size, device=device)
         torch.set_rng_state(rng_state)
-        param2.grad = torch.randn(model_size, device=device).cuda()
+        param2.grad = torch.randn(model_size, device=device).to(literal_device())
 
         optimizer.step()
         optimizer2.step()
@@ -65,7 +66,7 @@ def test_cpu_adam_opt(model_size):
 def test_cpu_adam_gpu_error():
     model_size = 64
     from deepspeed.ops.adam import DeepSpeedCPUAdam
-    device = 'cuda:0'
+    device = literal_device(0)
     param = torch.nn.Parameter(torch.randn(model_size, device=device))
     optimizer = DeepSpeedCPUAdam([param])
 

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -2,6 +2,7 @@ from deepspeed.utils import RepeatingLoader
 import torch
 import pytest
 import deepspeed
+from deepspeed.accelerator import runtime as accel_runtime
 from .common import distributed_test
 from .simple_model import SimpleModel, args_from_dict, random_dataset
 
@@ -49,8 +50,8 @@ def test_dataloader_drop_last(tmpdir, train_batch_size, drop_last):
                                                                 training_data=train_dataset,
                                                                 optimizer=optimizer)
         for n, batch in enumerate(training_dataloader):
-            x = batch[0].to(torch.cuda.current_device())
-            y = batch[1].to(torch.cuda.current_device())
+            x = batch[0].to(accel_runtime.current_device())
+            y = batch[1].to(accel_runtime.current_device())
             loss = model(x, y)
             model.backward(loss)
             model.step()

--- a/tests/unit/test_dist.py
+++ b/tests/unit/test_dist.py
@@ -2,6 +2,7 @@ import torch
 import torch.distributed as dist
 
 from .common import distributed_test
+from deepspeed.accelerator import literal_device
 
 import pytest
 
@@ -31,8 +32,8 @@ def test_dist_args(number, color):
 
 @distributed_test(world_size=[1, 2, 4])
 def test_dist_allreduce():
-    x = torch.ones(1, 3).cuda() * (dist.get_rank() + 1)
+    x = torch.ones(1, 3).to(literal_device()) * (dist.get_rank() + 1)
     sum_of_ranks = (dist.get_world_size() * (dist.get_world_size() + 1)) // 2
-    result = torch.ones(1, 3).cuda() * sum_of_ranks
+    result = torch.ones(1, 3).to(literal_device()) * sum_of_ranks
     dist.all_reduce(x)
     assert torch.all(x == result)

--- a/tests/unit/test_fp16.py
+++ b/tests/unit/test_fp16.py
@@ -10,6 +10,7 @@ import os
 from deepspeed.ops.adam import FusedAdam
 from .common import distributed_test
 from deepspeed.ops.op_builder import CPUAdamBuilder
+from deepspeed.accelerator import runtime as accel_runtime
 from .simple_model import SimpleModel, SimpleOptimizer, random_dataloader, args_from_dict, create_deepspeed_args, SimpleMoEModel, sequence_dataloader
 from .util import required_torch_version
 
@@ -215,7 +216,7 @@ def test_unfused_fp16_optimizer_gradnorm_for_moe(tmpdir, monkeypatch):
     hidden_dim = 10
 
     def mock_unscale_and_clip_grads(total_norm, apply_scale=True):
-        torch_norm_tensor = torch.cuda.FloatTensor([total_norm])
+        torch_norm_tensor = accel_runtime.FloatTensor([total_norm])
         all_gather_results = [
             torch.zeros_like(torch_norm_tensor) for _ in range(dist.get_world_size())
         ]
@@ -262,7 +263,7 @@ def test_fused_fp16_optimizer_gradnorm_for_moe(tmpdir, monkeypatch):
     hidden_dim = 10
 
     def mock_unscale_and_clip_grads(grads_groups_flat, total_norm, apply_scale=True):
-        torch_norm_tensor = torch.cuda.FloatTensor([total_norm])
+        torch_norm_tensor = accel_runtime.FloatTensor([total_norm])
         all_gather_results = [
             torch.zeros_like(torch_norm_tensor) for _ in range(dist.get_world_size())
         ]
@@ -317,7 +318,7 @@ def test_lamb_optimizer_gradnorm_for_moe(tmpdir, monkeypatch, fused_lamb_legacy:
     hidden_dim = 10
 
     def mock_unscale_and_clip_grads(total_norm, apply_scale=True):
-        torch_norm_tensor = torch.cuda.FloatTensor([total_norm])
+        torch_norm_tensor = accel_runtime.FloatTensor([total_norm])
         all_gather_results = [
             torch.zeros_like(torch_norm_tensor) for _ in range(dist.get_world_size())
         ]

--- a/tests/unit/test_partition.py
+++ b/tests/unit/test_partition.py
@@ -7,6 +7,7 @@ from deepspeed.runtime.utils import partition_uniform
 from deepspeed.runtime.utils import partition_balanced
 from deepspeed.runtime.utils import prefix_sum_inc
 from deepspeed.runtime.utils import PartitionedTensor
+from deepspeed.accelerator import literal_device
 
 from .common import distributed_test
 
@@ -21,7 +22,7 @@ def test_partitioned_tensor():
     rows = world * 4
     cols = 3
 
-    full = torch.rand(rows, cols).cuda()
+    full = torch.rand(rows, cols).to(literal_device())
     dist.broadcast(full, src=0, group=group)
     part = PartitionedTensor(full, group=group)
 
@@ -42,7 +43,7 @@ def test_partitioned_tensor_meta():
     rows = world * 7
     cols = 3
 
-    full = torch.rand(rows, cols).cuda()
+    full = torch.rand(rows, cols).to(literal_device())
     dist.broadcast(full, src=0, group=group)
     part = PartitionedTensor(full, group=group)
 

--- a/tests/unit/test_runtime_utils.py
+++ b/tests/unit/test_runtime_utils.py
@@ -7,6 +7,7 @@ import pytest
 import deepspeed.runtime.utils as ds_utils
 from deepspeed.utils.logging import log_dist
 import deepspeed.utils.groups as groups
+from deepspeed.accelerator import literal_device
 
 from .common import distributed_test
 
@@ -40,7 +41,7 @@ def test_clip_grad_norm_():
         norm = torch.Tensor([norm]).to(dist.get_rank())
 
         world_size = dist.get_world_size()
-        gathered_norm = [torch.zeros(1).cuda() for i in range(world_size)]
+        gathered_norm = [torch.zeros(1).to(literal_device()) for i in range(world_size)]
 
         torch.distributed.all_gather(gathered_norm, norm)
 

--- a/tests/unit/test_sparse_attention.py
+++ b/tests/unit/test_sparse_attention.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 import deepspeed
 from deepspeed.ops.op_builder import SparseAttnBuilder
+from deepspeed.accelerator import literal_device
 
 if not deepspeed.ops.__compatible_ops__[SparseAttnBuilder.NAME]:
     pytest.skip("sparse attention op is not compatible on this system",
@@ -252,15 +253,18 @@ def init_softmax_inputs(Z, H, M, N, scale, rho, block, dtype, dense_x=True, layo
 
 
 def _skip_on_cuda_compatability():
-    if torch.cuda.get_device_capability()[0] < 7:
-        pytest.skip("needs higher compute capability than 7")
-    cuda_major = int(torch.version.cuda.split('.')[0]) * 10
-    cuda_minor = int(torch.version.cuda.split('.')[1])
-    cuda_version = cuda_major + cuda_minor
-    if (cuda_version != 101 and cuda_version != 102) and \
-            (cuda_version != 111 and cuda_version != 110):
-        pytest.skip("requires cuda 10.1 or 10.2 or 11.0 or 11.1")
-
+    if deepspeed.accelerator.literal_device() == 'cuda':
+        if torch.cuda.get_device_capability()[0] < 7:
+            pytest.skip("needs higher compute capability than 7")
+        cuda_major = int(torch.version.cuda.split('.')[0]) * 10
+        cuda_minor = int(torch.version.cuda.split('.')[1])
+        cuda_version = cuda_major + cuda_minor
+        if (cuda_version != 101 and cuda_version != 102) and \
+                (cuda_version != 111 and cuda_version != 110):
+            pytest.skip("requires cuda 10.1 or 10.2 or 11.0 or 11.1")
+    else:
+        assert deepspeed.accelerator.literal_device() == 'xpu'
+        return
 
 @pytest.mark.parametrize("block", [16, 32])
 @pytest.mark.parametrize("width", [256, 576])

--- a/tests/unit/test_sparse_attention.py
+++ b/tests/unit/test_sparse_attention.py
@@ -266,6 +266,7 @@ def _skip_on_cuda_compatability():
         assert deepspeed.accelerator.literal_device() == 'xpu'
         return
 
+
 @pytest.mark.parametrize("block", [16, 32])
 @pytest.mark.parametrize("width", [256, 576])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32])

--- a/tests/unit/test_topology.py
+++ b/tests/unit/test_topology.py
@@ -8,6 +8,7 @@ from deepspeed.runtime.pipe.topology import ProcessTopology as Topo
 from deepspeed.runtime.pipe.topology import _prime_factors
 
 from .common import distributed_test
+from deepspeed.accelerator import literal_device
 
 
 def test_topology_2d():
@@ -171,13 +172,13 @@ def test_grid_pipe_data():
         grid.get_stage_id() == grid.get_pipe_parallel_world_size() - 1)
 
     # Test collectives along the pipeline parallel process groups
-    rank_tensor = torch.LongTensor(data=[rank]).cuda()
+    rank_tensor = torch.LongTensor(data=[rank]).to(literal_device())
     dist.all_reduce(rank_tensor, group=grid.get_pipe_parallel_group())
     pipe_group = grid.pp_group
     assert torch.all(rank_tensor == sum(pipe_group))
 
     # Test collectives along the data parallel process groups
-    rank_tensor = torch.LongTensor(data=[rank]).cuda()
+    rank_tensor = torch.LongTensor(data=[rank]).to(literal_device())
     dist.all_reduce(rank_tensor, group=grid.get_data_parallel_group())
     data_group = grid.dp_group
     assert torch.all(rank_tensor == sum(data_group))

--- a/tests/unit/test_zero.py
+++ b/tests/unit/test_zero.py
@@ -16,6 +16,7 @@ import deepspeed
 from deepspeed.runtime.engine import DeepSpeedEngine
 from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
 from deepspeed.utils.zero_to_fp32 import load_state_dict_from_zero_checkpoint
+from deepspeed.accelerator import literal_device
 
 
 def run_unbalanced_gradients(model, data_loader):
@@ -703,30 +704,30 @@ def test_zero3_param_partitioning_base(
             grad_multiplier = 1 if zero_grad else (train_iter + 1)
             if dist.get_rank() == 0:
                 assert torch.allclose(
-                    dloss_wrt_layer3.cuda(),
+                    dloss_wrt_layer3.to(literal_device()),
                     grad_multiplier * create_tensor([2] * 8,
                                                     torch.float))
                 assert torch.allclose(
-                    dloss_wrt_layer2.cuda(),
+                    dloss_wrt_layer2.to(literal_device()),
                     grad_multiplier * create_tensor([3 * 1] * 8,
                                                     torch.float))
                 assert torch.allclose(
-                    dloss_wrt_layer1.cuda(),
+                    dloss_wrt_layer1.to(literal_device()),
                     grad_multiplier * create_tensor([3 * 2 * 1] * 8,
                                                     torch.float))
             elif dist.get_rank() == 1:
                 # parameters dont split evenly across ranks so rank 1 has a zero-padded
                 # partition
                 assert torch.allclose(
-                    dloss_wrt_layer3.cuda(),
+                    dloss_wrt_layer3.to(literal_device()),
                     grad_multiplier * create_tensor(([8] * 7) + [0],
                                                     torch.float))
                 assert torch.allclose(
-                    dloss_wrt_layer2.cuda(),
+                    dloss_wrt_layer2.to(literal_device()),
                     grad_multiplier * create_tensor(([6 * 2] * 7) + [0],
                                                     torch.float))
                 assert torch.allclose(
-                    dloss_wrt_layer1.cuda(),
+                    dloss_wrt_layer1.to(literal_device()),
                     grad_multiplier * create_tensor(([6 * 4 * 1] * 7) + [0],
                                                     torch.float))
             else:
@@ -1143,28 +1144,28 @@ def test_zero3_param_partitioning_base_bf16(
             grad_multiplier = 1 if zero_grad else (train_iter + 1)
             if dist.get_rank() == 0:
                 assert torch.allclose(
-                    dloss_wrt_layer3.cuda(),
+                    dloss_wrt_layer3.to(literal_device()),
                     grad_multiplier * create_tensor([2] * 8).to(expected_grad_dtype))
                 assert torch.allclose(
-                    dloss_wrt_layer2.cuda(),
+                    dloss_wrt_layer2.to(literal_device()),
                     grad_multiplier * create_tensor([3 * 1] * 8).to(expected_grad_dtype))
                 assert torch.allclose(
-                    dloss_wrt_layer1.cuda(),
+                    dloss_wrt_layer1.to(literal_device()),
                     grad_multiplier *
                     create_tensor([3 * 2 * 1] * 8).to(expected_grad_dtype))
             elif dist.get_rank() == 1:
                 # parameters dont split evenly across ranks so rank 1 has a zero-padded
                 # partition
                 assert torch.allclose(
-                    dloss_wrt_layer3.cuda(),
+                    dloss_wrt_layer3.to(literal_device()),
                     grad_multiplier *
                     create_tensor(([8] * 7) + [0]).to(expected_grad_dtype))
                 assert torch.allclose(
-                    dloss_wrt_layer2.cuda(),
+                    dloss_wrt_layer2.to(literal_device()),
                     grad_multiplier *
                     create_tensor(([6 * 2] * 7) + [0]).to(expected_grad_dtype))
                 assert torch.allclose(
-                    dloss_wrt_layer1.cuda(),
+                    dloss_wrt_layer1.to(literal_device()),
                     grad_multiplier *
                     create_tensor(([6 * 4 * 1] * 7) + [0]).to(expected_grad_dtype))
             else:

--- a/tests/unit/test_zero_context.py
+++ b/tests/unit/test_zero_context.py
@@ -5,6 +5,7 @@ import torch
 import pytest
 
 import deepspeed
+from deepspeed.accelerator import literal_device
 from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus, partitioned_param_data_shape
 
 from .common import distributed_test, get_master_port
@@ -354,7 +355,7 @@ def test_subclass_param_init():
     assert model.param.ds_status == ZeroParamStatus.NOT_AVAILABLE
 
     # test that the weights manipulation during each __init__ worked in all w/o needing gathering
-    ones = torch.ones(5).half().cuda()
+    ones = torch.ones(5).half().to(literal_device())
     with deepspeed.zero.GatheredParameters(list(model.parameters(recurse=False))):
         assert torch.equal(model.param, ones + 1)
         assert torch.equal(model.param_pa, ones + 2)

--- a/tests/unit/util.py
+++ b/tests/unit/util.py
@@ -1,5 +1,6 @@
 import torch
 from deepspeed.git_version_info import torch_info
+from deepspeed.accelerator import runtime as accel_runtime
 
 
 def required_torch_version():
@@ -26,7 +27,7 @@ def bf16_required_version_check():
     if (TORCH_MAJOR > 1 or
         (TORCH_MAJOR == 1 and TORCH_MINOR >= 10)) and (CUDA_MAJOR >= 11) and (
             NCCL_MAJOR > 2 or
-            (NCCL_MAJOR == 2 and NCCL_MINOR >= 10)) and torch.cuda.is_bf16_supported():
+            (NCCL_MAJOR == 2 and NCCL_MINOR >= 10)) and accel_runtime.is_bf16_supported():
         return True
     else:
         return False

--- a/tests/unit/util.py
+++ b/tests/unit/util.py
@@ -27,7 +27,8 @@ def bf16_required_version_check():
     if (TORCH_MAJOR > 1 or
         (TORCH_MAJOR == 1 and TORCH_MINOR >= 10)) and (CUDA_MAJOR >= 11) and (
             NCCL_MAJOR > 2 or
-            (NCCL_MAJOR == 2 and NCCL_MINOR >= 10)) and accel_runtime.is_bf16_supported():
+            (NCCL_MAJOR == 2
+             and NCCL_MINOR >= 10)) and accel_runtime.is_bf16_supported():
         return True
     else:
         return False


### PR DESCRIPTION
* Make DeepSpeed independ to pytorch CUDA runtime
* Provide a deepspeed.accelerator.runtime layer to abstract torch.cuda/torch.xpu runtime
* Provide a deepspeed.accelerator.literal_device() function to query device literal string, instead of using 'cuda' string directly.