### PR TITLE
Propagate max errorcode to deepspeed when using PDSH launcher

### DIFF
--- a/deepspeed/launcher/multinode_runner.py
+++ b/deepspeed/launcher/multinode_runner.py
@@ -66,7 +66,7 @@ class PDSHRunner(MultiNodeRunner):
 
         # PDSH flags for max node fan out and specific hosts to launch on
         # See https://linux.die.net/man/1/pdsh for flag details
-        pdsh_cmd_args = ['pdsh', '-f', str(PDSH_MAX_FAN_OUT), '-w', active_workers]
+        pdsh_cmd_args = ['pdsh', '-S', '-f', str(PDSH_MAX_FAN_OUT), '-w', active_workers]
 
         exports = ""
         for key, val in self.exports.items():


### PR DESCRIPTION
Add '-S' argument to pdsh command to return the largest error code from the ssh sessions