### PR TITLE
Fixing a config mismatch in unit test.

### DIFF
--- a/tests/unit/runtime/half_precision/test_fp16.py
+++ b/tests/unit/runtime/half_precision/test_fp16.py
@@ -534,7 +534,7 @@ class TestAmp(DistributedTest):
 
     def test_adam_basic(self):
         config_dict = {
-            "train_batch_size": 1,
+            "train_batch_size": 2,
             "steps_per_print": 1,
             "amp": {
                 "enabled": True


### PR DESCRIPTION
There was a mismatch between `world_size` and `train_batch_size` that was causing a failure when running `unit/runtime/half_precision/test_fp16.py::TestAmp::test_adam_basic`.