### PR TITLE
Add unit test for various model families and inference tasks

### DIFF
--- a/tests/unit/test_inference.py
+++ b/tests/unit/test_inference.py
@@ -2,6 +2,7 @@ import os
 import torch
 import pytest
 import deepspeed
+from collections import defaultdict
 from transformers import pipeline
 from .common import distributed_test
 from packaging import version as pkg_version

--- a/tests/unit/test_inference.py
+++ b/tests/unit/test_inference.py
@@ -6,26 +6,31 @@ from transformers import pipeline
 from .common import distributed_test
 from packaging import version as pkg_version
 
+
 def pytest_configure():
     pytest.task_query_dict = {
-        "fill-mask": defaultdict(
+        "fill-mask":
+        defaultdict(
             lambda: "Hello I'm a [MASK] model.",
             {"roberta-base": "Hello I'm a <mask> model."},
         ),
-        "question-answering": defaultdict(
-            lambda: {
-                "question": "What is the greatest?",
-                "context": "DeepSpeed is the greatest",
-            }
-        ),
-        "text-classification": defaultdict(lambda: "DeepSpeed is the greatest"),
-        "token-classification": defaultdict(
-            lambda: "My name is jean-baptiste and I live in montreal."
-        ),
-        "text-generation": defaultdict(lambda: "DeepSpeed is the greatest"),
+        "question-answering":
+        defaultdict(lambda: {
+            "question": "What is the greatest?",
+            "context": "DeepSpeed is the greatest",
+        }),
+        "text-classification":
+        defaultdict(lambda: "DeepSpeed is the greatest"),
+        "token-classification":
+        defaultdict(lambda: "My name is jean-baptiste and I live in montreal."),
+        "text-generation":
+        defaultdict(lambda: "DeepSpeed is the greatest"),
     }
     pytest.task_model_dict = {
-        "fill-mask": {"bert": "bert-base-cased", "roberta": "roberta-base"},
+        "fill-mask": {
+            "bert": "bert-base-cased",
+            "roberta": "roberta-base"
+        },
         "question-answering": {
             "bert": "deepset/minilm-uncased-squad2",
             "roberta": "deepset/roberta-base-squad2",

--- a/tests/unit/test_inference.py
+++ b/tests/unit/test_inference.py
@@ -72,7 +72,7 @@ def query(task, model):
         "text-generation",
     ),
 )
-@pytest.mark.parametrize("model_family", ("bert", "roberta", "gpt2", "gpt_neo", "gptj"))
+@pytest.mark.parametrize("model_family", ("bert", "roberta", "gpt2", "gpt_neo"))
 def test_model_task_inject(task, model, query, dtype=torch.float):
     if pkg_version.parse(torch.__version__) <= pkg_version.parse('1.2'):
         pytest.skip("DS inference injection doesn't work well on older torch versions")

--- a/tests/unit/test_inference.py
+++ b/tests/unit/test_inference.py
@@ -7,49 +7,47 @@ from transformers import pipeline
 from .common import distributed_test
 from packaging import version as pkg_version
 
-
-def pytest_configure():
-    pytest.task_query_dict = {
-        "fill-mask":
-        defaultdict(
-            lambda: "Hello I'm a [MASK] model.",
-            {"roberta-base": "Hello I'm a <mask> model."},
-        ),
-        "question-answering":
-        defaultdict(lambda: {
-            "question": "What is the greatest?",
-            "context": "DeepSpeed is the greatest",
-        }),
-        "text-classification":
-        defaultdict(lambda: "DeepSpeed is the greatest"),
-        "token-classification":
-        defaultdict(lambda: "My name is jean-baptiste and I live in montreal."),
-        "text-generation":
-        defaultdict(lambda: "DeepSpeed is the greatest"),
-    }
-    pytest.task_model_dict = {
-        "fill-mask": {
-            "bert": "bert-base-cased",
-            "roberta": "roberta-base"
-        },
-        "question-answering": {
-            "bert": "deepset/minilm-uncased-squad2",
-            "roberta": "deepset/roberta-base-squad2",
-        },
-        "text-classification": {
-            "bert": "cross-encoder/ms-marco-MiniLM-L-12-v2",
-            "roberta": "j-hartmann/emotion-english-distilroberta-base",
-        },
-        "token-classification": {
-            "bert": "dslim/bert-base-NER",
-            "roberta": "Jean-Baptiste/roberta-large-ner-english",
-        },
-        "text-generation": {
-            "gpt2": "distilgpt2",
-            "gpt_neo": "Norod78/hebrew-bad_wiki-gpt_neo-tiny",
-            "gptj": "EleutherAI/gpt-j-6B",
-        },
-    }
+pytest.task_query_dict = {
+    "fill-mask":
+    defaultdict(
+        lambda: "Hello I'm a [MASK] model.",
+        {"roberta-base": "Hello I'm a <mask> model."},
+    ),
+    "question-answering":
+    defaultdict(lambda: {
+        "question": "What is the greatest?",
+        "context": "DeepSpeed is the greatest",
+    }),
+    "text-classification":
+    defaultdict(lambda: "DeepSpeed is the greatest"),
+    "token-classification":
+    defaultdict(lambda: "My name is jean-baptiste and I live in montreal."),
+    "text-generation":
+    defaultdict(lambda: "DeepSpeed is the greatest"),
+}
+pytest.task_model_dict = {
+    "fill-mask": {
+        "bert": "bert-base-cased",
+        "roberta": "roberta-base"
+    },
+    "question-answering": {
+        "bert": "deepset/minilm-uncased-squad2",
+        "roberta": "deepset/roberta-base-squad2",
+    },
+    "text-classification": {
+        "bert": "cross-encoder/ms-marco-MiniLM-L-12-v2",
+        "roberta": "j-hartmann/emotion-english-distilroberta-base",
+    },
+    "token-classification": {
+        "bert": "dslim/bert-base-NER",
+        "roberta": "Jean-Baptiste/roberta-large-ner-english",
+    },
+    "text-generation": {
+        "gpt2": "distilgpt2",
+        "gpt_neo": "Norod78/hebrew-bad_wiki-gpt_neo-tiny",
+        "gptj": "EleutherAI/gpt-j-6B",
+    },
+}
 
 
 @pytest.fixture


### PR DESCRIPTION
@jeffra and I observed that the latest release (0.6.5) broke deepspeed inference for a bert and roberta style models. These tests should help avoid similar problems in the future.

Note: the added unit tests fail on the current release due to a bug introduced in #1951 