### PR TITLE
Add torch-latest and torch-nightly CI workflows

### DIFF
--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -19,11 +19,11 @@ jobs:
   unit-tests:
     runs-on: [self-hosted, nvidia, cu111, v100]
 
-    env:
-      PIP: $(which pip)
-
     steps:
       - uses: actions/checkout@v2
+
+      - name: set pip
+          echo "PIP=$(which pip)" >> $GITHUB_ENV
 
       - name: environment
         run: |
@@ -32,20 +32,20 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          sudo $PIP uninstall --yes torch torchvision
-          sudo $PIP install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+          sudo ${{ env.PIP }} uninstall --yes torch torchvision
+          sudo ${{ env.PIP }} install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
       - name: Install deepspeed
         run: |
-          sudo $PIP uninstall --yes deepspeed
-          sudo $PIP install .[dev,autotuning]
+          sudo ${{ env.PIP }} uninstall --yes deepspeed
+          sudo ${{ env.PIP }} install .[dev,autotuning]
           ds_report
       - name: PyTorch Lightning Tests
         run: |
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
-          sudo $PIP uninstall --yes pytorch-lightning
-          sudo $PIP install pytorch-lightning
-          sudo $PIP install "protobuf<4.21.0"
+          sudo ${{ env.PIP }} uninstall --yes pytorch-lightning
+          sudo ${{ env.PIP }} install pytorch-lightning
+          sudo ${{ env.PIP }} install "protobuf<4.21.0"
           cd tests
           TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose lightning/

--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -17,7 +17,10 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: [self-hosted, nvidia, torch18, v100]
+    runs-on: [self-hosted, nvidia, cu111, v100]
+
+    env:
+      PIP: $(which pip)
 
     steps:
       - uses: actions/checkout@v2
@@ -29,17 +32,20 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+          sudo $PIP uninstall --yes torch torchvision
+          sudo $PIP install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
       - name: Install deepspeed
         run: |
-          pip install .[dev,autotuning]
+          sudo $PIP uninstall --yes deepspeed
+          sudo $PIP install .[dev,autotuning]
           ds_report
       - name: PyTorch Lightning Tests
         run: |
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
-          pip install pytorch-lightning
-          pip install "protobuf<4.21.0"
+          sudo $PIP uninstall --yes pytorch-lightning
+          sudo $PIP install pytorch-lightning
+          sudo $PIP install "protobuf<4.21.0"
           cd tests
           TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose lightning/

--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -22,9 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: set pip
-          echo "PIP=$(which pip)" >> $GITHUB_ENV
-
       - name: environment
         run: |
           nvidia-smi
@@ -32,20 +29,20 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          sudo ${{ env.PIP }} uninstall --yes torch torchvision
-          sudo ${{ env.PIP }} install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+          pip uninstall --yes torch torchvision
+          pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
       - name: Install deepspeed
         run: |
-          sudo ${{ env.PIP }} uninstall --yes deepspeed
-          sudo ${{ env.PIP }} install .[dev,autotuning]
+          pip uninstall --yes deepspeed
+          pip install .[dev,autotuning]
           ds_report
       - name: PyTorch Lightning Tests
         run: |
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
-          sudo ${{ env.PIP }} uninstall --yes pytorch-lightning
-          sudo ${{ env.PIP }} install pytorch-lightning
-          sudo ${{ env.PIP }} install "protobuf<4.21.0"
+          pip uninstall --yes pytorch-lightning
+          pip install pytorch-lightning
+          pip install "protobuf<4.21.0"
           cd tests
           TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose lightning/

--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -29,6 +29,7 @@ jobs:
           python --version
           which nvcc
           nvcc --version
+          pip install --upgrade pip
           pip uninstall --yes torch torchvision
           pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -29,7 +29,9 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+          PIP=$(which pip)
+          sudo $PIP uninstall --yes torch torchvision
+          sudo $PIP install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu113
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -40,11 +42,15 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          pip install .
+          PIP=$(which pip)
+          sudo $PIP uninstall --yes transformers
+          sudo $PIP install .
 
       - name: Install deepspeed
         run: |
-          pip install .[dev,1bit,autotuning,sparse_attn]
+          PIP=$(which pip)
+          sudo $PIP uninstall --yes deepspeed
+          sudo $PIP install .[dev,1bit,autotuning,sparse_attn]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -22,9 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: environment
+      - name: set pip
         run: |
           echo "PIP=$(which pip)" >> $GITHUB_ENV
+
+      - name: environment
+        run: |
           nvidia-smi
           which python
           python --version

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -30,8 +30,8 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          sudo $PIP uninstall --yes torch torchvision
-          sudo $PIP install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu113
+          sudo ${{ env.PIP }} uninstall --yes torch torchvision
+          sudo ${{ env.PIP }} install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu113
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -42,13 +42,13 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          sudo $PIP uninstall --yes transformers
-          sudo $PIP install .
+          sudo ${{ env.PIP }} uninstall --yes transformers
+          sudo ${{ env.PIP }} install .
 
       - name: Install deepspeed
         run: |
-          sudo $PIP uninstall --yes deepspeed
-          sudo $PIP install .[dev,1bit,autotuning,sparse_attn]
+          sudo ${{ env.PIP }} uninstall --yes deepspeed
+          sudo ${{ env.PIP }} install .[dev,1bit,autotuning,sparse_attn]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -1,0 +1,56 @@
+name: nv-torch-latest-v100
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'staging**'
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    runs-on: [self-hosted, nvidia, cu113, v100]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: environment
+        run: |
+          nvidia-smi
+          which python
+          python --version
+          which nvcc
+          nvcc --version
+          pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+          python -c "import torch; print('torch:', torch.__version__, torch)"
+          python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
+
+      - name: Install transformers
+        run: |
+          git clone https://github.com/huggingface/transformers
+          cd transformers
+          # if needed switch to the last known good SHA until transformers@master is fixed
+          # git checkout 1cc453d33
+          git rev-parse --short HEAD
+          pip install .
+
+      - name: Install deepspeed
+        run: |
+          pip install .[dev,1bit,autotuning,sparse_attn]
+          ds_report
+
+      - name: Unit tests
+        run: |
+          unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch
+          if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
+          cd tests
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -n 4 -m 'not sequential' unit/
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -m 'sequential' unit/

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -19,6 +19,9 @@ jobs:
   unit-tests:
     runs-on: [self-hosted, nvidia, cu113, v100]
 
+    env:
+      PIP: $(which pip)
+
     steps:
       - uses: actions/checkout@v2
 
@@ -29,7 +32,6 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          PIP=$(which pip)
           sudo $PIP uninstall --yes torch torchvision
           sudo $PIP install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu113
           python -c "import torch; print('torch:', torch.__version__, torch)"
@@ -42,13 +44,11 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          PIP=$(which pip)
           sudo $PIP uninstall --yes transformers
           sudo $PIP install .
 
       - name: Install deepspeed
         run: |
-          PIP=$(which pip)
           sudo $PIP uninstall --yes deepspeed
           sudo $PIP install .[dev,1bit,autotuning,sparse_attn]
           ds_report

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -29,6 +29,7 @@ jobs:
           python --version
           which nvcc
           nvcc --version
+          pip install --upgrade pip
           pip uninstall --yes torch torchvision
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu113
           python -c "import torch; print('torch:', torch.__version__, torch)"

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -19,14 +19,12 @@ jobs:
   unit-tests:
     runs-on: [self-hosted, nvidia, cu113, v100]
 
-    env:
-      PIP: $(which pip)
-
     steps:
       - uses: actions/checkout@v2
 
       - name: environment
         run: |
+          echo "PIP=$(which pip)" >> $GITHUB_ENV
           nvidia-smi
           which python
           python --version

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -22,10 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: set pip
-        run: |
-          echo "PIP=$(which pip)" >> $GITHUB_ENV
-
       - name: environment
         run: |
           nvidia-smi
@@ -33,8 +29,8 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          sudo ${{ env.PIP }} uninstall --yes torch torchvision
-          sudo ${{ env.PIP }} install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu113
+          pip uninstall --yes torch torchvision
+          pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu113
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -45,13 +41,13 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          sudo ${{ env.PIP }} uninstall --yes transformers
-          sudo ${{ env.PIP }} install .
+          pip uninstall --yes transformers
+          pip install .
 
       - name: Install deepspeed
         run: |
-          sudo ${{ env.PIP }} uninstall --yes deepspeed
-          sudo ${{ env.PIP }} install .[dev,1bit,autotuning,sparse_attn]
+          pip uninstall --yes deepspeed
+          pip install .[dev,1bit,autotuning,sparse_attn]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -12,6 +12,9 @@ jobs:
   unit-tests:
     runs-on: [self-hosted, nvidia, cu113, v100]
 
+    env:
+      PIP: $(which pip)
+
     steps:
       - uses: actions/checkout@v2
 
@@ -22,7 +25,8 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          pip install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu113
+          sudo $PIP uninstall --yes torch torchvision
+          sudo $PIP install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cu113
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -33,11 +37,13 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          pip install .
+          sudo $PIP uninstall --yes transformers
+          sudo $PIP install .
 
       - name: Install deepspeed
         run: |
-          pip install .[dev,1bit,autotuning,sparse_attn]
+          sudo $PIP uninstall --yes deepspeed
+          sudo $PIP install .[dev,1bit,autotuning,sparse_attn]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -12,11 +12,12 @@ jobs:
   unit-tests:
     runs-on: [self-hosted, nvidia, cu113, v100]
 
-    env:
-      PIP: $(which pip)
-
     steps:
       - uses: actions/checkout@v2
+
+      - name: set pip
+        run: |
+          echo "PIP=$(which pip)" >> $GITHUB_ENV
 
       - name: environment
         run: |
@@ -25,8 +26,8 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          sudo $PIP uninstall --yes torch torchvision
-          sudo $PIP install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cu113
+          sudo ${{ env.PIP }} uninstall --yes torch torchvision
+          sudo ${{ env.PIP }} install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cu113
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -37,13 +38,13 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          sudo $PIP uninstall --yes transformers
-          sudo $PIP install .
+          sudo ${{ env.PIP }} uninstall --yes transformers
+          sudo ${{ env.PIP }} install .
 
       - name: Install deepspeed
         run: |
-          sudo $PIP uninstall --yes deepspeed
-          sudo $PIP install .[dev,1bit,autotuning,sparse_attn]
+          sudo ${{ env.PIP }} uninstall --yes deepspeed
+          sudo ${{ env.PIP }} install .[dev,1bit,autotuning,sparse_attn]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -22,6 +22,7 @@ jobs:
           python --version
           which nvcc
           nvcc --version
+          pip install --upgrade pip
           pip uninstall --yes torch torchvision
           pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cu113
           python -c "import torch; print('torch:', torch.__version__, torch)"

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -15,10 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: set pip
-        run: |
-          echo "PIP=$(which pip)" >> $GITHUB_ENV
-
       - name: environment
         run: |
           nvidia-smi
@@ -26,8 +22,8 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          sudo ${{ env.PIP }} uninstall --yes torch torchvision
-          sudo ${{ env.PIP }} install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cu113
+          pip uninstall --yes torch torchvision
+          pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cu113
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -38,13 +34,13 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          sudo ${{ env.PIP }} uninstall --yes transformers
-          sudo ${{ env.PIP }} install .
+          pip uninstall --yes transformers
+          pip install .
 
       - name: Install deepspeed
         run: |
-          sudo ${{ env.PIP }} uninstall --yes deepspeed
-          sudo ${{ env.PIP }} install .[dev,1bit,autotuning,sparse_attn]
+          pip uninstall --yes deepspeed
+          pip install .[dev,1bit,autotuning,sparse_attn]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -1,0 +1,49 @@
+name: nv-torch-nightly-v100
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    runs-on: [self-hosted, nvidia, cu113, v100]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: environment
+        run: |
+          nvidia-smi
+          which python
+          python --version
+          which nvcc
+          nvcc --version
+          pip install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu113
+          python -c "import torch; print('torch:', torch.__version__, torch)"
+          python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
+
+      - name: Install transformers
+        run: |
+          git clone https://github.com/huggingface/transformers
+          cd transformers
+          # if needed switch to the last known good SHA until transformers@master is fixed
+          # git checkout 1cc453d33
+          git rev-parse --short HEAD
+          pip install .
+
+      - name: Install deepspeed
+        run: |
+          pip install .[dev,1bit,autotuning,sparse_attn]
+          ds_report
+
+      - name: Unit tests
+        run: |
+          unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch
+          if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
+          cd tests
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -n 4 -m 'not sequential' unit/
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -m 'sequential' unit/

--- a/.github/workflows/nv-torch12-p40.yml
+++ b/.github/workflows/nv-torch12-p40.yml
@@ -34,7 +34,7 @@ jobs:
           which nvcc
           nvcc --version
           sudo ${{ env.PIP }} uninstall --yes torch torchvision
-          sudo ${{ env.PIP }} torch==1.2.0 torchvision==0.4.0
+          sudo ${{ env.PIP }} install torch==1.2.0 torchvision==0.4.0
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-torch12-p40.yml
+++ b/.github/workflows/nv-torch12-p40.yml
@@ -19,11 +19,12 @@ jobs:
   unit-tests:
     runs-on: [self-hosted, nvidia, cu101, p40]
 
-    env:
-      PIP: $(which pip)
-
     steps:
       - uses: actions/checkout@v2
+
+      - name: set pip
+        run: |
+          echo "PIP=$(which pip)" >> $GITHUB_ENV
 
       - name: environment
         run: |
@@ -32,8 +33,8 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          sudo $PIP uninstall --yes torch torchvision
-          sudo $PIP torch==1.2.0 torchvision==0.4.0
+          sudo ${{ env.PIP }} uninstall --yes torch torchvision
+          sudo ${{ env.PIP }} torch==1.2.0 torchvision==0.4.0
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -44,13 +45,13 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          sudo $PIP uninstall --yes transformers
-          sudo $PIP install .
+          sudo ${{ env.PIP }} uninstall --yes transformers
+          sudo ${{ env.PIP }} install .
 
       - name: Install deepspeed
         run: |
-          sudo $PIP uninstall --yes deepspeed
-          sudo $PIP install .[dev,1bit,autotuning,sparse_attn]
+          sudo ${{ env.PIP }} uninstall --yes deepspeed
+          sudo ${{ env.PIP }} install .[dev,1bit,autotuning,sparse_attn]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch12-p40.yml
+++ b/.github/workflows/nv-torch12-p40.yml
@@ -17,7 +17,10 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: [self-hosted, nvidia, torch12, p40]
+    runs-on: [self-hosted, nvidia, cu101, p40]
+
+    env:
+      PIP: $(which pip)
 
     steps:
       - uses: actions/checkout@v2
@@ -29,6 +32,8 @@ jobs:
           python --version
           which nvcc
           nvcc --version
+          sudo $PIP uninstall --yes torch torchvision
+          sudo $PIP torch==1.2.0 torchvision==0.4.0
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -39,11 +44,13 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          pip install .
+          sudo $PIP uninstall --yes transformers
+          sudo $PIP install .
 
       - name: Install deepspeed
         run: |
-          pip install .[dev,autotuning]
+          sudo $PIP uninstall --yes deepspeed
+          sudo $PIP install .[dev,1bit,autotuning,sparse_attn]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch12-p40.yml
+++ b/.github/workflows/nv-torch12-p40.yml
@@ -22,10 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: set pip
-        run: |
-          echo "PIP=$(which pip)" >> $GITHUB_ENV
-
       - name: environment
         run: |
           nvidia-smi
@@ -33,8 +29,8 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          sudo ${{ env.PIP }} uninstall --yes torch torchvision
-          sudo ${{ env.PIP }} install torch==1.2.0 torchvision==0.4.0
+          pip uninstall --yes torch torchvision
+          pip install torch==1.2.0 torchvision==0.4.0
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -45,13 +41,13 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          sudo ${{ env.PIP }} uninstall --yes transformers
-          sudo ${{ env.PIP }} install .
+          pip uninstall --yes transformers
+          pip install .
 
       - name: Install deepspeed
         run: |
-          sudo ${{ env.PIP }} uninstall --yes deepspeed
-          sudo ${{ env.PIP }} install .[dev,1bit,autotuning,sparse_attn]
+          pip uninstall --yes deepspeed
+          pip install .[dev,1bit,autotuning,sparse_attn]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch12-p40.yml
+++ b/.github/workflows/nv-torch12-p40.yml
@@ -29,6 +29,7 @@ jobs:
           python --version
           which nvcc
           nvcc --version
+          pip install --upgrade pip
           pip uninstall --yes torch torchvision
           pip install torch==1.2.0 torchvision==0.4.0
           python -c "import torch; print('torch:', torch.__version__, torch)"

--- a/.github/workflows/nv-torch18-v100.yml
+++ b/.github/workflows/nv-torch18-v100.yml
@@ -17,7 +17,10 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: [self-hosted, nvidia, torch18, v100]
+    runs-on: [self-hosted, nvidia, cu111, v100]
+
+    env:
+      PIP: $(which pip)
 
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +32,8 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+          sudo $PIP uninstall --yes torch torchvision
+          sudo $PIP install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -40,11 +44,13 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          pip install .
+          sudo $PIP uninstall --yes transformers
+          sudo $PIP install .
 
       - name: Install deepspeed
         run: |
-          pip install .[dev,1bit,autotuning,sparse_attn]
+          sudo $PIP uninstall --yes deepspeed
+          sudo $PIP install .[dev,1bit,autotuning,sparse_attn]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch18-v100.yml
+++ b/.github/workflows/nv-torch18-v100.yml
@@ -22,10 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: set pip
-        run: |
-          echo "PIP=$(which pip)" >> $GITHUB_ENV
-
       - name: environment
         run: |
           nvidia-smi
@@ -33,8 +29,8 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          sudo ${{ env.PIP }} uninstall --yes torch torchvision
-          sudo ${{ env.PIP }} install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+          pip uninstall --yes torch torchvision
+          pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -45,13 +41,13 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          sudo ${{ env.PIP }} uninstall --yes transformers
-          sudo ${{ env.PIP }} install .
+          pip uninstall --yes transformers
+          pip install .
 
       - name: Install deepspeed
         run: |
-          sudo ${{ env.PIP }} uninstall --yes deepspeed
-          sudo ${{ env.PIP }} install .[dev,1bit,autotuning,sparse_attn]
+          pip uninstall --yes deepspeed
+          pip install .[dev,1bit,autotuning,sparse_attn]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch18-v100.yml
+++ b/.github/workflows/nv-torch18-v100.yml
@@ -19,11 +19,12 @@ jobs:
   unit-tests:
     runs-on: [self-hosted, nvidia, cu111, v100]
 
-    env:
-      PIP: $(which pip)
-
     steps:
       - uses: actions/checkout@v2
+
+      - name: set pip
+        run: |
+          echo "PIP=$(which pip)" >> $GITHUB_ENV
 
       - name: environment
         run: |
@@ -32,8 +33,8 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          sudo $PIP uninstall --yes torch torchvision
-          sudo $PIP install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+          sudo ${{ env.PIP }} uninstall --yes torch torchvision
+          sudo ${{ env.PIP }} install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -44,13 +45,13 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          sudo $PIP uninstall --yes transformers
-          sudo $PIP install .
+          sudo ${{ env.PIP }} uninstall --yes transformers
+          sudo ${{ env.PIP }} install .
 
       - name: Install deepspeed
         run: |
-          sudo $PIP uninstall --yes deepspeed
-          sudo $PIP install .[dev,1bit,autotuning,sparse_attn]
+          sudo ${{ env.PIP }} uninstall --yes deepspeed
+          sudo ${{ env.PIP }} install .[dev,1bit,autotuning,sparse_attn]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch18-v100.yml
+++ b/.github/workflows/nv-torch18-v100.yml
@@ -29,6 +29,7 @@ jobs:
           python --version
           which nvcc
           nvcc --version
+          pip install --upgrade pip
           pip uninstall --yes torch torchvision
           pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -19,11 +19,12 @@ jobs:
   unit-tests:
     runs-on: [self-hosted, nvidia, cu111, v100]
 
-    env:
-      PIP: $(which pip)
-
     steps:
       - uses: actions/checkout@v2
+
+      - name: set pip
+        run: |
+          echo "PIP=$(which pip)" >> $GITHUB_ENV
 
       - name: environment
         run: |
@@ -32,14 +33,14 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          sudo $PIP uninstall --yes torch torchvision
-          sudo $PIP install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+          sudo ${{ env.PIP }} uninstall --yes torch torchvision
+          sudo ${{ env.PIP }} install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
       - name: Install deepspeed
         run: |
-          sudo $PIP uninstall --yes deepspeed
-          sudo $PIP install .[dev,autotuning]
+          sudo ${{ env.PIP }} uninstall --yes deepspeed
+          sudo ${{ env.PIP }} install .[dev,autotuning]
           ds_report
       - name: HF transformers tests
         run: |
@@ -50,7 +51,7 @@ jobs:
           # git checkout 1cc453d33
           git rev-parse --short HEAD
           # scipy/sklearn required for tests, using the 'dev' extra forces torch re-install
-          sudo $PIP install .[testing]
+          sudo ${{ env.PIP }} install .[testing]
           # find reqs used in ds integration tests
           find examples/pytorch  -regextype posix-egrep -regex '.*(language-modeling|question-answering|summarization|image-classification|text-classification|translation).*/requirements.txt' -exec pip install -r {} \;
           TORCH_EXTENSIONS_DIR=./torch-extensions RUN_SLOW=1 pytest --color=yes --durations=0 --verbose tests/deepspeed

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -17,7 +17,10 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: [self-hosted, nvidia, torch18, v100]
+    runs-on: [self-hosted, nvidia, cu111, v100]
+
+    env:
+      PIP: $(which pip)
 
     steps:
       - uses: actions/checkout@v2
@@ -29,12 +32,14 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+          sudo $PIP uninstall --yes torch torchvision
+          sudo $PIP install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
       - name: Install deepspeed
         run: |
-          pip install .[dev,autotuning]
+          sudo $PIP uninstall --yes deepspeed
+          sudo $PIP install .[dev,autotuning]
           ds_report
       - name: HF transformers tests
         run: |
@@ -45,7 +50,7 @@ jobs:
           # git checkout 1cc453d33
           git rev-parse --short HEAD
           # scipy/sklearn required for tests, using the 'dev' extra forces torch re-install
-          pip install .[testing]
+          sudo $PIP install .[testing]
           # find reqs used in ds integration tests
           find examples/pytorch  -regextype posix-egrep -regex '.*(language-modeling|question-answering|summarization|image-classification|text-classification|translation).*/requirements.txt' -exec pip install -r {} \;
           TORCH_EXTENSIONS_DIR=./torch-extensions RUN_SLOW=1 pytest --color=yes --durations=0 --verbose tests/deepspeed

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -22,10 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: set pip
-        run: |
-          echo "PIP=$(which pip)" >> $GITHUB_ENV
-
       - name: environment
         run: |
           nvidia-smi
@@ -33,14 +29,14 @@ jobs:
           python --version
           which nvcc
           nvcc --version
-          sudo ${{ env.PIP }} uninstall --yes torch torchvision
-          sudo ${{ env.PIP }} install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+          pip uninstall --yes torch torchvision
+          pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
       - name: Install deepspeed
         run: |
-          sudo ${{ env.PIP }} uninstall --yes deepspeed
-          sudo ${{ env.PIP }} install .[dev,autotuning]
+          pip uninstall --yes deepspeed
+          pip install .[dev,autotuning]
           ds_report
       - name: HF transformers tests
         run: |
@@ -51,7 +47,7 @@ jobs:
           # git checkout 1cc453d33
           git rev-parse --short HEAD
           # scipy/sklearn required for tests, using the 'dev' extra forces torch re-install
-          sudo ${{ env.PIP }} install .[testing]
+          pip install .[testing]
           # find reqs used in ds integration tests
           find examples/pytorch  -regextype posix-egrep -regex '.*(language-modeling|question-answering|summarization|image-classification|text-classification|translation).*/requirements.txt' -exec pip install -r {} \;
           TORCH_EXTENSIONS_DIR=./torch-extensions RUN_SLOW=1 pytest --color=yes --durations=0 --verbose tests/deepspeed

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -29,6 +29,7 @@ jobs:
           python --version
           which nvcc
           nvcc --version
+          pip install --upgrade pip
           pip uninstall --yes torch torchvision
           pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"

--- a/setup.py
+++ b/setup.py
@@ -234,7 +234,7 @@ if torch_available and torch.version.cuda is not None:
         nccl_version = ".".join(str(torch.cuda.nccl.version())[:2])
     else:
         nccl_version = ".".join(map(str, torch.cuda.nccl.version()[:2]))
-    if torch.cuda.is_bf16_supported is not None:
+    if hasattr(torch.cuda, 'is_bf16_supported'):
         bf16_support = torch.cuda.is_bf16_supported()
 if torch_available and hasattr(torch.version, 'hip') and torch.version.hip is not None:
     hip_version = ".".join(torch.version.hip.split('.')[:2])

--- a/setup.py
+++ b/setup.py
@@ -234,7 +234,8 @@ if torch_available and torch.version.cuda is not None:
         nccl_version = ".".join(str(torch.cuda.nccl.version())[:2])
     else:
         nccl_version = ".".join(map(str, torch.cuda.nccl.version()[:2]))
-    bf16_support = torch.cuda.is_bf16_supported()
+    if torch.cuda.is_bf16_supported is not None:
+        bf16_support = torch.cuda.is_bf16_supported()
 if torch_available and hasattr(torch.version, 'hip') and torch.version.hip is not None:
     hip_version = ".".join(torch.version.hip.split('.')[:2])
 torch_info = {

--- a/setup.py
+++ b/setup.py
@@ -221,17 +221,23 @@ else:
     version_str += f'+{git_hash}'
 
 torch_version = ".".join([TORCH_MAJOR, TORCH_MINOR])
+bf16_support = False
 # Set cuda_version to 0.0 if cpu-only
 cuda_version = "0.0"
+nccl_version = "0.0"
 # Set hip_version to 0.0 if cpu-only
 hip_version = "0.0"
 if torch_available and torch.version.cuda is not None:
     cuda_version = ".".join(torch.version.cuda.split('.')[:2])
+    nccl_version = ".".join(map(str, torch.cuda.nccl.version()[:2]))
+    bf16_support = torch.cuda.is_bf16_supported()
 if torch_available and hasattr(torch.version, 'hip') and torch.version.hip is not None:
     hip_version = ".".join(torch.version.hip.split('.')[:2])
 torch_info = {
     "version": torch_version,
+    "bf16_support": bf16_support,
     "cuda_version": cuda_version,
+    "nccl_version": nccl_version,
     "hip_version": hip_version
 }
 

--- a/setup.py
+++ b/setup.py
@@ -229,7 +229,11 @@ nccl_version = "0.0"
 hip_version = "0.0"
 if torch_available and torch.version.cuda is not None:
     cuda_version = ".".join(torch.version.cuda.split('.')[:2])
-    nccl_version = ".".join(map(str, torch.cuda.nccl.version()[:2]))
+    if isinstance(torch.cuda.nccl.version(), int):
+        # This will break if minor version > 9
+        nccl_version = ".".join(str(torch.cuda.nccl.version())[:2])
+    else:
+        nccl_version = ".".join(map(str, torch.cuda.nccl.version()[:2]))
     bf16_support = torch.cuda.is_bf16_supported()
 if torch_available and hasattr(torch.version, 'hip') and torch.version.hip is not None:
     hip_version = ".".join(torch.version.hip.split('.')[:2])

--- a/tests/unit/util.py
+++ b/tests/unit/util.py
@@ -13,20 +13,15 @@ def required_torch_version():
 
 
 def bf16_required_version_check():
-    TORCH_MAJOR = int(torch.__version__.split('.')[0])
-    TORCH_MINOR = int(torch.__version__.split('.')[1])
+    split_version = lambda x: map(int, x.split('.')[:2])
+    TORCH_MAJOR, TORCH_MINOR = split_version(torch_info['version'])
+    NCCL_MAJOR, NCCL_MINOR = split_version(torch_info['nccl_version'])
+    CUDA_MAJOR, CUDA_MINOR = split_version(torch_info['cuda_version'])
 
-    if type(torch.cuda.nccl.version()) != tuple:
-        return False
-    else:
-        NCCL_MAJOR = torch.cuda.nccl.version()[0]
-        NCCL_MINOR = torch.cuda.nccl.version()[1]
-
-    CUDA_MAJOR = int(torch_info['cuda_version'].split('.')[0])
     if (TORCH_MAJOR > 1 or
         (TORCH_MAJOR == 1 and TORCH_MINOR >= 10)) and (CUDA_MAJOR >= 11) and (
             NCCL_MAJOR > 2 or
-            (NCCL_MAJOR == 2 and NCCL_MINOR >= 10)) and torch.cuda.is_bf16_supported():
+            (NCCL_MAJOR == 2 and NCCL_MINOR >= 10)) and torch_info['bf16_support']:
         return True
     else:
         return False


### PR DESCRIPTION
This PR adds a new workflow that runs unit tests on the latest stable torch release and the nightly release. The nightly is a scheduled workflow and runs once daily on main DeepSpeed branch.

Also addresses #1987 by extending torch information stored in `deepspeed.git_version_info.torch_info`. This was necessary to avoid initializing CUDA with `torch.cuda.is_bf16_supported()` before a distributed unit test when `bf16_required_version_check()` was used.