### PR TITLE
[doc] fix `min_loss_scale` default

### DIFF
--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -268,7 +268,7 @@ Example of <i>**scheduler**</i>
 
 | Description                                                                                           | Default |
 | ----------------------------------------------------------------------------------------------------- | ------- |
-| <i>**min_loss_scale**</i> is  a **fp16** parameter representing the minimum dynamic loss scale value. | `1000`  |
+| <i>**min_loss_scale**</i> is  a **fp16** parameter representing the minimum dynamic loss scale value. | `1`  |
 
 ### BFLOAT16 training options
 

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -268,7 +268,7 @@ Example of <i>**scheduler**</i>
 
 | Description                                                                                           | Default |
 | ----------------------------------------------------------------------------------------------------- | ------- |
-| <i>**min_loss_scale**</i> is  a **fp16** parameter representing the minimum dynamic loss scale value. | `1`  |
+| <i>**min_loss_scale**</i> is  a **fp16** parameter representing the minimum dynamic loss scale value. | `1`     |
 
 ### BFLOAT16 training options
 


### PR DESCRIPTION
`min_loss_scale` default should be `1` and not `1000`, since:

https://github.com/microsoft/DeepSpeed/blob/d9b788d773ce97281ee63064cc99993cb82397e2/deepspeed/runtime/constants.py#L170
