### PR TITLE
Remove mutable default parameter in `init_inference()`

### DIFF
--- a/deepspeed/__init__.py
+++ b/deepspeed/__init__.py
@@ -230,7 +230,7 @@ def default_inference_config():
     return DeepSpeedInferenceConfig().dict()
 
 
-def init_inference(model, config={}, **kwargs):
+def init_inference(model, config=None, **kwargs):
     """Initialize the DeepSpeed InferenceEngine.
 
     Description: all four cases are valid and supported in DS init_inference() API.
@@ -285,6 +285,8 @@ def init_inference(model, config={}, **kwargs):
              ranks=[0])
 
     # Load config_dict from config first
+    if config is None:
+        config = {}
     if isinstance(config, str):
         with open(config, "r") as f:
             config_dict = json.load(f)


### PR DESCRIPTION
A mutable default value is dangerous because editing it will change the value for all future calls to the function. The value is itself edited later in the function, so this problem will likely be encountered sooner or later.

---

I noticed this when was looking over the recent changes. This problem was just introduced in 8b4318b950d09d975c62cd8f4285821fa670ce87.