### PR TITLE
remove print side effect from importing deepspeed

### DIFF
--- a/deepspeed/autotuning/autotuner.py
+++ b/deepspeed/autotuning/autotuner.py
@@ -26,7 +26,6 @@ try:
     import mlflow
     has_mlflow = True
 except Exception as e:
-    print("MLFlow does not exist. Disabling MLFlow logging")
     has_mlflow = False
 
 ZERO_OPTIMIZATION_STAGE = "stage"


### PR DESCRIPTION
#2495 introduced a side effect from importing deepspeed that prints out the status of MLFlow on every rank. This PR removes this unnecessary logging.

```
>>> import deepspeed
MLFlow does not exist. Disabling MLFlow logging
>>>
```