### PR TITLE
Fix backward compatibility for InferenceConfig

### DIFF
--- a/.github/workflows/nv-accelerate-v100.yml
+++ b/.github/workflows/nv-accelerate-v100.yml
@@ -51,11 +51,12 @@ jobs:
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
           git clone https://github.com/huggingface/accelerate
           cd accelerate
+          git rev-parse --short HEAD
           # installing dependencies
           pip install .[testing]
           # force protobuf version due to issues
           pip install "protobuf<4.21.0"
           # tmp fix: force newer datasets version
-          pip install "datasets>=2.0.0"
+          #pip install "datasets>=2.0.0"
           pip list
           HF_DATASETS_CACHE=/blob/datasets_cache/ TRANSFORMERS_CACHE=/blob/transformers_cache/ TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose tests/deepspeed

--- a/.github/workflows/nv-accelerate-v100.yml
+++ b/.github/workflows/nv-accelerate-v100.yml
@@ -51,6 +51,8 @@ jobs:
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
           git clone https://github.com/huggingface/accelerate
           cd accelerate
+          # tmp fix
+          git checkout 5f4ba04628eeea14f9d248ab0e54399899503532
           git rev-parse --short HEAD
           # installing dependencies
           pip install .[testing]

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -54,7 +54,7 @@ jobs:
           git clone https://github.com/huggingface/transformers
           cd transformers
           # if needed switch to the last known good SHA until transformers@master is fixed
-          git checkout 6268694e2
+          #git checkout 6268694e2
           git rev-parse --short HEAD
           # scipy/sklearn required for tests, using the 'dev' extra forces torch re-install
           pip install .[testing]


### PR DESCRIPTION
#2472 attempted to conserve backward compatibility with the old `init_inference` interface, but we found that some things had broken based on MII unit tests. This PR fixes the bugs I found and also expands the `DeepSpeedConfigModel` class so that deprecated fields can set values of subfields. To demonstrate, here is an example:

Let's say we have a 2 configs, one nested in the other:
```python
class TPConfig(DeepSpeedConfigModel):
    tp_size: int = 1

class InfConfig(DeepSpeedConfigModel):
    tensor_parallel: TPConfig = {}
    mp_size: int = Field(1, deprecated=True, new_param="tensor_parallel.tp_size")
```

When a value is passed to `mp_size`, the correct value in the nested config will now be set. Previously, we had to write a custom `pydantic.validator` that would handle this.