### PR TITLE
Refactor residual add kernels

### DIFF
--- a/csrc/transformer/inference/csrc/pt_binding.cpp
+++ b/csrc/transformer/inference/csrc/pt_binding.cpp
@@ -1183,16 +1183,18 @@ at::Tensor fused_gemm_gelu(at::Tensor& input,
 }
 
 template <typename T>
-void residual_add_bias(at::Tensor& hidden_state,
-                       const at::Tensor& residual,
-                       const at::Tensor& attention_output,
-                       const at::Tensor& attention_bias,
-                       const at::Tensor& final_bias,
-                       const int mp_size,
-                       const bool mlp_after_attn,
-                       const bool add_bias,
-                       const bool preln)
+at::Tensor& residual_add_bias(at::Tensor& hidden_state,
+                              const at::Tensor& residual,
+                              const at::Tensor& attention_output,
+                              const at::Tensor& attention_bias,
+                              const at::Tensor& final_bias,
+                              const int mp_size,
+                              const bool mlp_after_attn,
+                              const bool add_bias,
+                              const bool preln)
 {
+    // TODO: check the ttype of tensors matches
+    // TODO: check the size of tensors matches
     int bsz = residual.size(0) * residual.size(1);
     int hidden_size = residual.size(2);
     if (mlp_after_attn)
@@ -1217,6 +1219,7 @@ void residual_add_bias(at::Tensor& hidden_state,
             bsz,
             mp_size,
             Context::Instance().GetCurrentStream());
+    return hidden_state;
 }
 
 std::vector<at::Tensor> apply_rotary_pos_emb(at::Tensor& mixed_query,

--- a/csrc/transformer/inference/csrc/pt_binding.cpp
+++ b/csrc/transformer/inference/csrc/pt_binding.cpp
@@ -1193,8 +1193,6 @@ at::Tensor& residual_add_bias(at::Tensor& hidden_state,
                               const bool add_bias,
                               const bool preln)
 {
-    // TODO: check the ttype of tensors matches
-    // TODO: check the size of tensors matches
     int bsz = residual.size(0) * residual.size(1);
     int hidden_size = residual.size(2);
     if (mlp_after_attn)
@@ -1361,7 +1359,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
           "DeepSpeed linear_layer with int8 (CUDA)");
     m.def("fused_gemm_gelu_fp32", &fused_gemm_gelu<float>, "DeepSpeed mlp with fp32 (CUDA)");
     m.def("fused_gemm_gelu_fp16", &fused_gemm_gelu<__half>, "DeepSpeed mlp with fp16 (CUDA)");
-    // m.def("residual_add_bias", &residual_add_bias, "DeepSpeed mlp with fp16 (CUDA)");
     m.def("residual_add_bias_fp32",
           &residual_add_bias<float>,
           "DeepSpeed residual add with fp32 (CUDA)");

--- a/csrc/transformer/inference/csrc/pt_binding.cpp
+++ b/csrc/transformer/inference/csrc/pt_binding.cpp
@@ -1182,63 +1182,41 @@ at::Tensor fused_gemm_gelu(at::Tensor& input,
     return output;
 }
 
-void residual_add_bias(at::Tensor& output,
-                       at::Tensor& input,
-                       at::Tensor& attention_output,
-                       at::Tensor& output_b,
-                       at::Tensor& attention_b,
-                       int mp_size,
-                       bool mlp_after_attn,
-                       bool add_bias,
-                       bool preln)
+template <typename T>
+void residual_add_bias(at::Tensor& hidden_state,
+                       const at::Tensor& residual,
+                       const at::Tensor& attention_output,
+                       const at::Tensor& attention_bias,
+                       const at::Tensor& final_bias,
+                       const int mp_size,
+                       const bool mlp_after_attn,
+                       const bool add_bias,
+                       const bool preln)
 {
-    int bsz = input.size(0) * input.size(1);
-    int hidden_size = input.size(2);
-    // cudaStreamWaitEvent(
-    //    Context::Instance().GetCurrentStream(), Context::Instance().GetCompEvent(2), 0);
-    if (input.scalar_type() == at::kFloat)
-        if (mlp_after_attn)
-            launch_bias_residual((float*)input.data_ptr(),
-                                 (float*)output.data_ptr(),
-                                 (float*)attention_output.data_ptr(),
-                                 (float*)output_b.data_ptr(),
-                                 (float*)attention_b.data_ptr(),
-                                 bsz,
-                                 hidden_size,
-                                 mp_size,
-                                 preln,
-                                 Context::Instance().GetCurrentStream());
-        else
-            launch_gptj_residual_add<float>((float*)input.data_ptr(),
-                                            (float*)output.data_ptr(),
-                                            (float*)attention_output.data_ptr(),
-                                            (float*)output_b.data_ptr(),
-                                            (float*)(add_bias ? attention_b.data_ptr() : nullptr),
-                                            hidden_size,
-                                            bsz,
-                                            mp_size,
-                                            Context::Instance().GetCurrentStream());
-    else if (mlp_after_attn)
-        launch_bias_residual((__half*)input.data_ptr(),
-                             (__half*)output.data_ptr(),
-                             (__half*)attention_output.data_ptr(),
-                             (__half*)output_b.data_ptr(),
-                             (__half*)attention_b.data_ptr(),
+    int bsz = residual.size(0) * residual.size(1);
+    int hidden_size = residual.size(2);
+    if (mlp_after_attn)
+        launch_bias_residual(static_cast<T*>(residual.data_ptr()),
+                             static_cast<T*>(hidden_state.data_ptr()),
+                             static_cast<T*>(attention_output.data_ptr()),
+                             static_cast<T*>(final_bias.data_ptr()),
+                             static_cast<T*>(attention_bias.data_ptr()),
                              bsz,
                              hidden_size,
                              mp_size,
                              preln,
                              Context::Instance().GetCurrentStream());
     else
-        launch_gptj_residual_add<__half>((__half*)input.data_ptr(),
-                                         (__half*)output.data_ptr(),
-                                         (__half*)attention_output.data_ptr(),
-                                         (__half*)output_b.data_ptr(),
-                                         (__half*)(add_bias ? attention_b.data_ptr() : nullptr),
-                                         hidden_size,
-                                         bsz,
-                                         mp_size,
-                                         Context::Instance().GetCurrentStream());
+        launch_gptj_residual_add<T>(
+            static_cast<T*>(residual.data_ptr()),
+            static_cast<T*>(hidden_state.data_ptr()),
+            static_cast<T*>(attention_output.data_ptr()),
+            static_cast<T*>(final_bias.data_ptr()),
+            static_cast<T*>((add_bias ? attention_bias.data_ptr() : nullptr)),
+            hidden_size,
+            bsz,
+            mp_size,
+            Context::Instance().GetCurrentStream());
 }
 
 std::vector<at::Tensor> apply_rotary_pos_emb(at::Tensor& mixed_query,
@@ -1380,7 +1358,13 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
           "DeepSpeed linear_layer with int8 (CUDA)");
     m.def("fused_gemm_gelu_fp32", &fused_gemm_gelu<float>, "DeepSpeed mlp with fp32 (CUDA)");
     m.def("fused_gemm_gelu_fp16", &fused_gemm_gelu<__half>, "DeepSpeed mlp with fp16 (CUDA)");
-    m.def("residual_add", &residual_add_bias, "DeepSpeed mlp with fp16 (CUDA)");
+    // m.def("residual_add_bias", &residual_add_bias, "DeepSpeed mlp with fp16 (CUDA)");
+    m.def("residual_add_bias_fp32",
+          &residual_add_bias<float>,
+          "DeepSpeed residual add with fp32 (CUDA)");
+    m.def("residual_add_bias_fp16",
+          &residual_add_bias<__half>,
+          "DeepSpeed residual add with fp16 (CUDA)");
     m.def("apply_rotary_pos_emb", &apply_rotary_pos_emb, "DeepSpeed mlp with fp16 (CUDA)");
     m.def("einsum_sec_sm_ecm_fp32",
           &einsum_sec_sm_ecm<float>,

--- a/deepspeed/ops/transformer/inference/transformer_inference.py
+++ b/deepspeed/ops/transformer/inference/transformer_inference.py
@@ -601,6 +601,7 @@ class DeepSpeedMLPFunction(Function):
                 fused_gemm_gelu,
                 vector_matmul_func,
                 bias_residual_func,
+                residual_add_func,
                 activation_func_type=ActivationFuncType.GELU):
 
         if attn_nw is None:
@@ -630,16 +631,16 @@ class DeepSpeedMLPFunction(Function):
                                         False,
                                         output_w.scale,
                                         config.q_int8)
-        inference_cuda_module.residual_add(
-            output,
-            residual if config.pre_layer_norm else residual_add,
-            input,
-            output_b,
+        residual_add_func(
+            output,                 # hidden state
+            residual if config.pre_layer_norm else residual_add,        # residual
+            input,                  # attention output
+            output_b,               # attention bias
             bias if bias is not None else output_b,
-            config.mp_size,
-            config.mlp_after_attn,
-            bias is not None,
-            config.pre_layer_norm)
+            config.mp_size,         # model parallel size
+            config.mlp_after_attn,  # whether mlp is after attention (GPTJ model architecture runs the MLP layer in parallel with attention)
+            bias is not None,       # whether bias addition is fused
+            config.pre_layer_norm)  # whether the layer norm is applied before attention
         if mp_group is not None and dist.get_world_size(group=mp_group) > 1:
             dist.all_reduce(output, group=mp_group)
         return output
@@ -710,6 +711,9 @@ class DeepSpeedMLP(nn.Module):
         self.bias_residual_func = inference_cuda_module.bias_residual_fp16 if config.fp16 or config.q_int8 else \
                                     inference_cuda_module.bias_residual_fp32
 
+        self.residual_add_func = inference_cuda_module.residual_add_bias_fp16 if config.fp16 or config.q_int8 else \
+                                    inference_cuda_module.residual_add_bias_fp32
+
     def forward(self, input, residual, residual_norm, bias):
         return DeepSpeedMLPFunction.apply(input,
                                           residual,
@@ -729,7 +733,8 @@ class DeepSpeedMLP(nn.Module):
                                           self.mlp_gemm_func,
                                           self.fused_gemm_gelu,
                                           self.vector_matmul_func,
-                                          self.bias_residual_func)
+                                          self.bias_residual_func,
+                                          self.residual_add_func)
 
 
 class DeepSpeedTransformerInference(nn.Module):

--- a/deepspeed/ops/transformer/inference/transformer_inference.py
+++ b/deepspeed/ops/transformer/inference/transformer_inference.py
@@ -635,8 +635,8 @@ class DeepSpeedMLPFunction(Function):
             output,                 # hidden state
             residual if config.pre_layer_norm else residual_add,        # residual
             input,                  # attention output
-            output_b,               # attention bias
             bias if bias is not None else output_b,
+            output_b,
             config.mp_size,         # model parallel size
             config.mlp_after_attn,  # whether mlp is after attention (GPTJ model architecture runs the MLP layer in parallel with attention)
             bias is not None,       # whether bias addition is fused

--- a/deepspeed/ops/transformer/inference/transformer_inference.py
+++ b/deepspeed/ops/transformer/inference/transformer_inference.py
@@ -631,7 +631,7 @@ class DeepSpeedMLPFunction(Function):
                                         False,
                                         output_w.scale,
                                         config.q_int8)
-        residual_add_func(
+        output = residual_add_func(
             output,                 # hidden state
             residual if config.pre_layer_norm else residual_add,        # residual
             input,                  # attention output

--- a/tests/unit/ops/transformer/inference/test_residual_add.py
+++ b/tests/unit/ops/transformer/inference/test_residual_add.py
@@ -103,9 +103,9 @@ def test_residual_add(inference_module,
             preln]
 
     if dtype == torch.float16:
-        inference_module.residual_add_bias_fp16(*res_add_args)
+        ds_out = inference_module.residual_add_bias_fp16(*res_add_args)
     elif dtype == torch.float32:
-        inference_module.residual_add_bias_fp32(*res_add_args)
+        ds_out = inference_module.residual_add_bias_fp32(*res_add_args)
     else:
         raise ValueError(f"Unsupported dtype: {dtype}")
 

--- a/tests/unit/ops/transformer/inference/test_residual_add.py
+++ b/tests/unit/ops/transformer/inference/test_residual_add.py
@@ -86,21 +86,23 @@ def test_residual_add(inference_module,
     ref_out = run_residual_add_reference(ref_out,
                                          residual,
                                          attention_output,
-                                         final_bias,
                                          attention_output_bias,
+                                         final_bias,
                                          mlp_after_attn,
                                          add_bias,
                                          mp_size)
 
-    res_add_args = [ds_out,         # in-place update of ds_out. Needs reafactoring to be consistent with other kernels.
-            residual,
-            attention_output,
-            attention_output_bias,
-            final_bias,
-            mp_size,
-            mlp_after_attn,
-            add_bias,
-            preln]
+    res_add_args = [
+        ds_out,
+        residual,
+        attention_output,
+        attention_output_bias,
+        final_bias,
+        mp_size,
+        mlp_after_attn,
+        add_bias,
+        preln
+    ]
 
     if dtype == torch.float16:
         ds_out = inference_module.residual_add_bias_fp16(*res_add_args)

--- a/tests/unit/ops/transformer/inference/test_residual_add.py
+++ b/tests/unit/ops/transformer/inference/test_residual_add.py
@@ -26,8 +26,8 @@ def inference_module():
 def run_residual_add_reference(hidden_state,
                                residual,
                                attention_output,
-                               final_bias,
                                attention_output_bias,
+                               final_bias,
                                mlp_after_attn,
                                add_bias,
                                mp_size=1):
@@ -92,15 +92,21 @@ def test_residual_add(inference_module,
                                          add_bias,
                                          mp_size)
 
-    inference_module.residual_add(
-            ds_out,         # in-place update of ds_out. Needs reafactoring to be consistent with other kernels.
+    res_add_args = [ds_out,         # in-place update of ds_out. Needs reafactoring to be consistent with other kernels.
             residual,
             attention_output,
-            final_bias,
             attention_output_bias,
+            final_bias,
             mp_size,
             mlp_after_attn,
             add_bias,
-            preln)
+            preln]
+
+    if dtype == torch.float16:
+        inference_module.residual_add_bias_fp16(*res_add_args)
+    elif dtype == torch.float32:
+        inference_module.residual_add_bias_fp32(*res_add_args)
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype}")
 
     assert (allclose(ds_out, ref_out))


### PR DESCRIPTION
This PR:
- [x] refactors the `residual_add_bias` kernel launch function to a templated function
- [x] exposes fp16/fp32 residual add kernels at python level
- [ ] ~~refactors the corresponding cuda kernels into their own separate `.cu` files~~
- [ ] ~~adds negative tests for type/shape matching of input tensors~~

NOTE: the tests for type/shape matching will be added in a separate PR at the python level.