### PR TITLE
Fix an exception when auto-casting dicts to fp16

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1694,7 +1694,7 @@ class DeepSpeedEngine(Module):
             return inputs.__class__(new_inputs)
         elif isinstance(inputs, dict):
             new_inputs = {}
-            for k, v in inputs:
+            for k, v in inputs.items():
                 new_inputs[k] = self._cast_inputs_half(v)
             return new_inputs
         elif hasattr(inputs, 'half'):


### PR DESCRIPTION
Deepspeed raises an exception when using fp16 auto_cast mode with a model that takes a dictionary as input. Quick test on `0.7.3` to display what I'm talking about:

```
$ cat test.py
import torch
import deepspeed
import argparse

parser = argparse.ArgumentParser(description='Test model')
parser.add_argument('--local_rank', type=int, default=-1,
                    help='local rank passed from distributed launcher')
parser = deepspeed.add_config_arguments(parser)
cmd_args = parser.parse_args()

class ValueDoubler(torch.nn.Module):
    def forward(self, d):
        return d["value"] * 2

m = ValueDoubler()
m, _, _, _ = deepspeed.initialize(args=cmd_args, model=m)

print("Torch: ", torch.__version__)
print("DeepSpeed: ", deepspeed.__version__)
print("New value: ", m({"value": 1.0}))
$ cat ds.json
{"fp16": {"auto_cast": true, "enabled": true}, "train_batch_size": 1}
$ deepspeed test.py --deepspeed --deepspeed_config ds.json
...
Torch:  1.12.1+cu102
DeepSpeed:  0.7.3
Traceback (most recent call last):
  File "test.py", line 20, in <module>
    print(m({"value": 1.0}))
  File "/data/home/mattks/.local/share/virtualenvs/test-t-h-loqS/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)
  File "/data/home/mattks/.local/share/virtualenvs/test-t-h-loqS/lib/python3.8/site-packages/deepspeed/utils/nvtx.py", line 11, in wrapped_fn
    return func(*args, **kwargs)
  File "/data/home/mattks/.local/share/virtualenvs/test-t-h-loqS/lib/python3.8/site-packages/deepspeed/runtime/engine.py", line 1664, in forward
    inputs = self._cast_inputs_half(inputs)
  File "/data/home/mattks/.local/share/virtualenvs/test-t-h-loqS/lib/python3.8/site-packages/deepspeed/runtime/engine.py", line 1693, in _cast_inputs_half
    new_inputs.append(self._cast_inputs_half(v))
  File "/data/home/mattks/.local/share/virtualenvs/test-t-h-loqS/lib/python3.8/site-packages/deepspeed/runtime/engine.py", line 1697, in _cast_inputs_half
    for k, v in inputs:
ValueError: too many values to unpack (expected 2)
```

And testing on master (I had to fuss it a little to get master to work):
```
$ deepspeed test.py --deepspeed --deepspeed_config ds.json
...
Torch:  1.12.1+cu102
DeepSpeed:  0.7.4+eed4032
Traceback (most recent call last):
  File "test.py", line 20, in <module>
    print(m({"value": 1.0}))
  File "/data/home/mattks/.local/share/virtualenvs/test-t-h-loqS/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)
  File "/data/home/mattks/.local/share/virtualenvs/test-t-h-loqS/lib/python3.8/site-packages/deepspeed/utils/nvtx.py", line 11, in wrapped_fn
    return func(*args, **kwargs)
  File "/data/home/mattks/.local/share/virtualenvs/test-t-h-loqS/lib/python3.8/site-packages/deepspeed/runtime/engine.py", line 1664, in forward
    inputs = self._cast_inputs_half(inputs)
  File "/data/home/mattks/.local/share/virtualenvs/test-t-h-loqS/lib/python3.8/site-packages/deepspeed/runtime/engine.py", line 1693, in _cast_inputs_half
    new_inputs.append(self._cast_inputs_half(v))
  File "/data/home/mattks/.local/share/virtualenvs/test-t-h-loqS/lib/python3.8/site-packages/deepspeed/runtime/engine.py", line 1697, in _cast_inputs_half
    for k, v in inputs:
ValueError: too many values to unpack (expected 2)
```

This PR fixes this:
```
$ deepspeed test.py --deepspeed --deepspeed_config ds.json
Torch:  1.12.1+cu102
DeepSpeed:  0.7.4+45d39d7
New value:  2.0
```