### PR TITLE
Update Half Precision Kernel Compatibility

### DIFF
--- a/csrc/includes/custom_cuda_layers.h
+++ b/csrc/includes/custom_cuda_layers.h
@@ -9,7 +9,7 @@
 #define HALF_PRECISION_AVAILABLE = 1
 #include <hip/hip_cooperative_groups.h>
 #else
-#if __CUDA_ARCH__ >= 700
+#if __CUDA_ARCH__ >= 530
 #define HALF_PRECISION_AVAILABLE = 1
 #endif
 #include <cooperative_groups.h>

--- a/csrc/transformer/inference/csrc/gelu.cu
+++ b/csrc/transformer/inference/csrc/gelu.cu
@@ -350,7 +350,7 @@ __global__ void gptj_residual_add(__half* input,
                                   int intermediate_size,
                                   float mp_scale)
 {
-#if __CUDA_ARCH__ >= 700 || defined(__HIP_PLATFORM_HCC__)
+#ifdef HALF_PRECISION_AVAILABLE
 
     float2* input_cast = reinterpret_cast<float2*>(input);
     float2* output_cast = reinterpret_cast<float2*>(output);
@@ -482,6 +482,7 @@ __global__ void moe_res_matmul(__half* residual,
                                int seq_len,
                                int hidden_dim)
 {
+#ifdef HALF_PRECISION_AVAILABLE
     unsigned tid = threadIdx.x;
 
     float2* residual_cast = reinterpret_cast<float2*>(residual);
@@ -509,6 +510,7 @@ __global__ void moe_res_matmul(__half* residual,
         mlp_out_cast[tid] = data;
         tid += blockDim.x;
     }
+#endif
 }
 
 template <typename T>

--- a/csrc/transformer/inference/includes/custom_cuda_layers.h
+++ b/csrc/transformer/inference/includes/custom_cuda_layers.h
@@ -4,7 +4,7 @@
 #define HALF_PRECISION_AVAILABLE = 1
 #include <hip/hip_cooperative_groups.h>
 #else
-#if __CUDA_ARCH__ >= 700
+#if __CUDA_ARCH__ >= 530
 #define HALF_PRECISION_AVAILABLE = 1
 #endif
 #include <cooperative_groups.h>

--- a/csrc/transformer/normalize_kernels.cu
+++ b/csrc/transformer/normalize_kernels.cu
@@ -862,6 +862,7 @@ __global__ void LayerNormBackward2(const __half* out_grad,
                                    bool invertible,
                                    int row_stride)
 {
+#ifdef HALF_PRECISION_AVAILABLE
     int iteration_stride = blockDim.x;
     int iterations = row_stride / iteration_stride;
 
@@ -985,6 +986,7 @@ __global__ void LayerNormBackward2(const __half* out_grad,
 
         inp_grad_h[high_index] = temp;
     }
+#endif
 }
 
 template <>
@@ -1172,6 +1174,7 @@ __global__ void LayerNormBackward2(const __half* out_grad,
                                    __half* inp_grad,
                                    int row_stride)
 {
+#ifdef HALF_PRECISION_AVAILABLE
     int iteration_stride = blockDim.x;
     int iterations = row_stride / iteration_stride;
 
@@ -1290,6 +1293,7 @@ __global__ void LayerNormBackward2(const __half* out_grad,
         __half2 temp = __float22half2_rn(vals_arr_f[iterations]);
         inp_grad_h[high_index] = temp;
     }
+#endif
 }
 
 template <>
@@ -1601,6 +1605,7 @@ __global__ void LayerNormBackward2_fused_add(const __half* out_grad1,
                                              bool invertible,
                                              int row_stride)
 {
+#ifdef HALF_PRECISION_AVAILABLE
     int iteration_stride = blockDim.x;
     int iterations = row_stride / iteration_stride;
 
@@ -1727,6 +1732,7 @@ __global__ void LayerNormBackward2_fused_add(const __half* out_grad1,
 
         inp_grad_h[high_index] = temp + out_grad_h2[high_index];
     }
+#endif
 }
 
 template <>
@@ -1922,6 +1928,7 @@ __global__ void LayerNormBackward2_fused_add(const __half* out_grad1,
                                              __half* inp_grad,
                                              int row_stride)
 {
+#ifdef HALF_PRECISION_AVAILABLE
     int iteration_stride = blockDim.x;
     int iterations = row_stride / iteration_stride;
 
@@ -2044,6 +2051,7 @@ __global__ void LayerNormBackward2_fused_add(const __half* out_grad1,
         __half2 temp = __float22half2_rn(vals_arr_f[iterations]);
         inp_grad_h[high_index] = temp + out_grad_h2[high_index];
     }
+#endif
 }
 
 template <>


### PR DESCRIPTION
This PR fixes two issues:

1. Some kernels were missing the header guard for preventing kernel compilation for virtual architectures (sm_52 in particular) that do not support half precision arithmetic. This could cause pre-building ops to fail even if the target architecture did support half precision.
2. The header guard prevented compilation of half precision kernels for virtual architectures that do support half precision arithmetic. The header guard is now aligned with Nvidia's documentation (AMD support remains unchanged).