### PR TITLE
Allowing base64 encoded ds config passed as command line argument and using it for autotuner

### DIFF
--- a/deepspeed/autotuning/autotuner.py
+++ b/deepspeed/autotuning/autotuner.py
@@ -45,17 +45,13 @@ class Autotuner:
 
         self.autotuning_config = DeepSpeedAutotuningConfig(self.user_config)
 
-        self.exps_dir = DEFAULT_EXPRS_DIR
-        if self.autotuning_config.exps_dir and self.autotuning_config.exps_dir != "":
-            self.exps_dir = self.autotuning_config.exps_dir
+        self.exps_dir = self.autotuning_config.exps_dir
         if self.autotuning_config.overwrite and os.path.exists(self.exps_dir):
             shutil.rmtree(self.exps_dir, ignore_errors=True)
         if not os.path.exists(self.exps_dir):
             os.makedirs(self.exps_dir, exist_ok=True)
 
-        self.results_dir = DEFAULT_RESULTS_DIR
-        if self.autotuning_config.results_dir and self.autotuning_config.results_dir != "":
-            self.results_dir = self.autotuning_config.results_dir
+        self.results_dir = self.autotuning_config.results_dir
         if self.autotuning_config.overwrite and os.path.exists(self.results_dir):
             shutil.rmtree(self.results_dir, ignore_errors=True)
         if not os.path.exists(self.results_dir):

--- a/deepspeed/autotuning/autotuner.py
+++ b/deepspeed/autotuning/autotuner.py
@@ -44,6 +44,8 @@ class Autotuner:
         assert self.user_config is not None, "DeepSpeed configuration is not provided"
 
         self.autotuning_config = DeepSpeedAutotuningConfig(self.user_config)
+        del self.user_config[AUTOTUNING][AUTOTUNING_EXPS_DIR]
+        del self.user_config[AUTOTUNING][AUTOTUNING_RESULTS_DIR]
 
         self.exps_dir = self.autotuning_config.exps_dir
         if self.autotuning_config.overwrite and os.path.exists(self.exps_dir):

--- a/deepspeed/autotuning/autotuner.py
+++ b/deepspeed/autotuning/autotuner.py
@@ -22,11 +22,12 @@ try:
 except ImportError:
     tabulate = None
 
-
 ZERO_OPTIMIZATION_STAGE = "stage"
 OFFLOAD_OPTIMIZER = "offload_optimizer"
 OFFLOAD_PARAM = "offload_param"
-ZERO_OPTIMIZATION_STAGE_DEFAULT=ZeroStageEnum.disabled
+ZERO_OPTIMIZATION_STAGE_DEFAULT = ZeroStageEnum.disabled
+
+
 class Autotuner:
     """The DeepSpeed Autotuner automatically discovers the optimal DeepSpeed configuration that delivers good training speed. The Autotuner uses model information, system information, and heuristics to efficiently tune system knobs that affect compute and memory efficiencies, such as ZeRO optimization stages, micro-batch sizes, and many other ZeRO optimization configurations. It not only reduces the time and resources user spend on tuning, but also can discover configurations better than hand-tuned methods.
     Autotuning with DeepSpeed requires no code change from DeepSpeed users. Please refer to the README for usage details.
@@ -372,7 +373,8 @@ class Autotuner:
                 if OFFLOAD_OPTIMIZER not in config_zero and OFFLOAD_OPTIMIZER in exp_config[
                         ZERO_OPTIMIZATION]:
                     del exp_config[ZERO_OPTIMIZATION][OFFLOAD_OPTIMIZER]
-                if OFFLOAD_PARAM not in config_zero and OFFLOAD_PARAM in exp_config[ZERO_OPTIMIZATION]:
+                if OFFLOAD_PARAM not in config_zero and OFFLOAD_PARAM in exp_config[
+                        ZERO_OPTIMIZATION]:
                     del exp_config[ZERO_OPTIMIZATION][OFFLOAD_PARAM]
             # set gradient accumulation steps according to max_train_batch_size_per_gpu
             mbs = exp_config[TRAIN_MICRO_BATCH_SIZE_PER_GPU]

--- a/deepspeed/autotuning/config.py
+++ b/deepspeed/autotuning/config.py
@@ -38,13 +38,15 @@ class DeepSpeedAutotuningConfig(DeepSpeedConfigObject):
                                      AUTOTUNING_FAST,
                                      AUTOTUNING_FAST_DEFAULT)
 
-        self.results_dir = os.path.abspath(get_scalar_param(autotuning_dict,
-                                            AUTOTUNING_RESULTS_DIR,
-                                            AUTOTUNING_RESULTS_DIR_DEFAULT))
+        self.results_dir = os.path.abspath(
+            get_scalar_param(autotuning_dict,
+                             AUTOTUNING_RESULTS_DIR,
+                             AUTOTUNING_RESULTS_DIR_DEFAULT))
         assert self.results_dir, "results_dir cannot be empty"
-        self.exps_dir = os.path.abspath(get_scalar_param(autotuning_dict,
-                                         AUTOTUNING_EXPS_DIR,
-                                         AUTOTUNING_EXPS_DIR_DEFAULT))
+        self.exps_dir = os.path.abspath(
+            get_scalar_param(autotuning_dict,
+                             AUTOTUNING_EXPS_DIR,
+                             AUTOTUNING_EXPS_DIR_DEFAULT))
         assert self.exps_dir, "exps_dir cannot be empty"
         self.overwrite = get_scalar_param(autotuning_dict,
                                           AUTOTUNING_OVERWRITE,

--- a/deepspeed/autotuning/config.py
+++ b/deepspeed/autotuning/config.py
@@ -38,14 +38,14 @@ class DeepSpeedAutotuningConfig(DeepSpeedConfigObject):
                                      AUTOTUNING_FAST,
                                      AUTOTUNING_FAST_DEFAULT)
 
-        self.results_dir = get_scalar_param(autotuning_dict,
+        self.results_dir = os.path.abspath(get_scalar_param(autotuning_dict,
                                             AUTOTUNING_RESULTS_DIR,
-                                            AUTOTUNING_RESULTS_DIR_DEFAULT)
-
-        self.exps_dir = get_scalar_param(autotuning_dict,
+                                            AUTOTUNING_RESULTS_DIR_DEFAULT))
+        assert self.results_dir, "results_dir cannot be empty"
+        self.exps_dir = os.path.abspath(get_scalar_param(autotuning_dict,
                                          AUTOTUNING_EXPS_DIR,
-                                         AUTOTUNING_EXPS_DIR_DEFAULT)
-
+                                         AUTOTUNING_EXPS_DIR_DEFAULT))
+        assert self.exps_dir, "exps_dir cannot be empty"
         self.overwrite = get_scalar_param(autotuning_dict,
                                           AUTOTUNING_OVERWRITE,
                                           AUTOTUNING_OVERWRITE_DEFAULT)

--- a/deepspeed/autotuning/constants.py
+++ b/deepspeed/autotuning/constants.py
@@ -22,8 +22,8 @@ DEFAULT_TEMPLATE_PATH_ZERO_3 = os.path.join(os.path.dirname(os.path.realpath(__f
                                             "config_templates",
                                             "template_zero3.json")
 
-DEFAULT_EXPRS_DIR = os.path.join(os.getcwd(), "autotuning_exps")
-DEFAULT_RESULTS_DIR = os.path.join(os.getcwd(), "autotuning_results")
+# DEFAULT_EXPRS_DIR = os.path.join(os.getcwd(), "autotuning_exps")
+# DEFAULT_RESULTS_DIR = os.path.join(os.getcwd(), "autotuning_results")
 
 METRIC_PERCENT_DIFF_CONST = 0.05
 DS_CONFIG = "ds_config"
@@ -54,10 +54,10 @@ AUTOTUNING_FAST = "fast"
 AUTOTUNING_FAST_DEFAULT = True
 
 AUTOTUNING_RESULTS_DIR = "results_dir"
-AUTOTUNING_RESULTS_DIR_DEFAULT = None
+AUTOTUNING_RESULTS_DIR_DEFAULT = "autotuning_results"
 
 AUTOTUNING_EXPS_DIR = "exps_dir"
-AUTOTUNING_EXPS_DIR_DEFAULT = None
+AUTOTUNING_EXPS_DIR_DEFAULT = "autotuning_exps"
 
 AUTOTUNING_OVERWRITE = "overwrite"
 AUTOTUNING_OVERWRITE_DEFAULT = True

--- a/deepspeed/profiling/flops_profiler/profiler.py
+++ b/deepspeed/profiling/flops_profiler/profiler.py
@@ -254,7 +254,7 @@ class FlopsProfiler(object):
         original_stdout = None
         f = None
         if output_file and output_file != "":
-            dir_path = os.path.dirname(output_file)
+            dir_path = os.path.dirname(os.path.abspath(output_file))
             if not os.path.exists(dir_path):
                 os.makedirs(dir_path)
             original_stdout = sys.stdout

--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -8,6 +8,7 @@ from typing import Union
 import torch
 import json
 import copy
+import base64
 
 from .constants import *
 from .fp16.loss_scaler import (
@@ -707,9 +708,13 @@ class DeepSpeedConfig(object):
                      "r"),
                 object_pairs_hook=dict_raise_error_on_duplicate_keys)
         else:
-            raise ValueError(
-                f"Expected a string path to an existing deepspeed config, or a dictionary. Received: {config}"
-            )
+            try:
+                config_decoded = base64.urlsafe_b64decode(config).decode('utf-8')
+                self._param_dict = json.loads(config_decoded)
+            except (UnicodeDecodeError, AttributeError):
+                raise ValueError(
+                    f"Expected a string path to an existing deepspeed config, or a dictionary. Received: {config}"
+                )
         try:
             self.global_rank = dist.get_rank()
             if mpu is None:

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -924,12 +924,6 @@ class DeepSpeedEngine(Module):
                     args, "deepspeed_config") and args.deepspeed_config is not None
             ), "DeepSpeed requires --deepspeed_config to specify configuration file"
 
-            assert os.path.isfile(
-                args.deepspeed_config
-            ), "DeepSpeed configuration file: {} is not an existing file".format(
-                args.deepspeed_config
-            )
-
     def _is_supported_optimizer(self, optimizer_name):
         return (optimizer_name in DEEPSPEED_OPTIMIZERS
                 or getattr(torch.optim,


### PR DESCRIPTION
This PR allows user to pass in base64 encoded json dict as command line argument for "--deepspeed" or "--deespeed_config", and thus enabling the autotuner to launch jobs on remote workers without copying over the config file. 