### PR TITLE
Fix for Zero3 when MP>1

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -158,7 +158,8 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             max_live_parameters=max_live_parameters,
             param_persistence_threshold=param_persistence_threshold,
             model_persistence_threshold=model_persistence_threshold,
-            offload_param_config=offload_optimizer_config)
+            offload_param_config=offload_optimizer_config,
+            mpu=mpu)
 
         self.persistent_parameters = self.parameter_offload.persistent_parameters
         self._configure_offloading(offload_optimizer_config, offload_param_config)


### PR DESCRIPTION
Small 1-line fix for a rare bug. 

Currently, if running Megatron-DeepSpeed with MP or PP > 1 with Zero-3, and at least one of `train_batch_size`, `train_micro_batch_size_per_gpu`, or `gradient_accumulation_steps` is not defined in the config, DeepSpeed fails with the following assertion error:

```
Traceback (most recent call last):
  File "/home/anthony.301/eai-deeperspeed/gpt-neox/train.py", line 27, in <module>
    pretrain(neox_args=neox_args)
  File "/home/anthony.301/eai-deeperspeed/gpt-neox/megatron/training.py", line 85, in pretrain
    model, optimizer, lr_scheduler = setup_model_and_optimizer(
  File "/home/anthony.301/eai-deeperspeed/gpt-neox/megatron/training.py", line 416, in setup_model_and_optimizer
    model, optimizer, _, lr_scheduler = deepspeed.initialize(
  File "/home/anthony.301/eai-deeperspeed/miniconda3/lib/python3.9/site-packages/deepspeed/__init__.py", line 124, in initialize
    engine = DeepSpeedEngine(args=args,
  File "/home/anthony.301/eai-deeperspeed/miniconda3/lib/python3.9/site-packages/deepspeed/runtime/engine.py", line 320, in __init__
    self._configure_optimizer(optimizer, model_parameters)
  File "/home/anthony.301/eai-deeperspeed/miniconda3/lib/python3.9/site-packages/deepspeed/runtime/engine.py", line 1146, in _configure_optimizer
    self.optimizer = self._configure_zero_optimizer(basic_optimizer)
  File "/home/anthony.301/eai-deeperspeed/miniconda3/lib/python3.9/site-packages/deepspeed/runtime/engine.py", line 1448, in _configure_zero_optimizer
    optimizer = DeepSpeedZeroOptimizer_Stage3(
  File "/home/anthony.301/eai-deeperspeed/miniconda3/lib/python3.9/site-packages/deepspeed/runtime/zero/stage3.py", line 151, in __init__
    self.parameter_offload = DeepSpeedZeRoOffload(
  File "/home/anthony.301/eai-deeperspeed/miniconda3/lib/python3.9/site-packages/deepspeed/runtime/zero/parameter_offload.py", line 203, in __init__
    self._convert_to_zero_parameters(ds_config, module, mpu)
  File "/home/anthony.301/eai-deeperspeed/miniconda3/lib/python3.9/site-packages/deepspeed/runtime/zero/parameter_offload.py", line 267, in _convert_to_zero_parameters
    Init(module=module,
  File "/home/anthony.301/eai-deeperspeed/miniconda3/lib/python3.9/site-packages/deepspeed/runtime/zero/partition_parameters.py", line 655, in __init__
    _ds_config = deepspeed.runtime.config.DeepSpeedConfig(
  File "/home/anthony.301/eai-deeperspeed/miniconda3/lib/python3.9/site-packages/deepspeed/runtime/config.py", line 801, in __init__
    self._configure_train_batch_size()
  File "/home/anthony.301/eai-deeperspeed/miniconda3/lib/python3.9/site-packages/deepspeed/runtime/config.py", line 988, in _configure_train_batch_size
    self._batch_assertion()
  File "/home/anthony.301/eai-deeperspeed/miniconda3/lib/python3.9/site-packages/deepspeed/runtime/config.py", line 919, in _batch_assertion
    assert (
AssertionError: Gradient accumulation steps: 0 has to be greater than 0
```

There are two `DeepSpeedConfig` objects when running DeepSpeed with Zero-3. Tracing the Zero-3 code, it appears that the `DeepSpeedConfig` created for Zero-3 doesn't pass the `mpu` object. Specifically:

https://github.com/microsoft/DeepSpeed/blob/c84bca37b18f0d6581b1fe6dbf3f41aefe404fe6/deepspeed/runtime/zero/stage3.py#L151 --> https://github.com/microsoft/DeepSpeed/blob/c84bca37b18f0d6581b1fe6dbf3f41aefe404fe6/deepspeed/runtime/zero/parameter_offload.py#L203 --> https://github.com/microsoft/DeepSpeed/blob/c84bca37b18f0d6581b1fe6dbf3f41aefe404fe6/deepspeed/runtime/zero/parameter_offload.py#L267 --> https://github.com/microsoft/DeepSpeed/blob/c84bca37b18f0d6581b1fe6dbf3f41aefe404fe6/deepspeed/runtime/zero/partition_parameters.py#L655 --> https://github.com/microsoft/DeepSpeed/blob/c84bca37b18f0d6581b1fe6dbf3f41aefe404fe6/deepspeed/runtime/config.py#L716 --> https://github.com/microsoft/DeepSpeed/blob/c84bca37b18f0d6581b1fe6dbf3f41aefe404fe6/deepspeed/runtime/config.py#L936

In essence, the Zero-3 config assigns an incorrect `world_size` for the config since `mpu` is not present, and therefore leads to the assertion error if the user doesn't explicitly set `train_batch_size`, `train_micro_batch_size_per_gpu`, and `gradient_accumulation_steps`. Note that other config params based on the `world_size` are set incorrectly as well without this patch.