### PR TITLE
Fix building package without a GPU

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -235,7 +235,7 @@ if torch_available and torch.version.cuda is not None:
         nccl_version = ".".join(str(torch.cuda.nccl.version())[:2])
     else:
         nccl_version = ".".join(map(str, torch.cuda.nccl.version()[:2]))
-    if hasattr(torch.cuda, 'is_bf16_supported'):
+    if hasattr(torch.cuda, 'is_bf16_supported') and torch.cuda.is_available():
         bf16_support = torch.cuda.is_bf16_supported()
 if torch_available and hasattr(torch.version, 'hip') and torch.version.hip is not None:
     hip_version = ".".join(torch.version.hip.split('.')[:2])


### PR DESCRIPTION
Fixes #2010.

The first commit is the minimal change needed to get DeepSpeed installed. The second commit that fully removes `bf16_support` from `torch_info`. If the second commit goes too far, it can be dropped before this PR is merged. I have tested both and confirmed that they both allow me to install DeepSpeed. See <https://github.com/microsoft/DeepSpeed/issues/2010#issuecomment-1165869012> for more information about my approach.