### PR TITLE
enable fp16 input autocasting

### DIFF
--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -163,6 +163,11 @@ def get_fp16_master_weights_and_grads_enabled(param_dict):
         return False
 
 
+def get_fp16_auto_cast(param_dict):
+    if get_fp16_enabled(param_dict):
+        return get_scalar_param(param_dict[FP16], FP16_AUTO_CAST, FP16_AUTO_CAST_DEFAULT)
+
+
 def get_loss_scale(param_dict):
     if get_fp16_enabled(param_dict):
         return get_scalar_param(param_dict[FP16],
@@ -820,6 +825,7 @@ class DeepSpeedConfig(object):
 
         self.gradient_clipping = get_gradient_clipping(param_dict)
         self.fp16_enabled = get_fp16_enabled(param_dict)
+        self.fp16_auto_cast = get_fp16_auto_cast(param_dict)
         self.bfloat16_enabled = get_bfloat16_enabled(param_dict)
         assert not (self.fp16_enabled and self.bfloat16_enabled), 'bfloat16 and fp16 modes cannot be simultaneously enabled'
         self.fp16_master_weights_and_gradients = get_fp16_master_weights_and_grads_enabled(

--- a/deepspeed/runtime/constants.py
+++ b/deepspeed/runtime/constants.py
@@ -133,6 +133,7 @@ FP16_FORMAT = '''
 FP16 parameters should be of the format:
 "fp16": {
   "enabled": true,
+  "auto_cast": false,
   "loss_scale": 0,
   "initial_scale_power": 32,
   "loss_scale_window": 1000,
@@ -148,6 +149,9 @@ FP16_ENABLED_DEFAULT = False
 # FP16 loss scale, zero means using dynamic scaling
 FP16_LOSS_SCALE = "loss_scale"
 FP16_LOSS_SCALE_DEFAULT = 0
+
+FP16_AUTO_CAST = "auto_cast"
+FP16_AUTO_CAST_DEFAULT = False
 
 # FP16 initial dynamic scale loss power
 FP16_INITIAL_SCALE_POWER = "initial_scale_power"

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -219,6 +219,7 @@ Example of <i>**scheduler**</i>
 ```json
 "fp16": {
     "enabled": true,
+    "auto_cast": false,
     "loss_scale": 0,
     "initial_scale_power": 32,
     "loss_scale_window": 1000,
@@ -232,6 +233,12 @@ Example of <i>**scheduler**</i>
 | Description                                                                                 | Default |
 | ------------------------------------------------------------------------------------------- | ------- |
 | <i>**enabled**</i> is a **fp16** parameter indicating whether or not FP16 training enabled. | `false` |
+
+<i>**fp16:auto_cast**</i>: [boolean]
+
+| Description                                                  | Default |
+| -------------------------------------------------------------| ------- |
+| <i>**auto_cast**</i> automatically casts inputs to **fp16**  | `false` |
 
 <i>**fp16:loss_scale**</i>: [float]
 


### PR DESCRIPTION
When enabled auto cast all inputs to fp16. Assumes the entire model is in fp16 as well, not to be confused with setups where the model composes of mixed dtypes like certain layers in fp32 and others in fp16.

Fixes #2019 