### PR TITLE
Unit tests setup own venv

### DIFF
--- a/.github/workflows/amd.yml
+++ b/.github/workflows/amd.yml
@@ -25,21 +25,14 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      # Runs a single command using the runners shell
-      - name: environment
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
+
+      - name: Install pytorch
         run: |
-          echo "JobID: $AISC_NODE_INSTANCE_ID"
-          rocm-smi --showhw
-          which python
-          python --version
-          which hipcc
-          hipcc --version
-          pip install --upgrade pip
-          pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/rocm5.1.1
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
-          sudo apt-get update
           sudo apt-get install -y libaio-dev
 
       - name: Install transformers

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -22,10 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: environment
-        run: |
-          which python
-          python --version
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
 
       - name: Install deepspeed
         run: |

--- a/.github/workflows/nv-accelerate-v100.yml
+++ b/.github/workflows/nv-accelerate-v100.yml
@@ -22,23 +22,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: environment
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
+
+      - name: Install pytorch
         run: |
-          echo "JobID: $AISC_NODE_INSTANCE_ID"
-          nvidia-smi
-          which python
-          python --version
-          which nvcc
-          nvcc --version
-          pip install --upgrade pip
-          pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu111
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
       - name: Install deepspeed
         run: |
-          pip uninstall --yes deepspeed
           pip install .[dev,autotuning]
           ds_report
 

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -22,16 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: environment
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
+
+      - name: Install pytorch
         run: |
-          echo "JobID: $AISC_NODE_INSTANCE_ID"
-          nvidia-smi
-          which python
-          python --version
-          which nvcc
-          nvcc --version
-          pip install --upgrade pip
-          pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu116
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
@@ -41,12 +36,10 @@ jobs:
           git clone https://github.com/huggingface/transformers
           cd transformers
           git rev-parse --short HEAD
-          pip uninstall --yes transformers
           pip install .
 
       - name: Install deepspeed
         run: |
-          pip uninstall --yes deepspeed
           pip install .[dev,1bit,autotuning,inf]
           ds_report
 

--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -22,23 +22,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: environment
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
+
+      - name: Install pytorch
         run: |
-          echo "JobID: $AISC_NODE_INSTANCE_ID"
-          nvidia-smi
-          which python
-          python --version
-          which nvcc
-          nvcc --version
-          pip install --upgrade pip
-          pip uninstall --yes torch torchvision
           pip install torch==1.9.1+cu111 torchvision==0.10.1+cu111 torchaudio==0.9.1 -f https://download.pytorch.org/whl/torch_stable.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
       - name: Install deepspeed
         run: |
-          pip uninstall --yes deepspeed
           pip install .[dev,autotuning]
           ds_report
 
@@ -49,7 +43,6 @@ jobs:
       - name: PyTorch Lightning Tests
         run: |
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
-          pip uninstall --yes pytorch-lightning
           pip install pytorch-lightning
           pip install "protobuf<4.21.0"
           cd tests

--- a/.github/workflows/nv-megatron.yml
+++ b/.github/workflows/nv-megatron.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           git clone --branch mrwyattii/add-unit-test https://github.com/microsoft/Megatron-DeepSpeed.git
           cd Megatron-DeepSpeed
-          pip uninstall megatron-lm
+          pip uninstall --yes megatron-lm
           pip install .
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi

--- a/.github/workflows/nv-megatron.yml
+++ b/.github/workflows/nv-megatron.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           git clone --branch mrwyattii/add-unit-test https://github.com/microsoft/Megatron-DeepSpeed.git
           cd Megatron-DeepSpeed
+          pip uninstall megatron-lm
           pip install .
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi

--- a/.github/workflows/nv-megatron.yml
+++ b/.github/workflows/nv-megatron.yml
@@ -22,31 +22,28 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: environment
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
+
+      - name: Install pytorch
         run: |
-          echo "JobID: $AISC_NODE_INSTANCE_ID"
-          nvidia-smi
-          which python
-          python --version
-          which nvcc
-          nvcc --version
-          pip install --upgrade pip
-          pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu116
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
-      - name: Install
+      - name: Install deepspeed
         run: |
-          pip uninstall --yes deepspeed
           pip install .[dev]
-          pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
+          ds_report
 
+      - name: Install apex
+        run: |
+          pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
       - name: Python environment
         run: |
           pip list
 
-      - name: Unit tests
+      - name: Megatron unit tests
         run: |
           git clone --branch mrwyattii/add-unit-test https://github.com/microsoft/Megatron-DeepSpeed.git
           cd Megatron-DeepSpeed

--- a/.github/workflows/nv-megatron.yml
+++ b/.github/workflows/nv-megatron.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Install apex
         run: |
           pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git
+
       - name: Python environment
         run: |
           pip list

--- a/.github/workflows/nv-megatron.yml
+++ b/.github/workflows/nv-megatron.yml
@@ -46,9 +46,8 @@ jobs:
 
       - name: Megatron unit tests
         run: |
-          git clone --branch mrwyattii/add-unit-test https://github.com/microsoft/Megatron-DeepSpeed.git
+          git clone --branch mrwyattii/fix-deprecated-numpy-types https://github.com/microsoft/Megatron-DeepSpeed.git
           cd Megatron-DeepSpeed
-          pip uninstall --yes megatron-lm
           pip install .
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi

--- a/.github/workflows/nv-mii.yml
+++ b/.github/workflows/nv-mii.yml
@@ -22,31 +22,25 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: environment
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
+
+      - name: Install pytorch
         run: |
-          echo "JobID: $AISC_NODE_INSTANCE_ID"
-          nvidia-smi
-          which python
-          python --version
-          which nvcc
-          nvcc --version
-          pip install --upgrade pip
-          pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu116
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
-      - name: Install MII
+      - name: Install deepspeed
         run: |
-          pip uninstall --yes deepspeed deepspeed-mii transformers
           pip install .[dev]
-          pip install git+https://github.com/huggingface/transformers.git
+          ds_report
 
       - name: Python environment
         run: |
           pip list
 
-      - name: Unit tests
+      - name: MII unit tests
         run: |
           git clone https://github.com/microsoft/DeepSpeed-MII.git
           cd DeepSpeed-MII

--- a/.github/workflows/nv-mii.yml
+++ b/.github/workflows/nv-mii.yml
@@ -31,6 +31,15 @@ jobs:
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
+      - name: Install transformers
+        run: |
+          git clone https://github.com/huggingface/transformers
+          cd transformers
+          # if needed switch to the last known good SHA until transformers@master is fixed
+          # git checkout 1cc453d33
+          git rev-parse --short HEAD
+          pip install .
+
       - name: Install deepspeed
         run: |
           pip install .[dev]

--- a/.github/workflows/nv-nightly.yml
+++ b/.github/workflows/nv-nightly.yml
@@ -15,16 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: environment
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
+
+      - name: Install pytorch
         run: |
-          echo "JobID: $AISC_NODE_INSTANCE_ID"
-          nvidia-smi
-          which python
-          python --version
-          which nvcc
-          nvcc --version
-          pip install --upgrade pip
-          pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu116
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
@@ -36,18 +31,15 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          pip uninstall --yes transformers
           pip install .
 
       - name: Install deepspeed
         run: |
-          pip uninstall --yes deepspeed
           pip install .[dev,1bit,autotuning,inf]
           ds_report
 
       - name: Install lm-eval
         run: |
-          pip uninstall --yes lm-eval
           pip install git+https://github.com/EleutherAI/lm-evaluation-harness
           # This is required until lm-eval makes a new release. v0.2.0 is
           # broken for latest version of transformers

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -25,15 +25,8 @@ jobs:
       - id: setup-venv
         uses: ./.github/workflows/setup-venv
 
-      - name: environment
+      - name: Install pytorch
         run: |
-          source ${{ steps.setup-venv.outputs.venv-name }}/bin/activate
-          echo "JobID: $AISC_NODE_INSTANCE_ID"
-          nvidia-smi
-          which python
-          python --version
-          which nvcc
-          nvcc --version
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu116
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -22,16 +22,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
+
       - name: environment
         run: |
+          source ${{ steps.setup-venv.outputs.venv-name }}/bin/activate
           echo "JobID: $AISC_NODE_INSTANCE_ID"
           nvidia-smi
           which python
           python --version
           which nvcc
           nvcc --version
-          pip install --upgrade pip
-          pip uninstall --yes torch torchvision triton
           pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu116
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
@@ -43,12 +45,10 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          pip uninstall --yes transformers
           pip install .
 
       - name: Install deepspeed
         run: |
-          pip uninstall --yes deepspeed
           pip install .[dev,1bit,autotuning]
           ds_report
 

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -15,16 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: environment
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
+
+      - name: Install pytorch
         run: |
-          echo "JobID: $AISC_NODE_INSTANCE_ID"
-          nvidia-smi
-          which python
-          python --version
-          which nvcc
-          nvcc --version
-          pip install --upgrade pip
-          pip uninstall --yes torch torchvision triton
           pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cu116
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
@@ -36,12 +31,10 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          pip uninstall --yes transformers
           pip install .
 
       - name: Install deepspeed
         run: |
-          pip uninstall --yes deepspeed
           pip install .[dev,1bit,autotuning]
           ds_report
 

--- a/.github/workflows/nv-torch18-p40.yml
+++ b/.github/workflows/nv-torch18-p40.yml
@@ -22,16 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: environment
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
+
+      - name: Install pytorch
         run: |
-          echo "JobID: $AISC_NODE_INSTANCE_ID"
-          nvidia-smi
-          which python
-          python --version
-          which nvcc
-          nvcc --version
-          pip install --upgrade pip
-          pip uninstall --yes torch torchvision triton
           pip install torch==1.8.2 torchvision==0.9.2 --extra-index-url https://download.pytorch.org/whl/lts/1.8/cu101
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
@@ -43,12 +38,10 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          pip uninstall --yes transformers
           pip install .
 
       - name: Install deepspeed
         run: |
-          pip uninstall --yes deepspeed
           pip install .[dev,1bit,autotuning]
           ds_report
 

--- a/.github/workflows/nv-torch18-v100.yml
+++ b/.github/workflows/nv-torch18-v100.yml
@@ -22,16 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: environment
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
+
+      - name: Install pytorch
         run: |
-          echo "JobID: $AISC_NODE_INSTANCE_ID"
-          nvidia-smi
-          which python
-          python --version
-          which nvcc
-          nvcc --version
-          pip install --upgrade pip
-          pip uninstall --yes torch torchvision triton
           pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
@@ -43,12 +38,10 @@ jobs:
           # if needed switch to the last known good SHA until transformers@master is fixed
           # git checkout 1cc453d33
           git rev-parse --short HEAD
-          pip uninstall --yes transformers
           pip install .
 
       - name: Install deepspeed
         run: |
-          pip uninstall --yes deepspeed
           pip install .[dev,1bit,autotuning]
           ds_report
 

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -22,25 +22,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: environment
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
+
+      - name: Install pytorch
         run: |
-          echo "JobID: $AISC_NODE_INSTANCE_ID"
-          nvidia-smi
-          which python
-          python --version
-          which nvcc
-          nvcc --version
-          pip install --upgrade pip
-          pip uninstall --yes torch torchvision triton
           pip install torch==1.8.2+cu111 torchvision==0.9.2+cu111 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
-          sudo apt-get update
           sudo apt-get install -y libaio-dev
 
       - name: Install deepspeed
         run: |
-          pip uninstall --yes deepspeed
           pip install .[dev,autotuning]
           ds_report
 

--- a/.github/workflows/pre-compile-ops.yml
+++ b/.github/workflows/pre-compile-ops.yml
@@ -19,14 +19,12 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
+
       # Runs a single command using the runners shell
       - name: environment
         run: |
-          nvidia-smi
-          which python
-          python --version
-          which nvcc
-          nvcc --version
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/setup-venv/action.yml
+++ b/.github/workflows/setup-venv/action.yml
@@ -16,6 +16,7 @@ runs:
         python -m pip install -U virtualenv
         python -m venv unit-test-venv
         source ./unit-test-venv/bin/activate
+        pip install --upgrade pip
         echo PATH=$PATH >> $GITHUB_ENV # Make it so venv is inherited for other steps
       shell: bash
     - id: print-env

--- a/.github/workflows/setup-venv/action.yml
+++ b/.github/workflows/setup-venv/action.yml
@@ -1,0 +1,24 @@
+name: Create Virtual Environment
+
+outputs:
+  venv-name:
+    description: "virtual environment name"
+    value: ${{ steps.create-env.outputs.venv-name }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: update-env
+      run: |
+        sudo apt-get update && sudo apt-get -y upgrade
+        pip install --upgrade pip
+        python -m pip install -U virtualenv
+      shell: bash
+    - id: create-venv
+      run: |
+        sudo apt-get update && sudo apt-get -y upgrade
+        pip install --upgrade pip
+        python -m pip install -U virtualenv
+        python -m venv unit-test-venv
+        echo "venv-name=unit-test-venv" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/setup-venv/action.yml
+++ b/.github/workflows/setup-venv/action.yml
@@ -21,14 +21,16 @@ runs:
       shell: bash
     - id: print-env
       run: |
-        echo "JobID: $AISC_NODE_INSTANCE_ID"
         which python
         python --version
+        if [[ -z "${AISC_NODE_INSTANCE_ID}" ]]; then
+          echo "JobID: ${AISC_NODE_INSTANCE_ID}"
+        fi
         if command -v nvidia-smi; then
           nvidia-smi
           which nvcc
           nvcc --version
-        else
+        elif command -c rocm-smi; then
           rocm-smi --showhw
           which hipcc
           hipcc --version

--- a/.github/workflows/setup-venv/action.yml
+++ b/.github/workflows/setup-venv/action.yml
@@ -1,10 +1,5 @@
 name: Create Virtual Environment
 
-outputs:
-  venv-name:
-    description: "virtual environment name"
-    value: ${{ steps.create-env.outputs.venv-name }}
-
 runs:
   using: "composite"
   steps:
@@ -20,5 +15,21 @@ runs:
         pip install --upgrade pip
         python -m pip install -U virtualenv
         python -m venv unit-test-venv
-        echo "venv-name=unit-test-venv" >> $GITHUB_OUTPUT
+        source ./unit-test-venv/bin/activate
+        echo PATH=$PATH >> $GITHUB_ENV # Make it so venv is inherited for other steps
+      shell: bash
+    - id: print-env
+      run: |
+        echo "JobID: $AISC_NODE_INSTANCE_ID"
+        which python
+        python --version
+        if command -v nvidia-smi; then
+          nvidia-smi
+          which nvcc
+          nvcc --version
+        else
+          rocm-smi --showhw
+          which hipcc
+          hipcc --version
+        fi
       shell: bash


### PR DESCRIPTION
After adding the Megatron unit test, we were seeing failures on other tests due to a conflict in the venv between megatron-lm versions. In the past, we would reconcile this by adding a `pip uninstall ...` to each workflow yaml. This updates our CI to have a reusable workflow that is called at the start of each workflow and creates a fresh virtual environment and prints relevant environment information.