### PR TITLE
Fix import error of op_builder

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -450,7 +450,7 @@ class OpBuilder(ABC):
             extra_link_args=self.strip_empty_entries(self.extra_ldflags()))
 
     def load(self, verbose=True):
-        from ...git_version_info import installed_ops, torch_info
+        from deepspeed.git_version_info import installed_ops, torch_info
         if installed_ops[self.name]:
             # Ensure the op we're about to load was compiled with the same
             # torch/cuda versions we are currently using at runtime.


### PR DESCRIPTION
This PR fixes an import error of in `builder.py`. (See also #2560)

The changes in 9548d48 causes the following error when you install deepspeed with `-e` option.

```
File "/DEEPSPEED_REPO_ROOT/op_builder/builder.py", line 453, in load
from ...git_version_info import installed_ops, torch_info 
ImportError: attempted relative import beyond top-level package 
```

When we have deepspeed installed with -e, we have builder.py in both `deepspeed/ops/op_builder/` and `op_builder/` (the former is a symbolic link). Python interpreter recognizes the path of builder.py as `op_builder/` at runtime and reference to `...git_version_info` fails. 

This PR fixes the issue by importing the module with the absolute path (proposed by @jeffra at #2560).