### PR TITLE
Fix broken link to DeepSpeed Megatron fork

### DIFF
--- a/docs/_tutorials/megatron.md
+++ b/docs/_tutorials/megatron.md
@@ -19,7 +19,7 @@ reduction_** from using DeepSpeed.
 
 ## Training GPT-2 with the Original Megatron-LM
 
-We've copied the original model code from [Megatron-LM](https://github.com/NVIDIA/Megatron-LM) into DeepSpeed [Megatron-LM](https://github.com/microsoft/DeepSpeedExamples/tree/master/Megatron-LM-v1.1.5-ZeRO3) and made it available as a submodule. To download, execute:
+We've copied the original model code from [Megatron-LM](https://github.com/NVIDIA/Megatron-LM) into DeepSpeed [Megatron-LM](https://github.com/microsoft/Megatron-DeepSpeed) and made it available as a submodule. To download, execute:
 ```bash
 git submodule update --init --recursive
 ```


### PR DESCRIPTION
This PR fixes a broken link pointing to the DeepSpeed Megatron fork in the `megatron.md` tutorial.