### PR TITLE
fix: fix BF16_Optimizer compatibility issue

### DIFF
--- a/deepspeed/runtime/bf16_optimizer.py
+++ b/deepspeed/runtime/bf16_optimizer.py
@@ -417,7 +417,7 @@ class BF16_Optimizer(ZeROOptimizer):
                                   hp_frag_address.numel)
                 for key,
                 value in self.optimizer.state[flat_hp_partition].items()
-                if torch.is_tensor(value)
+                if torch.is_tensor(value) and value.dim() > 0
             }
 
             lp_frag_address = fragment_address(start=fragment_start - lp_start,


### PR DESCRIPTION
Fix BF16_Optimizer compatibility issue with optimizer state 0-dim tensor, `tensor.narrow` does not support 0-dim tensor.