### PR TITLE
Graceful exit on failures for multi-node runs

### DIFF
--- a/deepspeed/launcher/launch.py
+++ b/deepspeed/launcher/launch.py
@@ -177,7 +177,7 @@ def main():
         for process in processes:
             logger.info(f"Killing subprocess {process.pid}")
             try:
-                process.kill()
+                process.terminate()
             except Exception:
                 pass
         if last_return_code is not None:


### PR DESCRIPTION
* Use Popen.terminate() to stop the child processes gracefully

* The Popen.kill() command cause the child training processes to end abruptly. This may cause the child processes to become zombies without communicating properly to the launcher process about the kill signal. So the launcher process continue to wait for signals from child process, causing the ssh command to not return back to the pdsh command

Fixes microsoft#1995