### PR TITLE
CI fixes related to triton

### DIFF
--- a/.github/workflows/amd.yml
+++ b/.github/workflows/amd.yml
@@ -35,7 +35,7 @@ jobs:
           which hipcc
           hipcc --version
           pip install --upgrade pip
-          pip uninstall --yes torch torchvision
+          pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/rocm5.1.1
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"

--- a/.github/workflows/nv-accelerate-v100.yml
+++ b/.github/workflows/nv-accelerate-v100.yml
@@ -31,7 +31,7 @@ jobs:
           which nvcc
           nvcc --version
           pip install --upgrade pip
-          pip uninstall --yes torch torchvision
+          pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu111
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -31,7 +31,7 @@ jobs:
           which nvcc
           nvcc --version
           pip install --upgrade pip
-          pip uninstall --yes torch torchvision
+          pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu113
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install deepspeed
         run: |
           pip uninstall --yes deepspeed
-          pip install .[dev,1bit,autotuning,sparse_attn,inf]
+          pip install .[dev,1bit,autotuning,inf]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-nightly.yml
+++ b/.github/workflows/nv-nightly.yml
@@ -24,7 +24,7 @@ jobs:
           which nvcc
           nvcc --version
           pip install --upgrade pip
-          pip uninstall --yes torch torchvision
+          pip uninstall --yes torch torchvision triton
           pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"

--- a/.github/workflows/nv-nightly.yml
+++ b/.github/workflows/nv-nightly.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install deepspeed
         run: |
           pip uninstall --yes deepspeed
-          pip install .[dev,1bit,autotuning,sparse_attn,inf]
+          pip install .[dev,1bit,autotuning,inf]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -31,7 +31,7 @@ jobs:
           which nvcc
           nvcc --version
           pip install --upgrade pip
-          pip uninstall --yes torch torchvision
+          pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu113
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install deepspeed
         run: |
           pip uninstall --yes deepspeed
-          pip install .[dev,1bit,autotuning,sparse_attn]
+          pip install .[dev,1bit,autotuning]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -24,7 +24,7 @@ jobs:
           which nvcc
           nvcc --version
           pip install --upgrade pip
-          pip uninstall --yes torch torchvision
+          pip uninstall --yes torch torchvision triton
           pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cu113
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install deepspeed
         run: |
           pip uninstall --yes deepspeed
-          pip install .[dev,1bit,autotuning,sparse_attn]
+          pip install .[dev,1bit,autotuning]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch18-p40.yml
+++ b/.github/workflows/nv-torch18-p40.yml
@@ -31,7 +31,7 @@ jobs:
           which nvcc
           nvcc --version
           pip install --upgrade pip
-          pip uninstall --yes torch torchvision
+          pip uninstall --yes torch torchvision triton
           pip install torch==1.8.2 torchvision==0.9.2 --extra-index-url https://download.pytorch.org/whl/lts/1.8/cu101
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"

--- a/.github/workflows/nv-torch18-p40.yml
+++ b/.github/workflows/nv-torch18-p40.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install deepspeed
         run: |
           pip uninstall --yes deepspeed
-          pip install .[dev,1bit,autotuning,sparse_attn]
+          pip install .[dev,1bit,autotuning]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-torch18-v100.yml
+++ b/.github/workflows/nv-torch18-v100.yml
@@ -31,7 +31,7 @@ jobs:
           which nvcc
           nvcc --version
           pip install --upgrade pip
-          pip uninstall --yes torch torchvision
+          pip uninstall --yes torch torchvision triton
           pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"

--- a/.github/workflows/nv-torch18-v100.yml
+++ b/.github/workflows/nv-torch18-v100.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install deepspeed
         run: |
           pip uninstall --yes deepspeed
-          pip install .[dev,1bit,autotuning,sparse_attn]
+          pip install .[dev,1bit,autotuning]
           ds_report
 
       - name: Unit tests

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -31,7 +31,7 @@ jobs:
           which nvcc
           nvcc --version
           pip install --upgrade pip
-          pip uninstall --yes torch torchvision
+          pip uninstall --yes torch torchvision triton
           pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"


### PR DESCRIPTION
Ensure that triton is not installed on our CI nodes, with upcoming triton 2.0 dependency this will conflict with sparse attn triton 1.0 dependency.