### PR TITLE
Fix MegatronLayerPolicy to have megatron_v2=True

### DIFF
--- a/deepspeed/module_inject/replace_policy.py
+++ b/deepspeed/module_inject/replace_policy.py
@@ -405,8 +405,8 @@ class MegatronLayerPolicy(TransformerPolicy):
     version = 0
     moe_type = 'standard'
 
-    def __init__(self, client_module, inference=True):
-        super().__init__(inference)
+    def __init__(self, client_module, inference=True, megatron_v2=True):
+        super().__init__(inference, megatron_v2=megatron_v2)
         self.client_module = client_module
         # we use megatron version to differentiate between the old and new
         # megatron-lm source code

--- a/deepspeed/module_inject/replace_policy.py
+++ b/deepspeed/module_inject/replace_policy.py
@@ -404,9 +404,10 @@ class MegatronLayerPolicy(TransformerPolicy):
     _orig_layer_class = None
     version = 0
     moe_type = 'standard'
+    megatron_v2 = True
 
-    def __init__(self, client_module, inference=True, megatron_v2=True):
-        super().__init__(inference, megatron_v2=megatron_v2)
+    def __init__(self, client_module, inference=True):
+        super().__init__(inference, megatron_v2=MegatronLayerPolicy.megatron_v2)
         self.client_module = client_module
         # we use megatron version to differentiate between the old and new
         # megatron-lm source code


### PR DESCRIPTION
This PR updates the `MegatronLayerPolicy` to set `megatron_v2=True`, which is required in order to properly transpose in the `replace_with_policy()` function.

After the change in this PR, in conjunction with [PR #99](https://github.com/microsoft/Megatron-DeepSpeed/pull/99) in the Megatron-DeepSpeed fork, the Megatron text-generation example works with DS inference.

@RezaYazdaniAminabadi Any feedback is welcome!