### PR TITLE
Fix issue with corrupted output on long generation for GPT

### DIFF
--- a/csrc/transformer/inference/csrc/pt_binding.cpp
+++ b/csrc/transformer/inference/csrc/pt_binding.cpp
@@ -107,7 +107,7 @@ void allocate_workspace(size_t hidden_dim,
                         unsigned num_layers,
                         size_t head_size = 128)
 {
-    size_t _workSpaceSize = 16 * (hidden_dim * batch_size * max_seq_len) +
+    size_t _workSpaceSize = 20 * (hidden_dim * batch_size * max_seq_len) +
                             (num_layers * batch_size * max_seq_len * hidden_dim * 2);  // KV-cache
     Context::Instance().GenWorkSpace(_workSpaceSize * sizeof(T));
 }
@@ -451,7 +451,7 @@ std::vector<at::Tensor> ds_softmax_context(at::Tensor& query_key_value,
     auto kv_cache = workspace + offset + (hidden_dim / heads) * (is_prompt ? 0 : soft_len - 1);
     size_t value_offset = bsz * MAX_OUT_TOKES * hidden_dim;
 
-    T* temp_buf = (T*)output.data_ptr() + at::numel(output);
+    T* temp_buf = (T*)kv_cache+value_offset+value_offset;
     launch_bias_add_transform_0213<T>((T*)query_cont,
                                       kv_cache,
                                       kv_cache + value_offset,

--- a/csrc/transformer/inference/includes/inference_cuda_layers.h
+++ b/csrc/transformer/inference/includes/inference_cuda_layers.h
@@ -21,7 +21,7 @@ Copyright 2022 The Microsoft DeepSpeed Team
 #include <cassert>
 #include <iostream>
 
-#define MAX_OUT_TOKES 1024
+#define MAX_OUT_TOKES 2048
 #define MAX_WARP_NUM 32
 #define WARP_SIZE 32
 

--- a/csrc/transformer/inference/includes/inference_cuda_layers.h
+++ b/csrc/transformer/inference/includes/inference_cuda_layers.h
@@ -21,7 +21,7 @@ Copyright 2022 The Microsoft DeepSpeed Team
 #include <cassert>
 #include <iostream>
 
-#define MAX_OUT_TOKES 128
+#define MAX_OUT_TOKES 1024
 #define MAX_WARP_NUM 32
 #define WARP_SIZE 32
 


### PR DESCRIPTION
Fix issue described in https://github.com/microsoft/DeepSpeed/issues/2300

Only updating MAX_OUT_TOKES doesn't helps and main issue is in temp_buf that was allocated just after `output` tensor

Then in `attention_unfused` 
`T* workspace = (T*)output + bsz * seq_len * heads * k;` where output is `temp_buf` from `ds_softmax_context`
In the result `temp_buf` overlaps `query_cont` allocated in  `ds_softmax_context`

I've put `temp_buf` just after `kv_cache` and it helps

Minimal steps to reproduce:
```bash
python3 benchmarks/inference/gpt-bench.py -m EleutherAI/gpt-neo-125M --kernel-inject --deepspeed --dtype=fp32 --max-tokens=1020 --trials 1
```

