### PR TITLE
Update relu.cu with mem_access_utils

### DIFF
--- a/csrc/transformer/inference/csrc/relu.cu
+++ b/csrc/transformer/inference/csrc/relu.cu
@@ -14,33 +14,6 @@ __global__ void fused_bias_relu(float* input,
                                 int total_count,
                                 int intermediate_size)
 {
-    float4* input_cast = reinterpret_cast<float4*>(input);
-    const float4* bias_cast = reinterpret_cast<const float4*>(bias);
-    int offset = blockIdx.x * blockDim.x + threadIdx.x;
-
-    if (offset < total_count) {
-        float4 data = input_cast[offset];
-        float4 bias_data = bias_cast[offset % intermediate_size];
-
-        data.x += bias_data.x;
-        data.y += bias_data.y;
-        data.z += bias_data.z;
-        data.w += bias_data.w;
-
-        data.x = relu(data.x);
-        data.y = relu(data.y);
-        data.z = relu(data.z);
-        data.w = relu(data.w);
-
-        input_cast[offset] = data;
-    }
-}
-
-__global__ void fused_bias_relu(float* input,
-                                const float* bias,
-                                int total_count,
-                                int intermediate_size)
-{
     // Input restriction: intermediate_size % vals_per_access == 0
     constexpr int granularity = 16;
     constexpr int vals_per_access = granularity / sizeof(float);

--- a/csrc/transformer/inference/csrc/relu.cu
+++ b/csrc/transformer/inference/csrc/relu.cu
@@ -3,7 +3,9 @@ Copyright 2022 The Microsoft DeepSpeed Team
 */
 
 #include "inference_cuda_layers.h"
+#include "memory_access_utils.h"
 
+namespace cg = cooperative_groups;
 #define MAX_CAP 4
 #define MAX_SEQ 2048
 


### PR DESCRIPTION
Updates the fused bias relu kernels to use mem_access_utils and cooperative groups. 

@awan-10 
@cmikeh2 