### PR TITLE
[zero] `_apply_to_tensors_only` handle `torch.Tensor` subclasses

### DIFF
--- a/deepspeed/runtime/zero/parameter_offload.py
+++ b/deepspeed/runtime/zero/parameter_offload.py
@@ -46,7 +46,8 @@ def _apply_to_tensors_only(module, functional, backward_function, outputs):
                                                   outputs[key])
         return outputs
 
-    elif type(outputs) is torch.Tensor:
+    elif isinstance(outputs, torch.Tensor):
+        # this also applies to torch.Tensor's subclasses like torch.nn.parameter.Parameter
         return functional.apply(module, backward_function, outputs)
     else:
         if not is_builtin_type(outputs):


### PR DESCRIPTION
In a complex code base I run into this warning:

> [WARNING] [parameter_offload.py:55:_apply_to_tensors_only] A module has unknown inputs or outputs type (<class 'torch.nn.parameter.Parameter'>) and the tensors embedded in it cannot be detected. The ZeRO-3 hooks designed to trigger before or after backward pass of the module relies on knowing the input and output tensors and therefore may not get triggered properly.

But `torch.nn.parameter.Parameter` is a subclass of `torch.Tensor`.

This PR fixes this by replacing the exact check for `torch.Tensor` with a more flexible check that includes its subclasses as well.

Thank you!

@tjruwase 