### PR TITLE
Add max_tokens alias to max_out_tokens arg to maintain backwards compatibility

### DIFF
--- a/deepspeed/inference/config.py
+++ b/deepspeed/inference/config.py
@@ -224,7 +224,7 @@ class DeepSpeedInferenceConfig(DeepSpeedConfigModel):
 
     config: Dict = None  # todo: really no need for this field if we can refactor
 
-    max_out_tokens: int = 1024
+    max_out_tokens: int = Field(1024, alias="max_tokens")
     """
     This argument shows the maximum number of tokens inference-engine can work
     with, including the input and output tokens. Please consider increasing it


### PR DESCRIPTION
This PR adds a `max_tokens` alias to the `max_out_tokens` argument in the `init_inference` API to support backwards compatibility after the config refactor PR #2472.

Thanks @molly-smith and @mrwyattii.