### PR TITLE
[inference] check for unsupported model generate args

### DIFF
--- a/deepspeed/inference/engine.py
+++ b/deepspeed/inference/engine.py
@@ -49,6 +49,10 @@ class InferenceEngine(Module):
 
         self._get_model_config_generate(config)  # keep for weird backward compatibility
 
+        # patch model generate with ours if model uses it
+        if hasattr(self.module, "generate"):
+            self.generate = self._generate
+
         if hasattr(self.module, "config"):
             DSPolicy.hf_model_config = self.module.config
 
@@ -517,7 +521,7 @@ class InferenceEngine(Module):
 
         return outputs
 
-    def generate(self, *inputs, **kwargs):
+    def _generate(self, *inputs, **kwargs):
         if "num_beams" in kwargs:
             if kwargs["num_beams"] > 1:
                 raise NotImplementedError(

--- a/deepspeed/inference/engine.py
+++ b/deepspeed/inference/engine.py
@@ -148,8 +148,6 @@ class InferenceEngine(Module):
         self.config = getattr(self.module,
                               'config',
                               None) if config.config is None else config.config
-        # todo: clarify with Reza if this gets used anywhere
-        self.generate = getattr(self.module, 'generate', None)
 
     def remove_mask_prepare_for_bloom(self):
         if hasattr(self.module, 'transformer'):
@@ -518,3 +516,13 @@ class InferenceEngine(Module):
             self._model_times.append(duration)
 
         return outputs
+
+    def generate(self, *inputs, **kwargs):
+        if "num_beams" in kwargs:
+            if kwargs["num_beams"] > 1:
+                raise NotImplementedError(
+                    "DeepSpeed inference does not support `num_beams` > 1, please add your"
+                    "request to this open issue https://github.com/microsoft/DeepSpeed/issues/2506 "
+                    "if this is something important to you.")
+
+        return self.module.generate(*inputs, **kwargs)

--- a/deepspeed/inference/engine.py
+++ b/deepspeed/inference/engine.py
@@ -522,11 +522,17 @@ class InferenceEngine(Module):
         return outputs
 
     def _generate(self, *inputs, **kwargs):
+        num_beams = 1
+        if "generation_config" in kwargs:
+            gen_config = kwargs["generation_config"]
+            num_beams = getattr(gen_config, "num_beams", 1)
         if "num_beams" in kwargs:
-            if kwargs["num_beams"] > 1:
-                raise NotImplementedError(
-                    "DeepSpeed inference does not support `num_beams` > 1, please add your"
-                    "request to this open issue https://github.com/microsoft/DeepSpeed/issues/2506 "
-                    "if this is something important to you.")
+            num_beams = kwargs["num_beams"]
+
+        if num_beams > 1:
+            raise NotImplementedError(
+                "DeepSpeed does not support `num_beams` > 1, if this is important to you please "
+                "add your request to: https://github.com/microsoft/DeepSpeed/issues/2506"
+            )
 
         return self.module.generate(*inputs, **kwargs)


### PR DESCRIPTION
Catch cases where users try and set `num_beams > 1` during model generation, which is not currently supported. This came up with a user request in #2506.