### PR TITLE
fixed "None type has no len()"

### DIFF
--- a/deepspeed/utils/timer.py
+++ b/deepspeed/utils/timer.py
@@ -88,6 +88,7 @@ class SynchronizedWallClockTimer:
             return elapsed_
 
         def mean(self):
+            self.elapsed(reset=False)
             return trim_mean(self.elapsed_records, 0.1)
 
     def __init__(self):


### PR DESCRIPTION
When using autotunning to calculate throughput with `transformer < 4.16.2`, It breaks with `None type has no len()`.

It seems `elapsed_records` is still `None` when being called at the first run.

This modification helps to save elapsed to `self.elapsed_records`, so that it won't throw an exception.