### PR TITLE
Fix for lightning tests

### DIFF
--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -40,5 +40,6 @@ jobs:
         run: |
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
           pip install pytorch-lightning
+          pip install "protobuf<4.21.0"
           cd tests
           TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose lightning/


### PR DESCRIPTION
Getting the following error with recent lightning tests:
```
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```

See https://github.com/PyTorchLightning/pytorch-lightning/issues/13159 and https://github.com/protocolbuffers/protobuf/issues/10051

The protobuf release causing the issue was also yanked: https://pypi.org/project/protobuf/4.21.0/

This PR pins the version of protobuf to `<4.21.0` for now