### PR TITLE
Fix runtime bug in developer install mode

### DIFF
--- a/accelerator/cuda_accelerator.py
+++ b/accelerator/cuda_accelerator.py
@@ -12,9 +12,10 @@ except ImportError:
 
 
 class CUDA_Accelerator(DeepSpeedAccelerator):
-    def __init__(self):
+    def __init__(self, from_setup=False):
         self._name = 'cuda'
         self._communication_backend_name = 'nccl'
+        self._from_setup = from_setup
 
         # begin initialize for create_op_builder()
         # put all valid class name <--> class type mapping into class_dict
@@ -222,11 +223,10 @@ class CUDA_Accelerator(DeepSpeedAccelerator):
             return False
 
     def op_builder_dir(self):
-        try:
+        if self._from_setup:
             # during installation time op_builder is visible, otherwise return deepspeed.ops.op_builder
-            import op_builder  # noqa: F401
             return "op_builder"
-        except ImportError:
+        else:
             return "deepspeed.ops.op_builder"
 
     # dict that holds class name <--> class type mapping i.e.

--- a/accelerator/real_accelerator.py
+++ b/accelerator/real_accelerator.py
@@ -34,7 +34,10 @@ def _validate_accelerator(accel_obj):
     #    f'{accel_obj.__class__.__name__} accelerator fails is_available() test'
 
 
-def get_accelerator():
+# the optional argument 'from_setup' indicates this call is from setup process
+# this argument only take effect from first call when the concrete accelerator
+# class object is initialized
+def get_accelerator(from_setup=False):
     global ds_accelerator
     if ds_accelerator is None:
         try:
@@ -47,7 +50,7 @@ def get_accelerator():
             return ds_accelerator
 
         from .cuda_accelerator import CUDA_Accelerator
-        ds_accelerator = CUDA_Accelerator()
+        ds_accelerator = CUDA_Accelerator(from_setup=from_setup)
         _validate_accelerator(ds_accelerator)
     return ds_accelerator
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ import time
 torch_available = True
 try:
     import torch
+    from accelerator import get_accelerator
+    # tell abstract accelerator currently in build time
+    get_accelerator(from_setup=True)
 except ImportError:
     torch_available = False
     print('[WARNING] Unable to import torch, pre-compiling ops will be disabled. ' \

--- a/setup.py
+++ b/setup.py
@@ -25,13 +25,14 @@ import time
 torch_available = True
 try:
     import torch
-    from accelerator import get_accelerator
-    # tell abstract accelerator currently in build time
-    get_accelerator(from_setup=True)
 except ImportError:
     torch_available = False
     print('[WARNING] Unable to import torch, pre-compiling ops will be disabled. ' \
         'Please visit https://pytorch.org/ to see how to properly install torch on your system.')
+
+from accelerator import get_accelerator
+# tell abstract accelerator currently in build time
+get_accelerator(from_setup=True)
 
 from op_builder import get_default_compute_capabilities, OpBuilder
 from op_builder.all_ops import ALL_OPS


### PR DESCRIPTION
This PR fix a bug that prevents deepspeed to work properly under developer install (`python setup.py develop`).   The root cause is in CUDA_Accelerator, when `op_builder_dir()` is called, CUDA_Accelerator suppose to return **"op_builder"** during build time, and **"deepspeed.ops.op_builder"** during runtime.   In previous implementation, CUDA_Accelerator would try to import `op_builder`.  If this import is successful, CUDA_Accelerator would assume this is build time and return "op_builder".  Otherwise it would assume this is runtime and return "deepspeed.ops.op_builder".

However, if deepspeed is installed through developer install, `op_builder` module would still be accessible, so CUDA_Accelerator would get confused and return "op_builder" in `op_builder_dir()`.   This would eventurally causing op builders be created from op_builder path and throw an error from [`builder.py#L453`](https://github.com/microsoft/DeepSpeed/blob/master/op_builder/builder.py#L453), which is supposed to be called from `deepspeed.ops.op_builder` only.

To resolve this issue, we introduced an optional argument in `accelerator.get_accelerator`, and call `get_accelerator(for_setup=True)` in the very beginning of setup.py.  get_accelerator would subsequently pass this argument to CUDA_Accelerator initializer.   When `op_builder_dir` is called, CUDA_Accelerator would use the value in this argument to decide whether to return "op_builder" or "deepspeed.ops.op_builder", so CUDA_Accelerator won't be confused whether its in  build time and runtime, and work correctly.

Note that XPU_Accelerator does not need to have this argument in initializer.  Because XPU_Accelerator is defined in sperate package, so its op builder path is the same during build time and runtime, so no distinguish is needed.