### PR TITLE
Fixing Optimizer Sanity Check

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -881,7 +881,7 @@ class DeepSpeedEngine(Module):
             model_dtype = torch.bfloat16
 
         if self._config.grad_accum_dtype == None:
-            if model_dtype == torch.bfloat16:
+            if model_dtype == torch.bfloat16 and not self.zero_optimization():
                 grad_accum_dtype = torch.float32
             else:
                 grad_accum_dtype = model_dtype
@@ -1203,10 +1203,6 @@ class DeepSpeedEngine(Module):
             not (amp_enabled and zero_enabled)
         ), "Amp and ZeRO are not currently compatible, please use (legacy) fp16 mode which performs similar to amp opt_mode=O2"
         if zero_enabled:
-            if model_dtype != grad_accum_dtype:
-                raise NotImplementedError(
-                    "Model data type and gradient accumulation data type must be equal to use ZeRO"
-                )
             if not is_zero_supported_optimizer(basic_optimizer):
                 assert (
                     self.zero_allow_untested_optimizer()
@@ -1216,16 +1212,15 @@ class DeepSpeedEngine(Module):
                     logger.warning(
                         "**** You are using ZeRO with an untested optimizer, proceed with caution *****"
                     )
-            # BF16 optimizer supports stage 1 optimizations
-            if model_dtype == torch.bfloat16:
-                if grad_accum_dtype != torch.float32:
-                    raise NotImplementedError(
-                        "BF16 optimizer for ZeRO requires fp32 gradient accumulation")
-                if self.zero_optimization_stage() == 1:
-                    return BFLOAT16
-                else:
-                    raise NotImplementedError(
-                        "ZeRO stages 2 and 3 are not supported with the BF16 optimizer")
+
+            if model_dtype == torch.bfloat16 and grad_accum_dtype == torch.float32 and self.zero_optimization_stage(
+            ) == 1:
+                return BFLOAT16
+
+            if model_dtype != grad_accum_dtype:
+                raise NotImplementedError(
+                    "Model data type and gradient accumulation data type must be equal to use ZeRO"
+                )
             return ZERO_OPTIMIZATION
         elif amp_enabled:
             if model_dtype != grad_accum_dtype:

--- a/tests/unit/runtime/test_ds_initialize.py
+++ b/tests/unit/runtime/test_ds_initialize.py
@@ -172,12 +172,16 @@ class TestOptimizerImplementation(DistributedTest):
         # ZeRO 1 Wrapper
         is_supported[('zero1', 'fp16', None)] = True
         is_supported[('zero1', 'fp16', 'fp16')] = True
+        is_supported[('zero1', 'bf16', None)] = True
+        is_supported[('zero1', 'bf16', 'bf16')] = True
         is_supported[('zero1', 'bf16', 'fp32')] = True
         is_supported[('zero1', 'fp32', None)] = True
         is_supported[('zero1', 'fp32', 'fp32')] = True
         # ZeRO 2 Wrapper
         is_supported[('zero2', 'fp16', None)] = True
         is_supported[('zero2', 'fp16', 'fp16')] = True
+        is_supported[('zero2', 'bf16', None)] = True
+        is_supported[('zero2', 'bf16', 'bf16')] = True
         is_supported[('zero2', 'fp32', None)] = True
         is_supported[('zero2', 'fp32', 'fp32')] = True
         # Amp Wrapper


### PR DESCRIPTION
Fixing the optimizer sanity check to make BF16 + FP32 gradients + ZeRO1 a special case. All other combinations follow the pattern of matching model dtype to gradient accumulation dtype for ZeRO.