### PR TITLE
Support fp32 gradaccum for bf16 model

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1130,9 +1130,14 @@ class DeepSpeedEngine(Module):
         ), "Amp and ZeRO are not currently compatible, please use (legacy) fp16 mode which performs similar to amp opt_mode=O2"
         if zero_enabled:
             if model_dtype != grad_accum_dtype:
-                raise NotImplementedError(
-                    "Model data type and gradient accumulation data type must be equal to use ZeRO"
-                )
+                if model_dtype == torch.bfloat16 and grad_accum_dtype == torch.float32:
+                    # when model_dtype is bfloat16, grad_accum_dtype of float32 should be valid, because
+                    # bfloat16 needs fp32 accumulation to maintain accuracy
+                    pass
+                else:
+                    raise NotImplementedError(
+                        "Model data type and gradient accumulation data type must be equal to use ZeRO"
+                    )
             if not is_zero_supported_optimizer(basic_optimizer):
                 assert (
                     self.zero_allow_untested_optimizer()

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1150,9 +1150,14 @@ class DeepSpeedEngine(Module):
             return ZERO_OPTIMIZATION
         elif amp_enabled:
             if model_dtype != grad_accum_dtype:
-                raise NotImplementedError(
-                    "Model data type and gradient accumulation data type must be equal to use Amp"
-                )
+                if model_dtype == torch.bfloat16 and grad_accum_dtype == torch.float32:
+                    # when model_dtype is bfloat16, grad_accum_dtype of float32 should be valid, because
+                    # bfloat16 needs fp32 accumulation to maintain accuracy
+                    pass
+                else:
+                    raise NotImplementedError(
+                        "Model data type and gradient accumulation data type must be equal to use Amp"
+                    )
             if model_dtype == torch.bfloat16 or model_dtype == torch.float16:
                 raise NotImplementedError(
                     "Cannot enable both amp with (legacy) fp16 or bfloat16 mode")


### PR DESCRIPTION
Recently deepspeed added sanity check for optimizer as the following link
https://github.com/microsoft/DeepSpeed/blob/master/deepspeed/runtime/engine.py#L1133

However, FP32 gradient accumulation data type is the default gradient accumulation type for bfloat16 model.   DeepSpeed code itself also set gradient accumulation data type to FP32 for BF16 model.
https://github.com/microsoft/DeepSpeed/blob/master/deepspeed/runtime/engine.py#L811

This PR allows this combination in sanity check, so bfloat16 model can pass sanity check with default configuration.

The following artical mentioned using FP32 accumulation type for BFloat16 datatype.
https://cloud.google.com/blog/products/ai-machine-learning/bfloat16-the-secret-to-high-performance-on-cloud-tpus