### PR TITLE
Optimize megatron unit test time

### DIFF
--- a/.github/workflows/nv-megatron.yml
+++ b/.github/workflows/nv-megatron.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install apex
         run: |
-          pip install -v --disable-pip-version-check --no-cache-dir  git+https://github.com/NVIDIA/apex.git
+          pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
 
       - name: Python environment
         run: |

--- a/.github/workflows/nv-megatron.yml
+++ b/.github/workflows/nv-megatron.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           pip uninstall --yes deepspeed
           pip install .[dev]
-          pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
+          pip install -v --disable-pip-version-check --no-cache-dir  git+https://github.com/NVIDIA/apex.git
 
       - name: Python environment
         run: |

--- a/.github/workflows/nv-megatron.yml
+++ b/.github/workflows/nv-megatron.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Unit tests
         run: |
-          git clone --branch mrwyattii/add-unit-test https://github.com/microsoft/Megatron-DeepSpeed.git
+          git clone https://github.com/microsoft/Megatron-DeepSpeed.git
           cd Megatron-DeepSpeed
           pip install .
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch


### PR DESCRIPTION
Change how we install Nvidia Apex (avoid compiling lots of things we don't actually need to for this test). As a result, reducing dependency install time from ~12m to ~20s:

Before:
<img width="461" alt="image" src="https://user-images.githubusercontent.com/18311180/208489267-345d0f99-e853-4fad-a6ec-1130b54a09db.png">

Now:
<img width="466" alt="image" src="https://user-images.githubusercontent.com/18311180/208489442-d580c24d-64a4-4c88-b14f-bce8a32a5d00.png">