### PR TITLE
Fix missing import in replace_module.py

### DIFF
--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -7,6 +7,7 @@ from .replace_policy import replace_policies
 from ..constants import INFERENCE_GENERIC_MODE, INFERENCE_SPECIALIZED_MODE
 from ..runtime.weight_quantizer import WeightQuantization
 from torch import nn
+from torch import distributed as dist
 
 
 class LinearAllreduce(nn.Module):


### PR DESCRIPTION
The lack of this import is causing inference initialization to fail for me. It seems like it should have been added in 36ad3119d5420c6b25b456626a40f4ded8c05a81 when `dist` was introduced to `replace_module.py`, but it appears to have been missed. This fix also appears to have been included in the in-progress PR #2028, but I was hoping this problem could get fixed on `master` sooner than the time it will take for that more complex PR to be merged.