### PR TITLE
[ZeRO] non-MoE stage 1 requires CG disabled

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1529,6 +1529,9 @@ class DeepSpeedEngine(Module):
             if zero_stage == ZeroStageEnum.optimizer_states:
                 overlap_comm = False
                 round_robin_gradients = False
+                # Non-MoE requires contiguous grads to be disabled w. stage 1
+                if not self.has_moe_layers:
+                    contiguous_gradients = False
 
             if isinstance(self.module, PipelineModule):
                 if overlap_comm:


### PR DESCRIPTION
MoE w. stage 1 requires contiguous gradients (CG) is enabled, which was fixed in https://github.com/microsoft/DeepSpeed/pull/2250. However, this introduces a performance regression when not using MoE. This PR reverts the non-MoE case to ensure CG is disabled.

/cc @siddharth9820, @tjruwase