### PR TITLE
Fix partition id in the fp32->fp16 param copying step for z2+cpu-offload

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1747,12 +1747,13 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             from deepspeed.ops.adam import DeepSpeedCPUAdam
             if type(self.optimizer) == DeepSpeedCPUAdam and self.dtype == torch.half:
                 bit16_param_groups = [[
-                    bit16_partitions[partition_id]
-                ] for bit16_partitions in self.parallel_partitioned_bit16_groups]
+                    bit16_partitions[dist.get_rank(group=self.real_dp_process_group[group_id])]
+                ] for group_id, bit16_partitions in enumerate(self.parallel_partitioned_bit16_groups)]
                 self.optimizer.step(fp16_param_groups=bit16_param_groups)
             else:
                 self.optimizer.step()
                 for bit16_partitions, fp32_partition in zip(self.parallel_partitioned_bit16_groups, self.single_partition_of_fp32_groups):
+                    partition_id = dist.get_rank(group=self.real_dp_process_group[group_id])
                     bit16_partitions[partition_id].data.copy_(fp32_partition.data)
         else:
             self.optimizer.step()


### PR DESCRIPTION
This is the same fix as this [PR](https://github.com/microsoft/DeepSpeed/pull/2058) for cpu-offloading. Here's the corresponding PR in the Megatron-Deepspeed repo that adds cpu-offloading support -  [link](https://github.com/microsoft/Megatron-DeepSpeed/pull/55) 

Here is the loss curve after the fix compared with zero-stage 0 for the following setting - 

Base Model - 1.3B
Number of Experts - 8
Batch Size - 256
Machine - Azure A100 40GB
Number of GPUs - 8
Dataset - BookCorpus

![image](https://user-images.githubusercontent.com/16764680/176053692-1d0e9c52-a6f2-40eb-9da9-373a7e612071.png)
