### PR TITLE
Wrong partition_id while copying fp32_params -> fp16 params in Z2 for MoE

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1762,7 +1762,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 for group in self.single_partition_of_fp32_groups:
                     group.grad = None  # in step
 
-            for bit16_partitions, fp32_partition in zip(self.parallel_partitioned_bit16_groups, self.single_partition_of_fp32_groups):
+            for group_id, (bit16_partitions, fp32_partition) in enumerate(zip(self.parallel_partitioned_bit16_groups, self.single_partition_of_fp32_groups)):
+                partition_id = dist.get_rank(group=self.real_dp_process_group[group_id])
                 bit16_partitions[partition_id].data.copy_(fp32_partition.data)
 
         self.stop_timers([OPTIMIZER_STEP])


### PR DESCRIPTION
Post the optimizer step, Z2 uses incorrect partition ids for copying updated fp-32 params to their fp-16 counterparts. This leads to only a fraction of the non-expert parameters being trained. For reference, I have the loss curves before and after the bug fix.

Base Model - 1.3B
Number of Experts - 8
Batch Size - 256
Machine - Azure A100 40GB
Number of GPUs - 8
Dataset - BookCorpus

![image](https://user-images.githubusercontent.com/16764680/176037985-eb93949e-adc4-4a2f-bd50-ad7e9ae2aa4a.png)

