### PR TITLE
[tests] dump connection info if distributed init fails

### DIFF
--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -102,6 +102,10 @@ def distributed_test(world_size=2, backend='nccl'):
             except Exception as err:
                 print(f"open network conns:{psutil.net_connections()}")
                 print(f"port attempting to be used: {os.environ['MASTER_PORT']}")
+                result = subprocess.check_output(['ps', 'aux'])
+                print(result.decode())
+                result = subprocess.check_output(['netstat', '-l'])
+                print(result.decode())
                 raise err
 
             if torch.cuda.is_available():

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -5,6 +5,8 @@ import torch
 import torch.distributed as dist
 from torch.multiprocessing import Process
 
+import psutil
+
 import deepspeed
 
 import pytest
@@ -95,7 +97,12 @@ def distributed_test(world_size=2, backend='nccl'):
 
             set_cuda_visibile()
 
-            deepspeed.init_distributed(dist_backend=backend)
+            try:
+                deepspeed.init_distributed(dist_backend=backend)
+            except Exception as err:
+                print(f"open network conns:{psutil.net_connections()}")
+                print(f"port attempting to be used: {os.environ['MASTER_PORT']}")
+                raise err
 
             if torch.cuda.is_available():
                 torch.cuda.set_device(local_rank)

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -5,6 +5,7 @@ import torch
 import torch.distributed as dist
 from torch.multiprocessing import Process
 
+import subprocess
 import psutil
 
 import deepspeed
@@ -43,7 +44,6 @@ def set_cuda_visibile():
         xdist_worker_id = 0
     if cuda_visible is None:
         # CUDA_VISIBLE_DEVICES is not set, discover it from nvidia-smi instead
-        import subprocess
         is_rocm_pytorch = hasattr(torch.version, 'hip') and torch.version.hip is not None
         if is_rocm_pytorch:
             rocm_smi = subprocess.check_output(['rocm-smi', '--showid'])


### PR DESCRIPTION
Occasionally on AMD CI runners we are seeing random address in use errors, hoping to dump some additional context if/when this happens again. We're currently unable to trigger this again so adding this code into `master` in case it happens again.