### PR TITLE
Updating autotune json default in docs.

### DIFF
--- a/csrc/lamb/fused_lamb_cuda_kernel.cu
+++ b/csrc/lamb/fused_lamb_cuda_kernel.cu
@@ -7,12 +7,12 @@
 #include "ATen/TensorUtils.h"
 #include "ATen/cuda/CUDAContext.h"
 #include "ATen/cuda/detail/IndexUtils.cuh"
-//#include "ATen/Type.h"
+// #include "ATen/Type.h"
 #include "ATen/AccumulateType.h"
 
 #include <iostream>
 
-//#include <helper_functions.h>
+// #include <helper_functions.h>
 #if defined(__HIP_PLATFORM_HCC__) && HIP_VERSION > 305
 #include <hip/hip_cooperative_groups.h>
 #else

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -652,8 +652,8 @@ Configuring the asynchronous I/O module for offloading parameter and optimizer s
 {
   "autotuning": {
     "enabled": false,
-    "results_dir": null,
-    "exps_dir": null,
+    "results_dir": "autotuning_results",
+    "exps_dir": "autotuning_exps",
     "overwrite": false,
     "metric": "throughput",
     "start_profile_step": 3,
@@ -678,15 +678,15 @@ Configuring the asynchronous I/O module for offloading parameter and optimizer s
 
 <i>**results_dir**</i>: [string]
 
-| Description                                                                                                                      | Default |
-| -------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| Path to the autotuning experiment results directory. If None, "autotuning_results" under the training script launching path is used. | `null`  |
+| Description                                                                                                                           | Default |
+| ------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| Path to the autotuning experiment results directory.  The default appears in the working directory from which Deepspeed was launched. | "autotuning_results"  |
 
 <i>**exps_dir**</i>: [string]
 
-| Description                                                                                                                        | Default |
-| ---------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| Path to the auotuning experiment descriptions directory. If None, "autotuning_exps" under the train script launching path is used. | `null`  |
+| Description                                                                                                                              | Default |
+| ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| Path to the auotuning experiment descriptions directory. The default appears in the working directory from which Deepspeed was launched. | "autotuning_exps"  |
 
 <i>**overwrite**</i>: [boolean]
 


### PR DESCRIPTION
Changing the defaults listed in the docs for the autotune json from `null` to the values found in constants.py. Addresses the issues found in bug [2373](https://github.com/microsoft/DeepSpeed/issues/2473).