### PR TITLE
Fix for AMD unit tests

### DIFF
--- a/.github/workflows/amd.yml
+++ b/.github/workflows/amd.yml
@@ -54,7 +54,7 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Install deepspeed
         run: |
-          sudo /opt/conda/bin/pip install .[dev,1bit,autotuning]
+          pip install .[dev,1bit,autotuning]
           #python -c "from deepspeed.env_report import cli_main; cli_main()"
           ds_report
 

--- a/deepspeed/ops/adam/cpu_adam.py
+++ b/deepspeed/ops/adam/cpu_adam.py
@@ -5,6 +5,7 @@ Copyright 2020 The Microsoft DeepSpeed Team
 import math
 import torch
 import time
+from cpuinfo import get_cpu_info
 from pathlib import Path
 from ..op_builder import CPUAdamBuilder
 from deepspeed.utils.logging import should_log_le

--- a/tests/unit/test_cpu_adam.py
+++ b/tests/unit/test_cpu_adam.py
@@ -88,3 +88,13 @@ def test_cpu_adam_gpu_error():
     param.grad = torch.randn(model_size, device=device)
     with pytest.raises(AssertionError):
         optimizer.step()
+
+
+def test_cpu_adam_fp16_amd_error():
+    model_size = 64
+    from deepspeed.ops.adam import DeepSpeedCPUAdam
+    device = 'cpu'
+    param = torch.nn.Parameter(torch.randn(model_size, device=device).to(torch.half))
+
+    with pytest.raises(Assertion_error):
+        optimizer = DeepSpeedCPUAdam([param])

--- a/tests/unit/test_cpu_adam.py
+++ b/tests/unit/test_cpu_adam.py
@@ -88,13 +88,3 @@ def test_cpu_adam_gpu_error():
     param.grad = torch.randn(model_size, device=device)
     with pytest.raises(AssertionError):
         optimizer.step()
-
-
-def test_cpu_adam_fp16_amd_error():
-    model_size = 64
-    from deepspeed.ops.adam import DeepSpeedCPUAdam
-    device = 'cpu'
-    param = torch.nn.Parameter(torch.randn(model_size, device=device).to(torch.half))
-
-    with pytest.raises(Assertion_error):
-        optimizer = DeepSpeedCPUAdam([param])


### PR DESCRIPTION
- Add asserts to prevent FP16 with CPUAdam on AMD CPUs (not supported)
- AMD runners now use a venv, removed sudo from pip install
- Add skips to unit tests for CPUAdam