### PR TITLE
Fix the layer-past for GPT based models

### DIFF
--- a/deepspeed/ops/transformer/inference/transformer_inference.py
+++ b/deepspeed/ops/transformer/inference/transformer_inference.py
@@ -812,6 +812,10 @@ class DeepSpeedTransformerInference(nn.Module):
                 output_attentions=False):
         get_present = (get_present or get_key_value or use_cache)
         input_mask = input_mask if attention_mask is None else attention_mask
+
+        # We set the prev key/value to None when there is a prompt
+        if input.shape[1] > 1:
+            self.layer_past = None
         layer_past = layer_past if layer_past is not None else self.layer_past
 
         attn_mask = None


### PR DESCRIPTION
This PR fixes several issues about illegal memory access on GPT-type models such as BLOOM. This was mostly encountered when sending queries back-to-back, like in the real online inference scenario. 

This addresses https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/308, https://github.com/microsoft/DeepSpeed/issues/2119, and https://github.com/bigscience-workshop/Megatron-DeepSpeed/issues/324.