### PR TITLE
Add note about nvcc/hipcc requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ dynamically link them at runtime.
 ## Requirements
 * [PyTorch](https://pytorch.org/) must be installed _before_ installing DeepSpeed.
 * For full feature support we recommend a version of PyTorch that is >= 1.8 and ideally the latest PyTorch stable release.
+* A CUDA or ROCm compiler such as [nvcc](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/#introduction) or [hipcc](https://github.com/ROCm-Developer-Tools/HIPCC) in order for DeepSpeed to compile our C++/CUDA/HIP extensions
 * Specific GPUs we develop and test against are listed below, this doesn't mean your GPU will not work if it doesn't fall into this category it's just DeepSpeed is most well tested on the following:
-  * NVIDIA: Pascal, Volta, and Ampere architectures
+  * NVIDIA: Pascal, Volta, Ampere, and Hopper architectures
   * AMD: MI100 and MI200
 
 ## PyPI

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ dynamically link them at runtime.
 ## Requirements
 * [PyTorch](https://pytorch.org/) must be installed _before_ installing DeepSpeed.
 * For full feature support we recommend a version of PyTorch that is >= 1.8 and ideally the latest PyTorch stable release.
-* A CUDA or ROCm compiler such as [nvcc](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/#introduction) or [hipcc](https://github.com/ROCm-Developer-Tools/HIPCC) in order for DeepSpeed to compile our C++/CUDA/HIP extensions
+* A CUDA or ROCm compiler such as [nvcc](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/#introduction) or [hipcc](https://github.com/ROCm-Developer-Tools/HIPCC) used to compile C++/CUDA/HIP extensions.
 * Specific GPUs we develop and test against are listed below, this doesn't mean your GPU will not work if it doesn't fall into this category it's just DeepSpeed is most well tested on the following:
   * NVIDIA: Pascal, Volta, Ampere, and Hopper architectures
   * AMD: MI100 and MI200


### PR DESCRIPTION
Add clarification about nvcc/hipcc requirement for deepspeed, came up in https://github.com/microsoft/DeepSpeed/issues/2137.