### PR TITLE
Improving memory utilization of Z2+MoE

### DIFF
--- a/deepspeed/moe/utils.py
+++ b/deepspeed/moe/utils.py
@@ -59,8 +59,9 @@ def split_params_grads_into_shared_and_expert_params(
     return shared_grads, expert_grads
 
 
-def split_params_into_different_moe_groups_for_optimizer(
-        param_groups: Tuple[Dict], max_group_size=178956971) -> Tuple[Dict]:
+def split_params_into_different_moe_groups_for_optimizer(param_groups: Tuple[Dict],
+                                                         max_group_size=178956971
+                                                         ) -> Tuple[Dict]:
     """Split parameters into different MoE groups for optimizer
 
     Args:

--- a/deepspeed/moe/utils.py
+++ b/deepspeed/moe/utils.py
@@ -124,14 +124,11 @@ def split_params_into_different_moe_groups_for_optimizer(param_groups: Tuple[Dic
                         cur_group.append(param)
                         size_of_cur_group += param.numel()
                     else:
-                        print(f'1. Size of current group = {size_of_cur_group/1e9} B')
                         all_groups.append(cur_group)
                         cur_group = [param]
                         size_of_cur_group = param.numel()
                 if cur_group:
                     all_groups.append(cur_group)
-                    print(f'2. Size of current group = {size_of_cur_group/1e9} B')
-                #print(f'Size of MoE group is = {size_of_moe_group/1e9} B')
                 for group in all_groups:
                     new_dict = {}
                     for key, val in v1.items():

--- a/deepspeed/moe/utils.py
+++ b/deepspeed/moe/utils.py
@@ -60,7 +60,7 @@ def split_params_grads_into_shared_and_expert_params(
 
 
 def split_params_into_different_moe_groups_for_optimizer(
-        param_groups: Tuple[Dict]) -> Tuple[Dict]:
+        param_groups: Tuple[Dict], max_group_size=178956971) -> Tuple[Dict]:
     """Split parameters into different MoE groups for optimizer
 
     Args:
@@ -112,8 +112,35 @@ def split_params_into_different_moe_groups_for_optimizer(
         param_group['params'] = new_params
 
     # Flatten the moe groups
-    for k, v in group_moe.items():
-        for k1, v1 in v.items():
-            param_groups.append(v1)
+    if max_group_size is not None:
+        for k, v in group_moe.items():
+            for k1, v1 in v.items():
+                cur_group = []
+                all_groups = []
+                size_of_cur_group = 0
+                for param in v1['params']:
+                    if size_of_cur_group + param.numel() <= max_group_size:
+                        cur_group.append(param)
+                        size_of_cur_group += param.numel()
+                    else:
+                        print(f'1. Size of current group = {size_of_cur_group/1e9} B')
+                        all_groups.append(cur_group)
+                        cur_group = [param]
+                        size_of_cur_group = param.numel()
+                if cur_group:
+                    all_groups.append(cur_group)
+                    print(f'2. Size of current group = {size_of_cur_group/1e9} B')
+                #print(f'Size of MoE group is = {size_of_moe_group/1e9} B')
+                for group in all_groups:
+                    new_dict = {}
+                    for key, val in v1.items():
+                        if key != 'params':
+                            new_dict[key] = val
+                    new_dict['params'] = group
+                    param_groups.append(new_dict)
+    else:
+        for k, v in group_moe.items():
+            for k1, v1 in v.items():
+                param_groups.append(v1)
 
     return tuple(param_groups)

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1731,7 +1731,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 self.start_timers([OPTIMIZER_STEP])
                 from deepspeed.ops.adam import DeepSpeedCPUAdam
                 if type(self.optimizer) == DeepSpeedCPUAdam and self.dtype == torch.half:
-                    self.optimizer.step(self.get_bit16_param_groups())
+                    self.optimizer.step(fp16_param_groups=self.get_bit16_param_groups())
                 else:
                     self.optimizer.step()
                     bit16_partitions = self.parallel_partitioned_bit16_groups[i]

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1756,9 +1756,6 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
                 self.stop_timers([OPTIMIZER_STEP])
             else:
-                if dist.get_rank() == 0:
-                    logger.info(f'Upscaling group {i}')
-
                 # free gradients for all the parameters that are not updated by this process(ZeRO stage2)
                 self.free_grad_in_param_list(self.params_not_in_partition[i])
 
@@ -1786,8 +1783,6 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 self.unscale_and_clip_grads([single_grad_partition],
                                             scaled_global_grad_norm)
                 self.stop_timers([OPTIMIZER_GRADIENTS])
-                if dist.get_rank() == 0:
-                    logger.info(f'Running optimizer on group {i}')
 
                 # Step 3:- run the optimizer if no offloading
                 self.start_timers([OPTIMIZER_STEP])

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -346,9 +346,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 assert (partitioned_data.data_ptr() %
                         (2 * self.nccl_start_alignment_factor) == 0)
 
-            # A partition of the fp32 master weights that will be updated by this process.
-            # Note that the params in single_partition_of_fp32_groups is cloned and detached
-            # from the origin params of the model.
+            # a partition of the fp32 master weights that will be updated by this process
             if not fp16_master_weights_and_gradients:
                 self.single_partition_of_fp32_groups.append(
                     self.parallel_partitioned_bit16_groups[i][partition_id].to(
@@ -358,9 +356,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     self.parallel_partitioned_bit16_groups[i][partition_id].to(
                         self.device).clone().half().detach())
 
-            # Set local optimizer to have flat params of its own partition.
-            # After this, the local optimizer will only contain its own partition of params.
-            # In that case, the local optimizer only saves the states(momentum, variance, etc.) related to its partition's params(zero stage1).
+            # modify optimizer of have flat master weight
             self.single_partition_of_fp32_groups[
                 i].requires_grad = True  # keep this in case internal optimizer uses it
             param_group['params'] = [self.single_partition_of_fp32_groups[i]]
@@ -1430,7 +1426,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         partitions = []
 
         dp = dist.get_world_size(group=self.real_dp_process_group[group_id])
-        # dp_id = dist.get_rank(group=self.real_dp_process_group[group_id])
+        dp_id = dist.get_rank(group=self.real_dp_process_group[group_id])
 
         total_num_elements = tensor.numel()
 
@@ -1653,6 +1649,32 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.custom_loss_scaler = True
         self.external_loss_scale = loss_scale
 
+    def scaled_global_norm(self, norm_type=2):
+        assert norm_type == 2, "only L2 norm supported"
+        norm_groups = []
+        for i, group in enumerate(self.bit16_groups):
+            partition_id = dist.get_rank(group=self.real_dp_process_group[i])
+            if self.cpu_offload:
+                norm_groups.append(
+                    self.complete_grad_norm_calculation_for_cpu_offload(
+                        self.params_in_partition[i]))
+                single_grad_partition = self.single_partition_of_fp32_groups[i].grad
+            else:
+                norm_groups.append(
+                    self.get_grad_norm_direct(self.averaged_gradients[i],
+                                              self.params_in_partition[i]))
+
+        if self.has_moe_layers:
+            self._average_expert_grad_norms(norm_groups)
+
+        # note that the get_global_norm function only supports l2 norm
+        return get_global_norm(norm_list=norm_groups)
+
+    def get_bit16_param_groups(self):
+        return [[
+                   bit16_partitions[dist.get_rank(group=self.real_dp_process_group[i])]
+                ] for i, bit16_partitions in enumerate(self.parallel_partitioned_bit16_groups)]
+
     def step(self, closure=None):
         """
         Not supporting closure.
@@ -1671,7 +1693,6 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         prev_scale = self.loss_scale
         self._update_scale(self.overflow)
         if self.overflow:
-
             if dist.get_rank() == 0:
                 logger.info(
                     "[deepspeed] OVERFLOW! Rank {} Skipping step. Attempted loss scale: {}, "
@@ -1692,23 +1713,33 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             self.stop_timers(timer_names)
             return
 
-        self.start_timers([OPTIMIZER_GRADIENTS])
-        norm_groups = []
-        single_partition_grad_groups = []
-        # skip = False
+        # Step 1:- Calculate gradient norm using fp-16 grads
+        see_memory_usage('Before norm calculation')
+        scaled_global_grad_norm = self.scaled_global_norm()
+        self._global_grad_norm = scaled_global_grad_norm / self.loss_scale
+
+        see_memory_usage('After norm before optimizer')
+        # Step 2:- run optimizer and upscaling simultaneously
         for i, group in enumerate(self.bit16_groups):
+            self.start_timers([OPTIMIZER_GRADIENTS])
             partition_id = dist.get_rank(group=self.real_dp_process_group[i])
             if self.cpu_offload:
-                norm_groups.append(
-                    self.complete_grad_norm_calculation_for_cpu_offload(
-                        self.params_in_partition[i]))
                 single_grad_partition = self.single_partition_of_fp32_groups[i].grad
+                self.unscale_and_clip_grads([single_grad_partition], scaled_global_grad_norm)
+                self.stop_timers([OPTIMIZER_GRADIENTS])
+                from deepspeed.ops.adam import DeepSpeedCPUAdam
+                if type(self.optimizer) == DeepSpeedCPUAdam and self.dtype == torch.half:
+                    self.optimizer.step(self.get_bit16_param_groups())
+                else:
+                    self.optimizer.step()
+                    bit16_partitions = self.parallel_partitioned_bit16_groups[i]
+                    fp32_partition = self.single_partition_of_fp32_groups[i]
+                    bit16_partitions[partition_id].data.copy_(fp32_partition.data)
             else:
-                norm_groups.append(
-                    self.get_grad_norm_direct(self.averaged_gradients[i],
-                                              self.params_in_partition[i]))
+                if dist.get_rank() == 0:
+                    logger.info(f'Upscaling group {i}')
 
-                # free gradients for all the parameters that are not updated by this process(ZeRO stage2)
+                # free gradients for all the parameters that are not updated by this process
                 self.free_grad_in_param_list(self.params_not_in_partition[i])
 
                 # create a flat gradients for parameters updated by this process
@@ -1727,58 +1758,35 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                         single_grad_partition.numel(), self.partition_size[i], i, partition_id)
 
                 self.single_partition_of_fp32_groups[i].grad = single_grad_partition
-                # release all the gradient since we have already created a necessary copy in dp_grad_partition(ZeRO stage2)
+                # release all the gradient since we have already created a necessary copy in dp_grad_partition
                 self.free_grad_in_param_list(self.params_in_partition[i])
 
                 self.averaged_gradients[i] = None
 
-            single_partition_grad_groups.append(single_grad_partition)
+                self.unscale_and_clip_grads([single_grad_partition], scaled_global_grad_norm)
+                self.stop_timers([OPTIMIZER_GRADIENTS])
+                if dist.get_rank() == 0:
+                    logger.info(f'Running optimizer on group {i}')
 
-        if self.has_moe_layers:
-            self._average_expert_grad_norms(norm_groups)
-
-        scaled_global_grad_norm = get_global_norm(norm_list=norm_groups)
-        self.unscale_and_clip_grads(single_partition_grad_groups,
-                                    scaled_global_grad_norm)
-
-        # Stash unscaled gradient norm
-        self._global_grad_norm = scaled_global_grad_norm / self.loss_scale
-
-        self.stop_timers([OPTIMIZER_GRADIENTS])
-
-        self.start_timers([OPTIMIZER_STEP])
-        if self.deepspeed_adam_offload:
-            from deepspeed.ops.adam import DeepSpeedCPUAdam
-            if type(self.optimizer) == DeepSpeedCPUAdam and self.dtype == torch.half:
-                bit16_param_groups = [[
-                    bit16_partitions[partition_id]
-                ] for bit16_partitions in self.parallel_partitioned_bit16_groups]
-                self.optimizer.step(fp16_param_groups=bit16_param_groups)
-            else:
+                # Step 3:- run the optimizer if no offloading
+                self.start_timers([OPTIMIZER_STEP])
+                
                 self.optimizer.step()
-                # after step(), single_partition_of_fp32_groups has the local optimizer's own partition of updated params
-                for bit16_partitions, fp32_partition in zip(self.parallel_partitioned_bit16_groups, self.single_partition_of_fp32_groups):
-                    bit16_partitions[partition_id].data.copy_(fp32_partition.data)
-        else:
-            self.optimizer.step()
+                # Step 4:- get rid of the fp32 gradients. Not needed anymore    
+                self.single_partition_of_fp32_groups[i].grad = None
+                del single_grad_partition
+                self.stop_timers([OPTIMIZER_STEP])
 
-            # get rid of the fp32 gradients. Not needed anymore
-            if not self.cpu_offload:
-                for group in self.single_partition_of_fp32_groups:
-                    group.grad = None  # in step
-
-            for group_id, (bit16_partitions, fp32_partition) in enumerate(zip(self.parallel_partitioned_bit16_groups, self.single_partition_of_fp32_groups)):
-                partition_id = dist.get_rank(group=self.real_dp_process_group[group_id])
+                bit16_partitions = self.parallel_partitioned_bit16_groups[i]
+                fp32_partition = self.single_partition_of_fp32_groups[i]
                 bit16_partitions[partition_id].data.copy_(fp32_partition.data)
 
-        self.stop_timers([OPTIMIZER_STEP])
-
+        see_memory_usage('After optimizer before all-gather')
         if self.cpu_offload:
             self.reset_cpu_buffers()
 
         self.start_timers([OPTIMIZER_ALLGATHER])
-        # Gather the updated weights from everyone.
-        # Then all partitions of the model parameters are updated and ready for next round forward.
+        # gather the updated weights from everyone
         all_gather_dp_groups(
             partitioned_param_groups=self.parallel_partitioned_bit16_groups,
             dp_process_group=self.real_dp_process_group,
@@ -1788,7 +1796,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.stop_timers([OPTIMIZER_ALLGATHER])
 
         # TODO: we probably don't need this? just to be safe
-        for i in range(len(norm_groups)):
+        for i in range(len(self.bit16_groups)):
             self._update_model_bit16_weights(i)
 
         self.log_timers(timer_names)

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1750,7 +1750,6 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     fp32_partition = self.single_partition_of_fp32_groups[i]
                     bit16_partitions[partition_id].data.copy_(fp32_partition.data)
 
-                self.single_partition_of_fp32_groups[i].grad = None
                 self.stop_timers([OPTIMIZER_STEP])
             else:
                 if dist.get_rank() == 0:

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -346,7 +346,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 assert (partitioned_data.data_ptr() %
                         (2 * self.nccl_start_alignment_factor) == 0)
 
-            # a partition of the fp32 master weights that will be updated by this process
+            # A partition of the fp32 master weights that will be updated by this process.
+            # Note that the params in single_partition_of_fp32_groups is cloned and detached
+            # from the origin params of the model.
             if not fp16_master_weights_and_gradients:
                 self.single_partition_of_fp32_groups.append(
                     self.parallel_partitioned_bit16_groups[i][partition_id].to(
@@ -356,7 +358,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     self.parallel_partitioned_bit16_groups[i][partition_id].to(
                         self.device).clone().half().detach())
 
-            # modify optimizer of have flat master weight
+            # Set local optimizer to have flat params of its own partition.
+            # After this, the local optimizer will only contain its own partition of params.
+            # In that case, the local optimizer only saves the states(momentum, variance, etc.) related to its partition's params(zero stage1).
             self.single_partition_of_fp32_groups[
                 i].requires_grad = True  # keep this in case internal optimizer uses it
             param_group['params'] = [self.single_partition_of_fp32_groups[i]]
@@ -1426,7 +1430,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         partitions = []
 
         dp = dist.get_world_size(group=self.real_dp_process_group[group_id])
-        dp_id = dist.get_rank(group=self.real_dp_process_group[group_id])
+        # dp_id = dist.get_rank(group=self.real_dp_process_group[group_id])
 
         total_num_elements = tensor.numel()
 
@@ -1755,7 +1759,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 if dist.get_rank() == 0:
                     logger.info(f'Upscaling group {i}')
 
-                # free gradients for all the parameters that are not updated by this process
+                # free gradients for all the parameters that are not updated by this process(ZeRO stage2)
                 self.free_grad_in_param_list(self.params_not_in_partition[i])
 
                 # create a flat gradients for parameters updated by this process
@@ -1774,7 +1778,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                         single_grad_partition.numel(), self.partition_size[i], i, partition_id)
 
                 self.single_partition_of_fp32_groups[i].grad = single_grad_partition
-                # release all the gradient since we have already created a necessary copy in dp_grad_partition
+                # release all the gradient since we have already created a necessary copy in dp_grad_partition(ZeRO stage2)
                 self.free_grad_in_param_list(self.params_in_partition[i])
 
                 self.averaged_gradients[i] = None
@@ -1801,7 +1805,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             self.reset_cpu_buffers()
 
         self.start_timers([OPTIMIZER_ALLGATHER])
-        # gather the updated weights from everyone
+        # Gather the updated weights from everyone.
+        # Then all partitions of the model parameters are updated and ready for next round forward.
         all_gather_dp_groups(
             partitioned_param_groups=self.parallel_partitioned_bit16_groups,
             dp_process_group=self.real_dp_process_group,

--- a/setup.py
+++ b/setup.py
@@ -235,7 +235,7 @@ if torch_available and torch.version.cuda is not None:
         nccl_version = ".".join(str(torch.cuda.nccl.version())[:2])
     else:
         nccl_version = ".".join(map(str, torch.cuda.nccl.version()[:2]))
-    if hasattr(torch.cuda, 'is_bf16_supported'):
+    if hasattr(torch.cuda, 'is_bf16_supported') and torch.cuda.is_available():
         bf16_support = torch.cuda.is_bf16_supported()
 if torch_available and hasattr(torch.version, 'hip') and torch.version.hip is not None:
     hip_version = ".".join(torch.version.hip.split('.')[:2])


### PR DESCRIPTION
## Summary

While running experiments, I found that an inordinate amount of memory is used in the gradient upscaling step for high expert to GPU ratios (like 1 or 1/2). 

This PR does two things:
- It creates an upper limit on the expert parameter group size (see `deepspeed/moe/utils.py`).
- Instead of first upscaling all the gradients and running the optimizer once, this PR makes it such that a combined upscaling+optimizer step is executed on each parameter group one by one. Thus at a given time only fp32 gradients of 1 parameter group can exist in GPU memory. (see `deepspeed/runtime/zero/stage_1_and_2.py`)

## Highlight Result
Prior to this PR a **6.7B base model with 16 experts ran OOM on 32 A100 GPUs (40GB)**. 
With the changes, I am able to run the same model with a peak memory utilization of 31.3 GB. Thus at the bare minimum we are **saving 21.75% memory** for this model.

Train loss curve for reference
![image](https://user-images.githubusercontent.com/16764680/177897087-17173810-bc11-417c-9d85-c0d568ebd81f.png)



## Sanity Checks
Train loss curves before and after the changes match

![image](https://user-images.githubusercontent.com/16764680/177894013-deb369f7-91b4-4116-8176-b150756be1ee.png)

![image](https://user-images.githubusercontent.com/16764680/177894058-a9b9f33b-372d-405c-9f40-2ba2b455d89a.png)


## Batch Times
To create the most pathological case, I set global batch size to 8. Yet, there is no penalty in batch times.

![image](https://user-images.githubusercontent.com/16764680/177894131-eca32df9-e6bb-4d38-ad0e-4e08a2a44806.png)

## Memory Consumption
The memory saved is expected to increase with increasing model sizes.
![image](https://user-images.githubusercontent.com/16764680/177894199-7255e4b1-cace-43fe-86c1-f777a80490a8.png)














