### PR TITLE
only add deps if extra is explicitly called

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -407,18 +407,6 @@ class OpBuilder(ABC):
                 return '-D__AVX256__'
         return '-D__SCALAR__'
 
-    def python_requirements(self):
-        '''
-        Override if op wants to define special dependencies, otherwise will
-        take self.name and load requirements-<op-name>.txt if it exists.
-        '''
-        path = f'requirements/requirements-{self.name}.txt'
-        requirements = []
-        if os.path.isfile(path):
-            with open(path, 'r') as fd:
-                requirements = [r.strip() for r in fd.readlines()]
-        return requirements
-
     def command_exists(self, cmd):
         if '|' in cmd:
             cmds = cmd.split("|")

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ extras_require = {
     'autotuning': fetch_requirements('requirements/requirements-autotuning.txt'),
     'autotuning_ml': fetch_requirements('requirements/requirements-autotuning-ml.txt'),
     'sparse_attn': fetch_requirements('requirements/requirements-sparse_attn.txt'),
-    'inf': fetch_requirements('requirements/requirements-inf.txt')
+    'inf': fetch_requirements('requirements/requirements-inf.txt'),
+    'sd': fetch_requirements('requirements/requirements-sd.txt')
 }
 
 # Add specific cupy version to both onebit extension variants
@@ -149,11 +150,6 @@ for op_name, builder in ALL_OPS.items():
         if env_var not in os.environ:
             builder.warning(f"One can disable {op_name} with {env_var}=0")
         abort(f"Unable to pre-compile {op_name}")
-
-    # If op is compatible update install reqs so it can potentially build/run later
-    if op_compatible:
-        reqs = builder.python_requirements()
-        install_requires += builder.python_requirements()
 
     # if op is compatible but install is not enabled (JIT mode)
     if is_rocm_pytorch and op_compatible and not op_enabled(op_name):


### PR DESCRIPTION
Now that we have two features that depend on different triton versions we can no longer assume what triton version to install. Sparse attn was the only op that used this feature but previous to this PR we added triton to the dependency list iff it was detected as compatible during install time. This was causing version conflicts if we wanted to install the `sd` extra that requires triton 2.0.0. Also the `sd` extra was missing from setup.py, this PR adds it in.