### PR TITLE
Fix bugs in exp_count and add a boolean flag on whether to use both masks in calculating l_aux

### DIFF
--- a/deepspeed/moe/sharded_moe.py
+++ b/deepspeed/moe/sharded_moe.py
@@ -277,7 +277,8 @@ def top1gating(logits: Tensor,
 
 def top2gating(logits: Tensor,
                capacity_factor: float,
-               min_capacity: int) -> Tuple[Tensor,
+               min_capacity: int,
+               use_both_masks=False) -> Tuple[Tensor,
                                            Tensor,
                                            Tensor,
                                            Tensor]:
@@ -309,12 +310,18 @@ def top2gating(logits: Tensor,
     locations2 += torch.sum(mask1, dim=0, keepdim=True)
 
     # gating decisions
-    exp_counts = torch.sum(mask1, dim=0).detach().to('cpu')
+    exp_counts = torch.sum(mask1 + mask2, dim=0).detach().to('cpu')
 
     # Compute l_aux
     me = torch.mean(gates, dim=0)
-    ce = torch.mean(mask1.float(), dim=0)
-    l_aux = torch.mean(me * ce) * num_experts * num_experts
+    
+    # Whether to use both masks in calculating l_aux
+    if use_both_masks is True:
+        ce = torch.mean((mask1 + mask2).float(), dim=0)
+        l_aux = torch.mean(me * ce) * num_experts * num_experts * 1/2
+    else:
+        ce = torch.mean(mask1.float(), dim=0)
+        l_aux = torch.mean(me * ce) * num_experts * num_experts
 
     # Remove locations outside capacity from mask
     mask1 *= torch.lt(locations1, capacity)


### PR DESCRIPTION
1. Correct the calculation of `exp_count` in top2gating.

2. Add a boolean flag on whether to use both masks in calculating `l_aux`

@awan-10 I'm so sorry that I made some misoperations in recorrecting the pr [#2551](https://github.com/microsoft/DeepSpeed/pull/2551). So I open a new pull request of same content as [#2551](https://github.com/microsoft/DeepSpeed/pull/2551). 
