### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,10 @@
 # This file is used to subscribe for notifications for PRs
 # related to specific file paths, does not necessarily mean
 # approval is required from these people before merging.
+#
+# Learn more about CODEOWNERS syntax here: 
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
 
 # top-level repo folders
 /.github/ @jeffra @mrwyattii

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,20 +15,20 @@
 /op_builder/ @jeffra
 /release/ @jeffra @mrwyattii
 /requirements/ @jeffra @mrwyattii
-/scripts/ @jeffra @awan-10 @Quentin-Anthony
+/scripts/ @jeffra @awan-10
 /tests/ @jeffra @mrwyattii @tjruwase
 
 # deepspeed
 /deepspeed/autotuning/ @cli99
 /deepspeed/checkpoint/ @tjruwase
-/deepspeed/comm/ @awan-10 @Quentin-Anthony
+/deepspeed/comm/ @awan-10
 /deepspeed/compression/ @yaozhewei @minjiaz @xiaoxiawu-microsoft @conglongli
 /deepspeed/elasticity/ @aj-prime @awan-10
 /deepspeed/launcher/ @jeffra @awan-10
 /deepspeed/module_inject/ @RezaYazdaniAminabadi @jeffra @mrwyattii @awan-10 @cmikeh2 @arashb
 /deepspeed/moe/ @awan-10
-/deepspeed/monitor/ @Quentin-Anthony @awan-10 @jeffra
-/deepspeed/nebula/ @trajepl @tjruwase @jeffra
+/deepspeed/monitor/ @awan-10 @jeffra
+/deepspeed/nebula/ @tjruwase @jeffra
 /deepspeed/ops/ @RezaYazdaniAminabadi @jeffra @mrwyattii @awan-10 @cmikeh2 @arashb
 /deepspeed/pipe/ @ShadenSmith @duli2012
 /deepspeed/profiling/ @cli99
@@ -38,11 +38,11 @@
 /deepspeed/inference/ @RezaYazdaniAminabadi @jeffra @mrwyattii @awan-10 @cmikeh2 @arashb
 /deepspeed/model_implementations/ @RezaYazdaniAminabadi @jeffra @mrwyattii @awan-10 @cmikeh2 @arashb
 
-# deepspeed training runtime
+# training
 /deepspeed/runtime/ @jeffra @tjruwase
 /deepspeed/runtime/activation_checkpointing/ @jeffra @tjruwase
-/deepspeed/runtime/checkpoint_engine/ @trajepl @tjruwase @jeffra
-/deepspeed/runtime/comm/ @awan-10 @Quentin-Anthony
+/deepspeed/runtime/checkpoint_engine/ @tjruwase @jeffra
+/deepspeed/runtime/comm/ @awan-10
 /deepspeed/runtime/compression/ @awan-10 @conglongli
 /deepspeed/runtime/data_pipeline/ @conglongli
 /deepspeed/runtime/fp16/ @jeffra @tjruwase

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,7 +16,7 @@
 /docker/ @jeffra @awan-10
 /docs/ @jeffra @mrwyattii
 /examples/ @jeffra @awan-10 @mrwyattii
-/op_builder/ @jeffra
+/op_builder/ @jeffra @RezaYazdaniAminabadi @cmikeh2
 /release/ @jeffra @mrwyattii
 /requirements/ @jeffra @mrwyattii
 /scripts/ @jeffra @awan-10

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,7 +23,7 @@
 /deepspeed/checkpoint/ @tjruwase
 /deepspeed/comm/ @awan-10
 /deepspeed/compression/ @yaozhewei @minjiaz @xiaoxiawu-microsoft @conglongli
-/deepspeed/elasticity/ @aj-prime @awan-10
+/deepspeed/elasticity/ @jeffra @awan-10
 /deepspeed/launcher/ @jeffra @awan-10
 /deepspeed/module_inject/ @RezaYazdaniAminabadi @jeffra @mrwyattii @awan-10 @cmikeh2 @arashb
 /deepspeed/moe/ @awan-10

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # related to specific file paths, does not necessarily mean
 # approval is required from these people before merging.
 #
-# Learn more about CODEOWNERS syntax here: 
+# Learn more about CODEOWNERS syntax here:
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,52 @@
-*       @jeffra @samyam @tjruwase @ShadenSmith @conglongli @awan-10 @cli99 @eltonzheng @minjiaz @RezaYazdaniAminabadi @duli2012 @mrwyattii @yaozhewei @arashb @xiaoxiawu-microsoft @samadejacobs @cmikeh2 @GuanhuaWang
+# This file is used to subscribe for notifications for PRs
+# related to specific file paths, does not necessarily mean
+# approval is required from these people before merging.
+
+# top-level repo folders
+/.github/ @jeffra @mrwyattii
+/azure/ @jeffra @awan-10
+/benchmarks/ @jeffra @awan-10 @mrwyattii @molly-smith
+/bin/ @jeffra
+/csrc/ @RezaYazdaniAminabadi @awan-10 @jeffra @cmikeh2 @arashb
+/deepspeed/ @jeffra
+/docker/ @jeffra @awan-10
+/docs/ @jeffra @mrwyattii
+/examples/ @jeffra @awan-10 @mrwyattii
+/op_builder/ @jeffra
+/release/ @jeffra @mrwyattii
+/requirements/ @jeffra @mrwyattii
+/scripts/ @jeffra @awan-10 @Quentin-Anthony
+/tests/ @jeffra @mrwyattii @tjruwase
+
+# deepspeed
+/deepspeed/autotuning/ @cli99
+/deepspeed/checkpoint/ @tjruwase
+/deepspeed/comm/ @awan-10 @Quentin-Anthony
+/deepspeed/compression/ @yaozhewei @minjiaz @xiaoxiawu-microsoft @conglongli
+/deepspeed/elasticity/ @aj-prime @awan-10
+/deepspeed/launcher/ @jeffra @awan-10
+/deepspeed/module_inject/ @RezaYazdaniAminabadi @jeffra @mrwyattii @awan-10 @cmikeh2 @arashb
+/deepspeed/moe/ @awan-10
+/deepspeed/monitor/ @Quentin-Anthony @awan-10 @jeffra
+/deepspeed/nebula/ @trajepl @tjruwase @jeffra
+/deepspeed/ops/ @RezaYazdaniAminabadi @jeffra @mrwyattii @awan-10 @cmikeh2 @arashb
+/deepspeed/pipe/ @ShadenSmith @duli2012
+/deepspeed/profiling/ @cli99
+/deepspeed/utils/ @jeffra @tjruwase @awan-10
+
+# inference
+/deepspeed/inference/ @RezaYazdaniAminabadi @jeffra @mrwyattii @awan-10 @cmikeh2 @arashb
+/deepspeed/model_implementations/ @RezaYazdaniAminabadi @jeffra @mrwyattii @awan-10 @cmikeh2 @arashb
+
+# deepspeed training runtime
+/deepspeed/runtime/ @jeffra @tjruwase
+/deepspeed/runtime/activation_checkpointing/ @jeffra @tjruwase
+/deepspeed/runtime/checkpoint_engine/ @trajepl @tjruwase @jeffra
+/deepspeed/runtime/comm/ @awan-10 @Quentin-Anthony
+/deepspeed/runtime/compression/ @awan-10 @conglongli
+/deepspeed/runtime/data_pipeline/ @conglongli
+/deepspeed/runtime/fp16/ @jeffra @tjruwase
+/deepspeed/runtime/fp16/onebit/ @conglongli @awan-10
+/deepspeed/runtime/pipe/ @ShadenSmith @duli2012
+/deepspeed/runtime/swap_tensor/ @tjruwase @mrwyattii
+/deepspeed/runtime/zero/ @jeffra @tjruwase @samyam @mrwyattii


### PR DESCRIPTION
Update codeowners to be more targeted, this way not everyone in the team will be notified for all PRs only ones of interest for them.