### PR TITLE
Pin transformers unit test version

### DIFF
--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -46,7 +46,7 @@ jobs:
           git clone https://github.com/huggingface/transformers
           cd transformers
           # if needed switch to the last known good SHA until transformers@master is fixed
-          #git checkout 6268694e2
+          git checkout 1d33f55cb
           git rev-parse --short HEAD
           # scipy/sklearn required for tests, using the 'dev' extra forces torch re-install
           pip install .[testing]


### PR DESCRIPTION
We are seeing an error pop up in the transformers unit test after a recent update. Pinning the version of transformers used until we can do a deeper dive in the cause of this error.