### PR TITLE
Upgrade P40 tests to torch 1.8

### DIFF
--- a/.github/workflows/nv-torch18-p40.yml
+++ b/.github/workflows/nv-torch18-p40.yml
@@ -1,4 +1,4 @@
-name: nv-torch12-p40
+name: nv-torch18-p40
 
 on:
   push:
@@ -32,7 +32,7 @@ jobs:
           nvcc --version
           pip install --upgrade pip
           pip uninstall --yes torch torchvision
-          pip install torch==1.2.0 torchvision==0.4.0
+          pip3 install torch==1.8.2 torchvision==0.9.2 --extra-index-url https://download.pytorch.org/whl/lts/1.8/cu101
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -60,4 +60,4 @@ jobs:
         run: |
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
           cd tests
-          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -n 4 unit/ --torch_ver="1.2" --cuda_ver="10"
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -n 4 unit/ --torch_ver="1.8" --cuda_ver="10"

--- a/.github/workflows/nv-torch18-p40.yml
+++ b/.github/workflows/nv-torch18-p40.yml
@@ -32,7 +32,7 @@ jobs:
           nvcc --version
           pip install --upgrade pip
           pip uninstall --yes torch torchvision
-          pip3 install torch==1.8.2 torchvision==0.9.2 --extra-index-url https://download.pytorch.org/whl/lts/1.8/cu101
+          pip install torch==1.8.2 torchvision==0.9.2 --extra-index-url https://download.pytorch.org/whl/lts/1.8/cu101
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 


### PR DESCRIPTION
We have recently seen problems with our P40 CI workflow from torch. The P40 runner was previously running torch 1.2, but this version is quite old and probably not widely used. We're upgrading to torch 1.8 and making torch 1.8 the minimum supported version for DeepSpeed.