### PR TITLE
[docs] fix broken read-the-docs build

### DIFF
--- a/docs/code-docs/source/conf.py
+++ b/docs/code-docs/source/conf.py
@@ -20,7 +20,7 @@ copyright = '2020, Microsoft'
 author = 'Microsoft'
 
 # The full version, including alpha/beta/rc tags
-release = '0.3.0'
+release = '0.6'
 
 master_doc = 'index'
 

--- a/docs/code-docs/source/index.rst
+++ b/docs/code-docs/source/index.rst
@@ -1,102 +1,12 @@
 DeepSpeed
 =========
 
-Model Setup
------------
-
-.. toctree::
-   :maxdepth: 2
-
-   initialize
-   inference-init
-
-Training API
-------------
-
-.. toctree::
-   :maxdepth: 2
-
-   training
-
-Inference API
-------------
-
-.. toctree::
-   :maxdepth: 2
-
-   inference-engine
-
-Checkpointing API
------------------
-.. toctree::
-   :maxdepth: 2
-
-   model-checkpointing
-   activation-checkpointing
-
-
 ZeRO API
 --------
 .. toctree::
    :maxdepth: 2
 
    zero3
-
-Mixture of Experts (MoE)
-------------------------
-.. toctree::
-   :maxdepth: 2
-
-   moe
-
-Transformer Kernel API
-----------------------
-.. toctree::
-   :maxdepth: 2
-
-   kernel
-
-Pipeline Parallelism
---------------------
-.. toctree::
-   :maxdepth: 2
-
-   pipeline
-
-Optimizers
---------------------
-.. toctree::
-   :maxdepth: 2
-
-   optimizers
-
-Learning Rate Schedulers
---------------------
-.. toctree::
-   :maxdepth: 2
-
-   schedulers
-
-Flops Profiler
---------------------
-.. toctree::
-   :maxdepth: 2
-
-   flops-profiler
-
-Autotuning
---------------------
-.. toctree::
-   :maxdepth: 2
-
-   autotuning
-
-Memory Usage
-------------------
-.. toctree::
-   :maxdepth: 2
-
-   memory
 
 Indices and tables
 ------------------

--- a/docs/code-docs/source/index.rst
+++ b/docs/code-docs/source/index.rst
@@ -1,12 +1,102 @@
 DeepSpeed
 =========
 
+Model Setup
+-----------
+
+.. toctree::
+   :maxdepth: 2
+
+   initialize
+   inference-init
+
+Training API
+------------
+
+.. toctree::
+   :maxdepth: 2
+
+   training
+
+Inference API
+------------
+
+.. toctree::
+   :maxdepth: 2
+
+   inference-engine
+
+Checkpointing API
+-----------------
+.. toctree::
+   :maxdepth: 2
+
+   model-checkpointing
+   activation-checkpointing
+
+
 ZeRO API
 --------
 .. toctree::
    :maxdepth: 2
 
    zero3
+
+Mixture of Experts (MoE)
+------------------------
+.. toctree::
+   :maxdepth: 2
+
+   moe
+
+Transformer Kernel API
+----------------------
+.. toctree::
+   :maxdepth: 2
+
+   kernel
+
+Pipeline Parallelism
+--------------------
+.. toctree::
+   :maxdepth: 2
+
+   pipeline
+
+Optimizers
+--------------------
+.. toctree::
+   :maxdepth: 2
+
+   optimizers
+
+Learning Rate Schedulers
+--------------------
+.. toctree::
+   :maxdepth: 2
+
+   schedulers
+
+Flops Profiler
+--------------------
+.. toctree::
+   :maxdepth: 2
+
+   flops-profiler
+
+Autotuning
+--------------------
+.. toctree::
+   :maxdepth: 2
+
+   autotuning
+
+Memory Usage
+------------------
+.. toctree::
+   :maxdepth: 2
+
+   memory
 
 Indices and tables
 ------------------

--- a/docs/code-docs/source/memory.rst
+++ b/docs/code-docs/source/memory.rst
@@ -7,9 +7,9 @@ API To Estimate Memory Usage
 
 ZeRO2:
 
-.. autofunction:: deepspeed.runtime.zero.stage2.estimate_zero2_model_states_mem_needs_all_live
+.. autofunction:: deepspeed.runtime.zero.stage_1_and_2.estimate_zero2_model_states_mem_needs_all_live
 
-.. autofunction:: deepspeed.runtime.zero.stage2.estimate_zero2_model_states_mem_needs_all_cold
+.. autofunction:: deepspeed.runtime.zero.stage_1_and_2.estimate_zero2_model_states_mem_needs_all_cold
 
 Examples:
 
@@ -18,7 +18,7 @@ Let's try a 3B model with just 1 node with 8 gpus, using live model:
 .. code-block:: bash
 
     python -c 'from transformers import AutoModel; \
-    from deepspeed.runtime.zero.stage2 import estimate_zero2_model_states_mem_needs_all_live; \
+    from deepspeed.runtime.zero.stage_1_and_2 import estimate_zero2_model_states_mem_needs_all_live; \
     model = AutoModel.from_pretrained("t5-3b"); \
     estimate_zero2_model_states_mem_needs_all_live(model, num_gpus_per_node=8, num_nodes=1)'
     Estimated memory needed for params, optim states and gradients for a:
@@ -34,7 +34,7 @@ faster as we don't need to load the model.
 
 .. code-block:: bash
 
-    python -c 'from deepspeed.runtime.zero.stage2 import estimate_zero2_model_states_mem_needs_all_cold; \
+    python -c 'from deepspeed.runtime.zero.stage_1_and_2 import estimate_zero2_model_states_mem_needs_all_cold; \
     estimate_zero2_model_states_mem_needs_all_cold(total_params=2851e6, num_gpus_per_node=8, num_nodes=1)'
     Estimated memory needed for params, optim states and gradients for a:
     HW: Setup with 1 node, 8 GPUs per node.

--- a/requirements/requirements-readthedocs.txt
+++ b/requirements/requirements-readthedocs.txt
@@ -1,8 +1,8 @@
 docutils<0.18
 hjson
+packaging
 psutil
+py-cpuinfo
+pydantic
 torch
 tqdm
-py-cpuinfo
-packaging
-pydantic

--- a/requirements/requirements-readthedocs.txt
+++ b/requirements/requirements-readthedocs.txt
@@ -3,3 +3,4 @@ hjson
 psutil
 torch
 tqdm
+py-cpuinfo

--- a/requirements/requirements-readthedocs.txt
+++ b/requirements/requirements-readthedocs.txt
@@ -4,3 +4,5 @@ psutil
 torch
 tqdm
 py-cpuinfo
+packaging
+pydantic


### PR DESCRIPTION
Our ZeRO-3 APIs were not being rendered properly on the RTD page, these changes fix that. In near future we'll be moving ds-config docs to RTD and will also add proper CI checks for RTD build failures then.