### PR TITLE
Make OPT policy backward compatible with pre-OPT transformers versions

### DIFF
--- a/deepspeed/module_inject/replace_policy.py
+++ b/deepspeed/module_inject/replace_policy.py
@@ -444,12 +444,11 @@ class HFOPTLayerPolicy(DSPolicy):
         try:
             import transformers
             HFOPTLayerPolicy._orig_layer_class = transformers.models.opt.modeling_opt.OPTDecoderLayer
+            if isinstance(DSPolicy.hf_model_config,
+                          transformers.models.opt.configuration_opt.OPTConfig):
+                self.pre_attn_norm = self.hf_model_config.do_layer_norm_before
         except:
             HFOPTLayerPolicy._orig_layer_class = None
-
-        if isinstance(DSPolicy.hf_model_config,
-                      transformers.models.opt.configuration_opt.OPTConfig):
-            self.pre_attn_norm = self.hf_model_config.do_layer_norm_before
 
     def get_hidden_heads(self):
         return self.client_module.self_attn.embed_dim, \


### PR DESCRIPTION
DS instantiates all policies [here](https://github.com/microsoft/DeepSpeed/blob/86164c487e6266c2528a615835a6020c57f7bb22/deepspeed/module_inject/replace_module.py#L962), regardless whether the policy is directly being used. As a result, we need more safeguards in each policy implementation for package compatibly. This PR adds a safeguard in OPT policy, in case the older `transformers` versions which don't support OPT models are being used.  

fixes #2248