### PR TITLE
[ds-inference] checkpoint loading => tqdm

### DIFF
--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -1,5 +1,6 @@
 import copy
 import torch
+import tqdm
 import deepspeed
 import deepspeed.ops.transformer as transformer_inference
 from .replace_policy import HFBertLayerPolicy, HFGPT2LayerPolicy, HFGPTJLayerPolicy, BLOOMLayerPolicy
@@ -765,9 +766,7 @@ def replace_transformer_layer(orig_layer_impl,
                                      _replace_policy=policy)
 
     if checkpoint is not None:
-        for i in range(len(checkpoint)):
-            if not deepspeed.comm.is_initialized() or deepspeed.comm.get_rank() == 0:
-                print(f"loading checkpoint ({i})")
+        for i in tqdm.tqdm(range(len(checkpoint)), desc=f"Loading {len(checkpoint)} checkpoint shards"):
             sd = torch.load(checkpoint[i], map_location='cpu')
             load_model_with_checkpoint(replaced_module, sd, mp_replace)
     return replaced_module


### PR DESCRIPTION
solve 2 issues:
- less noise using tqdm progress bar
- more informative - tell users how much to wait and how many shards to load

New way:

```
Loading 72 checkpoints:  12%|█▎        | 9/72 [01:12<08:39,  8.25s/it]
```