### PR TITLE
Fix _gelu_flops_compute prototype according to pytorch

### DIFF
--- a/deepspeed/profiling/flops_profiler/profiler.py
+++ b/deepspeed/profiling/flops_profiler/profiler.py
@@ -510,7 +510,7 @@ def _silu_flops_compute(input: Tensor, inplace: bool = False):
     return input.numel(), 0
 
 
-def _gelu_flops_compute(input):
+def _gelu_flops_compute(input, approximate: Optional[str] = None):
     return input.numel(), 0
 
 


### PR DESCRIPTION
Hi DeepSpeed Team,

`F.gelu` in `profiling/flops_profiler/profiler.py` is wrapping PyTorch's `_gelu_flops_compute`. However, PyTorch's and DeepSpeed's `_gelu_flops_compute` don't have the same prototype which causes an error.
This patch fixes DeepSpeed's `_gelu_flops_compute` so that both projects use the same prototype.

Please verify that the rest of DeepSpeed is still working after applying this patch.

I'm using:
- torch==1.13.0
- deepspeed 0.7.5 (commit master 30c8d8a8818ee3585d320469e0777083530a1cc4)