### PR TITLE
[inference tests] turn off time check for now

### DIFF
--- a/tests/unit/test_inference.py
+++ b/tests/unit/test_inference.py
@@ -255,7 +255,7 @@ def test_model_task(
 
         # These performance tests are only measuring the time for a single
         # inference request, we just want to check that performance isn't terrible
-        assert ds_time <= (bs_time * 1.1)
+        #assert ds_time <= (bs_time * 1.1)
         assert assert_fn(bs_output, ds_output)
 
     _go()
@@ -318,7 +318,7 @@ def test_lm_correctness(model_family, model_name, task):
 
         ppl_diff = abs(bs_output["results"][task]["ppl"] -
                        ds_output["results"][task]["ppl"])
-        assert ds_time <= bs_time
+        #assert ds_time <= bs_time
         assert ppl_diff < 0.01
 
     _go()


### PR DESCRIPTION
The time checks in our inference tests have been flakey for a bit, turning off for now until we can revisit a better way to test for perf regressions.