### PR TITLE
Fix CI issues related to cupy install

### DIFF
--- a/.github/workflows/amd.yml
+++ b/.github/workflows/amd.yml
@@ -37,6 +37,12 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/rocm5.1.1
+          # Since the cupy install that happens in DS's setup.py gets the cuda
+          # version from pytorch/driver api (and not nvcc/runtime api), it's
+          # possible that when torch releases a new version, the DS install
+          # will install a new version of cupy. The resulting environment
+          # causes an error when import cupy. To avoid this, we uninstall cupy.
+          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
           sudo apt-get update

--- a/.github/workflows/amd.yml
+++ b/.github/workflows/amd.yml
@@ -37,12 +37,6 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/rocm5.1.1
-          # Since the cupy install that happens in DS's setup.py gets the cuda
-          # version from pytorch/driver api (and not nvcc/runtime api), it's
-          # possible that when torch releases a new version, the DS install
-          # will install a new version of cupy. The resulting environment
-          # causes an error when import cupy. To avoid this, we uninstall cupy.
-          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
           sudo apt-get update

--- a/.github/workflows/amd.yml
+++ b/.github/workflows/amd.yml
@@ -42,10 +42,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libaio-dev
 
-      - name: Python environment
-        run: |
-          pip list
-
       - name: Install transformers
         run: |
           git clone https://github.com/huggingface/transformers
@@ -61,6 +57,10 @@ jobs:
           pip install .[dev,1bit,autotuning]
           #python -c "from deepspeed.env_report import cli_main; cli_main()"
           ds_report
+
+      - name: Python environment
+        run: |
+          pip list
 
       # Runs a set of commands using the runners shell
       - name: Unit tests

--- a/.github/workflows/nv-accelerate-v100.yml
+++ b/.github/workflows/nv-accelerate-v100.yml
@@ -36,15 +36,15 @@ jobs:
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
-      - name: Python environment
-        run: |
-          pip list
-
       - name: Install deepspeed
         run: |
           pip uninstall --yes deepspeed
           pip install .[dev,autotuning]
           ds_report
+
+      - name: Python environment
+        run: |
+          pip list
 
       - name: HF Accelerate tests
         run: |

--- a/.github/workflows/nv-accelerate-v100.yml
+++ b/.github/workflows/nv-accelerate-v100.yml
@@ -33,12 +33,6 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu111
-          # Since the cupy install that happens in DS's setup.py gets the cuda
-          # version from pytorch/driver api (and not nvcc/runtime api), it's
-          # possible that when torch releases a new version, the DS install
-          # will install a new version of cupy. The resulting environment
-          # causes an error when import cupy. To avoid this, we uninstall cupy.
-          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-accelerate-v100.yml
+++ b/.github/workflows/nv-accelerate-v100.yml
@@ -33,6 +33,12 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu111
+          # Since the cupy install that happens in DS's setup.py gets the cuda
+          # version from pytorch/driver api (and not nvcc/runtime api), it's
+          # possible that when torch releases a new version, the DS install
+          # will install a new version of cupy. The resulting environment
+          # causes an error when import cupy. To avoid this, we uninstall cupy.
+          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -33,6 +33,12 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch==1.12.0 torchvision --extra-index-url https://download.pytorch.org/whl/cu113
+          # Since the cupy install that happens in DS's setup.py gets the cuda
+          # version from pytorch/driver api (and not nvcc/runtime api), it's
+          # possible that when torch releases a new version, the DS install
+          # will install a new version of cupy. The resulting environment
+          # causes an error when import cupy. To avoid this, we uninstall cupy.
+          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -50,15 +50,15 @@ jobs:
           pip uninstall --yes transformers
           pip install .
 
-      - name: Python environment
-        run: |
-          pip list
-
       - name: Install deepspeed
         run: |
           pip uninstall --yes deepspeed
           pip install .[dev,1bit,autotuning,inf]
           ds_report
+
+      - name: Python environment
+        run: |
+          pip list
 
       - name: Unit tests
         run: |

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: [self-hosted, nvidia, cu113, v100]
+    runs-on: [self-hosted, nvidia, cu116, v100]
 
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
           nvcc --version
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
-          pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu113
+          pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu116
           # Since the cupy install that happens in DS's setup.py gets the cuda
           # version from pytorch/driver api (and not nvcc/runtime api), it's
           # possible that when torch releases a new version, the DS install

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -33,12 +33,6 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu116
-          # Since the cupy install that happens in DS's setup.py gets the cuda
-          # version from pytorch/driver api (and not nvcc/runtime api), it's
-          # possible that when torch releases a new version, the DS install
-          # will install a new version of cupy. The resulting environment
-          # causes an error when import cupy. To avoid this, we uninstall cupy.
-          pip list | grep -Po "cupy[^\s]*" | xargs --no-run-if-empty pip uninstall --yes
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -65,5 +59,5 @@ jobs:
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
           cd tests
-          TRANSFORMERS_CACHE=/blob/transformers_cache/ TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose -m 'seq_inference' unit/ --cuda_ver="11"
-          TRANSFORMERS_CACHE=/blob/transformers_cache/ TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 -n 4 --verbose -m 'inference' unit/ --cuda_ver="11"
+          TRANSFORMERS_CACHE=/blob/transformers_cache/ TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose -m 'seq_inference' unit/ --torch_ver="1.13" --cuda_ver="11.6"
+          TRANSFORMERS_CACHE=/blob/transformers_cache/ TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked -n 4 --verbose -m 'inference' unit/ --torch_ver="1.13" --cuda_ver="11.6"

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -38,7 +38,7 @@ jobs:
           # possible that when torch releases a new version, the DS install
           # will install a new version of cupy. The resulting environment
           # causes an error when import cupy. To avoid this, we uninstall cupy.
-          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
+          pip list | grep -Po "cupy[^\s]*" | xargs --no-run-if-empty pip uninstall --yes
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: [self-hosted, nvidia, cu111, v100]
+    runs-on: [self-hosted, nvidia, cu113, v100]
 
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
           nvcc --version
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
-          pip install torch==1.12.0 torchvision --extra-index-url https://download.pytorch.org/whl/cu113
+          pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu113
           # Since the cupy install that happens in DS's setup.py gets the cuda
           # version from pytorch/driver api (and not nvcc/runtime api), it's
           # possible that when torch releases a new version, the DS install

--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -36,15 +36,15 @@ jobs:
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
-      - name: Python environment
-        run: |
-          pip list
-
       - name: Install deepspeed
         run: |
           pip uninstall --yes deepspeed
           pip install .[dev,autotuning]
           ds_report
+
+      - name: Python environment
+        run: |
+          pip list
 
       - name: PyTorch Lightning Tests
         run: |

--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -33,12 +33,6 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision
           pip install torch==1.9.1+cu111 torchvision==0.10.1+cu111 torchaudio==0.9.1 -f https://download.pytorch.org/whl/torch_stable.html
-          # Since the cupy install that happens in DS's setup.py gets the cuda
-          # version from pytorch/driver api (and not nvcc/runtime api), it's
-          # possible that when torch releases a new version, the DS install
-          # will install a new version of cupy. The resulting environment
-          # causes an error when import cupy. To avoid this, we uninstall cupy.
-          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -33,6 +33,12 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision
           pip install torch==1.9.1+cu111 torchvision==0.10.1+cu111 torchaudio==0.9.1 -f https://download.pytorch.org/whl/torch_stable.html
+          # Since the cupy install that happens in DS's setup.py gets the cuda
+          # version from pytorch/driver api (and not nvcc/runtime api), it's
+          # possible that when torch releases a new version, the DS install
+          # will install a new version of cupy. The resulting environment
+          # causes an error when import cupy. To avoid this, we uninstall cupy.
+          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-nightly.yml
+++ b/.github/workflows/nv-nightly.yml
@@ -25,13 +25,7 @@ jobs:
           nvcc --version
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
-          pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cu116
-          # Since the cupy install that happens in DS's setup.py gets the cuda
-          # version from pytorch/driver api (and not nvcc/runtime api), it's
-          # possible that when torch releases a new version, the DS install
-          # will install a new version of cupy. The resulting environment
-          # causes an error when import cupy. To avoid this, we uninstall cupy.
-          pip list | grep -Po "cupy[^\s]*" | xargs --no-run-if-empty pip uninstall --yes
+          pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu116
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -60,4 +54,4 @@ jobs:
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
           cd tests
-          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -m 'nightly' unit/ --torch_ver="1.8" --cuda_ver="11"
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -m 'nightly' unit/ --torch_ver="1.13" --cuda_ver="11.6"

--- a/.github/workflows/nv-nightly.yml
+++ b/.github/workflows/nv-nightly.yml
@@ -51,6 +51,10 @@ jobs:
           pip install .[dev,1bit,autotuning,inf]
           ds_report
 
+      - name: Python environment
+        run: |
+          pip list
+
       - name: Unit tests
         run: |
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch

--- a/.github/workflows/nv-nightly.yml
+++ b/.github/workflows/nv-nightly.yml
@@ -26,6 +26,12 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+          # Since the cupy install that happens in DS's setup.py gets the cuda
+          # version from pytorch/driver api (and not nvcc/runtime api), it's
+          # possible that when torch releases a new version, the DS install
+          # will install a new version of cupy. The resulting environment
+          # causes an error when import cupy. To avoid this, we uninstall cupy.
+          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-nightly.yml
+++ b/.github/workflows/nv-nightly.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: [self-hosted, nvidia, cu111, v100]
+    runs-on: [self-hosted, nvidia, cu116, v100]
 
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
           nvcc --version
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
-          pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+          pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cu116
           # Since the cupy install that happens in DS's setup.py gets the cuda
           # version from pytorch/driver api (and not nvcc/runtime api), it's
           # possible that when torch releases a new version, the DS install

--- a/.github/workflows/nv-nightly.yml
+++ b/.github/workflows/nv-nightly.yml
@@ -31,7 +31,7 @@ jobs:
           # possible that when torch releases a new version, the DS install
           # will install a new version of cupy. The resulting environment
           # causes an error when import cupy. To avoid this, we uninstall cupy.
-          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
+          pip list | grep -Po "cupy[^\s]*" | xargs --no-run-if-empty pip uninstall --yes
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: [self-hosted, nvidia, cu111, v100]
+    runs-on: [self-hosted, nvidia, cu113, v100]
 
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
           nvcc --version
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
-          pip install torch==1.12.0 torchvision --extra-index-url https://download.pytorch.org/whl/cu113 # Need to resolve errors with torch==1.13.0
+          pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu113
           # Since the cupy install that happens in DS's setup.py gets the cuda
           # version from pytorch/driver api (and not nvcc/runtime api), it's
           # possible that when torch releases a new version, the DS install

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -61,5 +61,5 @@ jobs:
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
           cd tests
-          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose -n 4 unit/ --torch_ver="1.13" --cuda_ver="11.6"
-          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose -m 'sequential' unit/ --torch_ver="1.13" --cuda_ver="11.6"
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose --forked -n 4 unit/ --torch_ver="1.13" --cuda_ver="11.6"
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose --forked -m 'sequential' unit/ --torch_ver="1.13" --cuda_ver="11.6"

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -33,12 +33,6 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu116
-          # Since the cupy install that happens in DS's setup.py gets the cuda
-          # version from pytorch/driver api (and not nvcc/runtime api), it's
-          # possible that when torch releases a new version, the DS install
-          # will install a new version of cupy. The resulting environment
-          # causes an error when import cupy. To avoid this, we uninstall cupy.
-          pip list | grep -Po "cupy[^\s]*" | xargs --no-run-if-empty pip uninstall --yes
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -67,5 +61,5 @@ jobs:
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
           cd tests
-          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose -n 4 unit/ --torch_ver="1.12" --cuda_ver="11"
-          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose -m 'sequential' unit/ --torch_ver="1.12" --cuda_ver="11"
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose -n 4 unit/ --torch_ver="1.13" --cuda_ver="11.6"
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose -m 'sequential' unit/ --torch_ver="1.13" --cuda_ver="11.6"

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -33,7 +33,12 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch==1.12.0 torchvision --extra-index-url https://download.pytorch.org/whl/cu113 # Need to resolve errors with torch==1.13.0
-          pip install cupy-cuda113
+          # Since the cupy install that happens in DS's setup.py gets the cuda
+          # version from pytorch/driver api (and not nvcc/runtime api), it's
+          # possible that when torch releases a new version, the DS install
+          # will install a new version of cupy. The resulting environment
+          # causes an error when import cupy. To avoid this, we uninstall cupy.
+          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: [self-hosted, nvidia, cu113, v100]
+    runs-on: [self-hosted, nvidia, cu116, v100]
 
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
           nvcc --version
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
-          pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu113
+          pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu116
           # Since the cupy install that happens in DS's setup.py gets the cuda
           # version from pytorch/driver api (and not nvcc/runtime api), it's
           # possible that when torch releases a new version, the DS install

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -52,15 +52,15 @@ jobs:
           pip uninstall --yes transformers
           pip install .
 
-      - name: Python environment
-        run: |
-          pip list
-
       - name: Install deepspeed
         run: |
           pip uninstall --yes deepspeed
           pip install .[dev,1bit,autotuning]
           ds_report
+
+      - name: Python environment
+        run: |
+          pip list
 
       - name: Unit tests
         run: |

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -38,7 +38,7 @@ jobs:
           # possible that when torch releases a new version, the DS install
           # will install a new version of cupy. The resulting environment
           # causes an error when import cupy. To avoid this, we uninstall cupy.
-          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
+          pip list | grep -Po "cupy[^\s]*" | xargs --no-run-if-empty pip uninstall --yes
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -26,12 +26,6 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cu116
-          # Since the cupy install that happens in DS's setup.py gets the cuda
-          # version from pytorch/driver api (and not nvcc/runtime api), it's
-          # possible that when torch releases a new version, the DS install
-          # will install a new version of cupy. The resulting environment
-          # causes an error when import cupy. To avoid this, we uninstall cupy.
-          pip list | grep -Po "cupy[^\s]*" | xargs --no-run-if-empty pip uninstall --yes
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -26,6 +26,12 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cu113
+          # Since the cupy install that happens in DS's setup.py gets the cuda
+          # version from pytorch/driver api (and not nvcc/runtime api), it's
+          # possible that when torch releases a new version, the DS install
+          # will install a new version of cupy. The resulting environment
+          # causes an error when import cupy. To avoid this, we uninstall cupy.
+          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -45,15 +45,15 @@ jobs:
           pip uninstall --yes transformers
           pip install .
 
-      - name: Python environment
-        run: |
-          pip list
-
       - name: Install deepspeed
         run: |
           pip uninstall --yes deepspeed
           pip install .[dev,1bit,autotuning]
           ds_report
+
+      - name: Python environment
+        run: |
+          pip list
 
       - name: Unit tests
         run: |

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -31,7 +31,7 @@ jobs:
           # possible that when torch releases a new version, the DS install
           # will install a new version of cupy. The resulting environment
           # causes an error when import cupy. To avoid this, we uninstall cupy.
-          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
+          pip list | grep -Po "cupy[^\s]*" | xargs --no-run-if-empty pip uninstall --yes
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: [self-hosted, nvidia, cu113, v100]
+    runs-on: [self-hosted, nvidia, cu116, v100]
 
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
           nvcc --version
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
-          pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cu113
+          pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cu116
           # Since the cupy install that happens in DS's setup.py gets the cuda
           # version from pytorch/driver api (and not nvcc/runtime api), it's
           # possible that when torch releases a new version, the DS install

--- a/.github/workflows/nv-torch18-p40.yml
+++ b/.github/workflows/nv-torch18-p40.yml
@@ -33,12 +33,6 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch==1.8.2 torchvision==0.9.2 --extra-index-url https://download.pytorch.org/whl/lts/1.8/cu101
-          # Since the cupy install that happens in DS's setup.py gets the cuda
-          # version from pytorch/driver api (and not nvcc/runtime api), it's
-          # possible that when torch releases a new version, the DS install
-          # will install a new version of cupy. The resulting environment
-          # causes an error when import cupy. To avoid this, we uninstall cupy.
-          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-torch18-p40.yml
+++ b/.github/workflows/nv-torch18-p40.yml
@@ -60,4 +60,4 @@ jobs:
         run: |
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
           cd tests
-          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -n 4 unit/ --torch_ver="1.8" --cuda_ver="10"
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -n 4 unit/ --torch_ver="1.8" --cuda_ver="10.1"

--- a/.github/workflows/nv-torch18-p40.yml
+++ b/.github/workflows/nv-torch18-p40.yml
@@ -36,10 +36,6 @@ jobs:
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
-      - name: Python environment
-        run: |
-          pip list
-
       - name: Install transformers
         run: |
           git clone https://github.com/huggingface/transformers
@@ -55,6 +51,10 @@ jobs:
           pip uninstall --yes deepspeed
           pip install .[dev,1bit,autotuning]
           ds_report
+
+      - name: Python environment
+        run: |
+          pip list
 
       - name: Unit tests
         run: |

--- a/.github/workflows/nv-torch18-p40.yml
+++ b/.github/workflows/nv-torch18-p40.yml
@@ -33,6 +33,12 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch==1.8.2 torchvision==0.9.2 --extra-index-url https://download.pytorch.org/whl/lts/1.8/cu101
+          # Since the cupy install that happens in DS's setup.py gets the cuda
+          # version from pytorch/driver api (and not nvcc/runtime api), it's
+          # possible that when torch releases a new version, the DS install
+          # will install a new version of cupy. The resulting environment
+          # causes an error when import cupy. To avoid this, we uninstall cupy.
+          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-torch18-v100.yml
+++ b/.github/workflows/nv-torch18-v100.yml
@@ -46,15 +46,15 @@ jobs:
           pip uninstall --yes transformers
           pip install .
 
-      - name: Python environment
-        run: |
-          pip list
-
       - name: Install deepspeed
         run: |
           pip uninstall --yes deepspeed
           pip install .[dev,1bit,autotuning]
           ds_report
+
+      - name: Python environment
+        run: |
+          pip list
 
       - name: Unit tests
         run: |

--- a/.github/workflows/nv-torch18-v100.yml
+++ b/.github/workflows/nv-torch18-v100.yml
@@ -33,12 +33,6 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
-          # Since the cupy install that happens in DS's setup.py gets the cuda
-          # version from pytorch/driver api (and not nvcc/runtime api), it's
-          # possible that when torch releases a new version, the DS install
-          # will install a new version of cupy. The resulting environment
-          # causes an error when import cupy. To avoid this, we uninstall cupy.
-          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-torch18-v100.yml
+++ b/.github/workflows/nv-torch18-v100.yml
@@ -33,6 +33,12 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+          # Since the cupy install that happens in DS's setup.py gets the cuda
+          # version from pytorch/driver api (and not nvcc/runtime api), it's
+          # possible that when torch releases a new version, the DS install
+          # will install a new version of cupy. The resulting environment
+          # causes an error when import cupy. To avoid this, we uninstall cupy.
+          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -38,15 +38,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libaio-dev
 
-      - name: Python environment
-        run: |
-          pip list
-
       - name: Install deepspeed
         run: |
           pip uninstall --yes deepspeed
           pip install .[dev,autotuning]
           ds_report
+
+      - name: Python environment
+        run: |
+          pip list
 
       - name: HF transformers tests
         run: |

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -33,6 +33,12 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
+          # Since the cupy install that happens in DS's setup.py gets the cuda
+          # version from pytorch/driver api (and not nvcc/runtime api), it's
+          # possible that when torch releases a new version, the DS install
+          # will install a new version of cupy. The resulting environment
+          # causes an error when import cupy. To avoid this, we uninstall cupy.
+          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
           sudo apt-get update

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -33,12 +33,6 @@ jobs:
           pip install --upgrade pip
           pip uninstall --yes torch torchvision triton
           pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
-          # Since the cupy install that happens in DS's setup.py gets the cuda
-          # version from pytorch/driver api (and not nvcc/runtime api), it's
-          # possible that when torch releases a new version, the DS install
-          # will install a new version of cupy. The resulting environment
-          # causes an error when import cupy. To avoid this, we uninstall cupy.
-          pip uninstall --yes $(pip list | grep -Po "cupy[^\s]*" | tr '\n' ' ')
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
           sudo apt-get update

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ except ImportError:
         'Please visit https://pytorch.org/ to see how to properly install torch on your system.')
 
 from op_builder import ALL_OPS, get_default_compute_capabilities, OpBuilder
+from op_builder.builder import installed_cuda_version
 
 # fetch rocm state
 is_rocm_pytorch = OpBuilder.is_rocm_pytorch()
@@ -74,7 +75,7 @@ if torch_available and torch.cuda.is_available():
         if rocm_major <= 4:
             cupy = f"cupy-rocm-{rocm_major}-{rocm_minor}"
     else:
-        cupy = f"cupy-cuda{torch.version.cuda.replace('.','')[:3]}"
+        cupy = f"cupy-cuda{''.join(map(str,installed_cuda_version()))}"
     if cupy:
         extras_require['1bit'].append(cupy)
         extras_require['1bit_mpi'].append(cupy)


### PR DESCRIPTION
We were seeing many errors related to installed version of `cupy` or multiple versions of `cupy` installed in our CI. The problem stems from cupy version needing to match with the CUDA runtime version rather than CUDA driver version. For example, if we have CUDA 11.3 runtime (from `nvcc --version`), CUDA 11.6 driver (from `nvidia-smi`), and pytorch installed with version 11.6, then in our `setup.py` we were incorrectly installing the `cupy` version to match the driver version (i.e., 11.6) since we detected the version from `torch.version.cuda`. In this PR I correct that and use the version from `nvcc --version`.

Additionally, a few other changes to update our CI:
- update torch latest from 1.12 -> 1.13
- CI runners for torch latest were updated from CUDA 11.3 -> 11.6
- move the python environment printout to after DeepSpeed install. This was causing trouble when debugging the problem initially, as installing DeepSpeed changes the python environment
- change nv-nightly test to use latest torch version (we are running inference tests here, so this should match nv-inference torch version)