### PR TITLE
Fix issue w. bloom int8 when changing tp size

### DIFF
--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -142,6 +142,8 @@ class GroupQuantizer:
         self.group_size = group_size
         self.num_bits = num_bits
         self.q_int8 = q_int8
+        # TODO(jeff): need to check w. Reza on why this is needed when changing tp size w. bloom
+        self.num_groups = 32
 
     def quantize(self, inputs, qkv=True, count=1, parallel_dim=0):
         if not self.q_int8 or not qkv:


### PR DESCRIPTION
When trying to load https://huggingface.co/microsoft/bloom-deepspeed-inference-int8 on 8 x A100-40GB this triggers a crash during checkpoint loading:

<img width="926" alt="image" src="https://user-images.githubusercontent.com/645595/209248908-584aa672-4b24-40ed-a48e-3ba266cf37d3.png">

After bisecting it appears to be introduced in https://github.com/microsoft/DeepSpeed/pull/2547, which refactored the way `num_groups` is used during quantization. After peer-debugging w. @cmikeh2 we determined that `num_groups` in this case should be set to 32. We've tested both 176B and 7.1B versions of Bloom where we change from TP 4->8 and TP 2->4 respectively.

Also reported by @JingfengYang and confirmed fixes their issue in https://github.com/microsoft/DeepSpeed/pull/2217#issuecomment-1362681481
