### PR TITLE
real_accelerator validation check for both accelerator and deepspeed accelerator path

### DIFF
--- a/accelerator/real_accelerator.py
+++ b/accelerator/real_accelerator.py
@@ -1,11 +1,33 @@
-from .abstract_accelerator import DeepSpeedAccelerator
+try:
+    from accelerator.abstract_accelerator import DeepSpeedAccelerator as dsa1
+except ImportError as e:
+    dsa1 = None
+try:
+    from deepspeed.accelerator.abstract_accelerator import DeepSpeedAccelerator as dsa2
+except ImportError as e:
+    dsa2 = None
 
 ds_accelerator = None
 
 
 def _validate_accelerator(accel_obj):
-    assert isinstance(accel_obj, DeepSpeedAccelerator), \
-        f'{accel_obj.__class__.__name__} accelerator is not subclass of DeepSpeedAccelerator'
+    # because abstract_accelerator has different path during
+    # build time (accelerator.abstract_accelerator)
+    # and run time (deepspeed.accelerator.abstract_accelerator)
+    # and extension would import the
+    # run time abstract_accelerator/DeepSpeedAccelerator as its base
+    # class, so we need to compare accel_obj with both base class.
+    # if accel_obj is instance of DeepSpeedAccelerator in one of
+    # accelerator.abstractor_accelerator
+    # or deepspeed.accelerator.abstract_accelerator, consider accel_obj
+    # is a conforming object
+    if not ((dsa1 != None and isinstance(accel_obj,
+                                         dsa1)) or
+            (dsa2 != None and isinstance(accel_obj,
+                                         dsa2))):
+        raise AssertionError(
+            f'{accel_obj.__class__.__name__} accelerator is not subclass of DeepSpeedAccelerator'
+        )
 
     # TODO: turn off is_available test since this breaks tests
     #assert accel_obj.is_available(), \


### PR DESCRIPTION
This PR change validation check in real_accelerator.py.  real_accelerator checks whether the real accelerator object is an instance of DeepSpeedAccelerator to ensure interface compatibility.  However, because during DeepSpeed build time, accelerator are accessed through module path **accelerator** and during run time, accelerator are accessed through module path **deepspeed.accelerator**, so in the first situation, real accelerator object should be instance of `accelerator.abstract_accelerator.DeepSpeedAccelerator` and in the second situation, real accelerator object should be instance of `deepspeed.accelerator.abstract_accelerator.DeepSpeedAccelerator`.

For CUDA_Accelerator, it is fine because cuda_accelerator.py is in the same path of real_accelerator.py, so when they reference to `.abstract_accelerator.DeepSpeedAccelerator`, they are referencing the same class.

However, for an extension that implements a concreate class of DeepSpeedAccelerator, it does not know whether it is called from **accelerator.real_accelerator** or **deepspeed.accelerator.real_accelerator**, so extension will always inherit from `deepspeed.accelerator.abstract_accelerator.DeepSpeedAccelerator`.  So during build time, the validation will fail.

This PR would check real accelerator object against both `accelerator.abstract_accelerator.DeepSpeedAccelerator` and `deepspeed.accelerator.abstract_accelerator.DeepSpeedAccelerator`, if any one of the checks passes, the validation passes.  This allows extension works during both build time and runtime.