### PR TITLE
Refactor/Pydantify comms config 

### DIFF
--- a/deepspeed/comm/comm.py
+++ b/deepspeed/comm/comm.py
@@ -75,7 +75,7 @@ from deepspeed.comm.utils import *
 
 
 def _configure_using_config_file(config):
-    if config.comms_logger_enabled:
+    if config.enabled:
         comms_logger.configure(config)
 
 

--- a/deepspeed/comm/config.py
+++ b/deepspeed/comm/config.py
@@ -3,29 +3,16 @@ Copyright (c) Microsoft Corporation
 Licensed under the MIT license.
 """
 
-from pydantic import BaseModel
-from .constants import *
+from deepspeed.runtime.config_utils import DeepSpeedConfigModel
 
 
-class CommsConfig(BaseModel):
-    class Config:
-        validate_all = True
-        validate_assignment = True
-        use_enum_values = True
-        extra = 'forbid'
+def get_comms_config(param_dict):
+    return DeepSpeedCommsConfig(**param_dict.get("comms_logger", {}))
 
 
-class CommsLoggerConfig(CommsConfig):
-    enabled: bool = COMMS_LOGGER_ENABLED_DEFAULT
-    prof_all: bool = COMMS_LOGGER_PROF_ALL_DEFAULT
-    prof_ops: list = COMMS_LOGGER_PROF_OPS_DEFAULT
-    verbose: bool = COMMS_LOGGER_VERBOSE_DEFAULT
-    debug: bool = COMMS_LOGGER_DEBUG_DEFAULT
-
-
-class DeepSpeedCommsConfig:
-    def __init__(self, ds_config):
-        self.comms_logger_enabled = 'comms_logger' in ds_config
-
-        if self.comms_logger_enabled:
-            self.comms_logger = CommsLoggerConfig(**ds_config['comms_logger'])
+class DeepSpeedCommsConfig(DeepSpeedConfigModel):
+    enabled: bool = False
+    prof_all: bool = True
+    prof_ops: list = []
+    verbose: bool = False
+    debug: bool = False

--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -24,7 +24,7 @@ from .config_utils import (
 )
 from .zero.config import get_zero_config, ZeroStageEnum
 from .activation_checkpointing.config import DeepSpeedActivationCheckpointingConfig
-from ..comm.config import DeepSpeedCommsConfig
+from ..comm.config import get_comms_config
 from ..monitor.config import DeepSpeedMonitorConfig
 
 from deepspeed import comm as dist
@@ -828,7 +828,7 @@ class DeepSpeedConfig(object):
         self.activation_checkpointing_config = DeepSpeedActivationCheckpointingConfig(
             param_dict)
 
-        self.comms_config = DeepSpeedCommsConfig(param_dict)
+        self.comms_config = get_comms_config(param_dict)
         self.monitor_config = DeepSpeedMonitorConfig(param_dict)
 
         self.gradient_clipping = get_gradient_clipping(param_dict)

--- a/deepspeed/utils/comms_logging.py
+++ b/deepspeed/utils/comms_logging.py
@@ -64,12 +64,12 @@ class CommsLogger:
         self.enabled = COMMS_LOGGER_ENABLED_DEFAULT
 
     def configure(self, comms_config):
-        self.enabled = comms_config.comms_logger_enabled
+        self.enabled = comms_config.enabled
         if self.enabled:
-            self.verbose = comms_config.comms_logger.verbose
-            self.debug = comms_config.comms_logger.debug
-            self.prof_ops = comms_config.comms_logger.prof_ops
-            self.prof_all = comms_config.comms_logger.prof_all
+            self.verbose = comms_config.verbose
+            self.debug = comms_config.debug
+            self.prof_ops = comms_config.prof_ops
+            self.prof_all = comms_config.prof_all
 
     # There are three settings for the op profiler:
     # - Global profiling (profile all comms)


### PR DESCRIPTION
Splitting work from https://github.com/microsoft/DeepSpeed/pull/2210 to make it easier to review and merge.

Comms already used Pydantic, but updating it to use the DeepSpeedConfigModel like all other configs

TODO:
- [ ] Refactor how the config is used
- [ ] Verify that this code is tested somehow in unit tests
- [ ] Add auto-gen docs