### PR TITLE
Ensure MOE is initialized for SD

### DIFF
--- a/deepspeed/inference/engine.py
+++ b/deepspeed/inference/engine.py
@@ -102,6 +102,8 @@ class InferenceEngine(Module):
 
         if isinstance(self.module, torch.nn.Module):
             moe, _ = has_moe_layers(self.module)
+        else:
+            moe = False
 
         if moe and dist.get_world_size() > 1:
             self._create_ep_parallel_group(config.moe.moe_experts)


### PR DESCRIPTION
Since the pipeline for SD is not a `torch.nn.Module`, we need to ensure that the local `moe` variable is set in the else condition. For now, since we don't support MOE with SD I'm setting it to `False`.

@RezaYazdaniAminabadi @awan-10 @jeffra 