### PR TITLE
remove require grad in params count

### DIFF
--- a/deepspeed/profiling/flops_profiler/profiler.py
+++ b/deepspeed/profiling/flops_profiler/profiler.py
@@ -148,8 +148,7 @@ class FlopsProfiler(object):
         def add_or_reset_attrs(module):
             module.__flops__ = 0
             module.__macs__ = 0
-            module.__params__ = sum(p.numel() for p in module.parameters()
-                                    if p.requires_grad)
+            module.__params__ = sum(p.numel() for p in module.parameters())
             module.__start_time__ = 0
             module.__duration__ = 0
 
@@ -339,7 +338,7 @@ class FlopsProfiler(object):
             macs = get_module_macs(module)
             items = [
                 params_to_string(params),
-                "{:.2%} Params".format(params / total_params),
+                "{:.2%} Params".format(params / total_params if total_params else 0),
                 macs_to_string(macs),
                 "{:.2%} MACs".format(0.0 if total_macs == 0 else macs / total_macs),
             ]


### PR DESCRIPTION
This PR removes the require_grad check when counting the nubmer of parameters, which is often preferred.