### PR TITLE
Skip test_bias_gelu unit test if torch < 1.12

### DIFF
--- a/tests/unit/ops/transformer/inference/test_bias_gelu.py
+++ b/tests/unit/ops/transformer/inference/test_bias_gelu.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 import deepspeed
 from deepspeed.ops.op_builder import InferenceBuilder
+from packaging import version as pkg_version
 
 if not deepspeed.ops.__compatible_ops__[InferenceBuilder.NAME]:
     pytest.skip("Inference ops are not available on this system",
@@ -21,21 +22,11 @@ def allclose(x, y):
     return torch.allclose(x, y, rtol=rtol, atol=atol)
 
 
-def version_appropriate_gelu(activations):
-    global torch_minor_version
-    if torch_minor_version is None:
-        torch_minor_version = int(torch.__version__.split('.')[1])
-    # If torch version = 1.12
-    if torch_minor_version < 12:
-        return torch.nn.functional.gelu(activations)
-    else:
-        return torch.nn.functional.gelu(activations, approximate='tanh')
-
-
 def run_bias_gelu_reference(activations, bias):
     # Expected behavior is that of casting to float32 internally and using the tanh approximation
-    return version_appropriate_gelu(
-        activations.to(torch.float32) + bias.to(torch.float32)).to(activations.dtype)
+    return torch.nn.functional.gelu(activations.to(torch.float32) +
+                                    bias.to(torch.float32),
+                                    approximate='tanh').to(activations.dtype)
 
 
 def run_bias_gelu_ds(activations, bias):
@@ -54,6 +45,9 @@ def run_bias_gelu_ds(activations, bias):
 @pytest.mark.parametrize("channels", [512, 1232, 4096])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
 def test_bias_gelu(batch, sequence, channels, dtype):
+    if pkg_version.parse(torch.__version__) < pkg_version.parse("1.12"):
+        pytest.skip("gelu implementation matches only after torch 1.12")
+
     activations_ds = torch.randn((batch, sequence, channels), dtype=dtype, device='cuda')
     bias_ds = torch.randn((channels), dtype=dtype, device='cuda')
 


### PR DESCRIPTION
This PR adds a torch version check in the `test_bias_gelu` unit test to skip if the torch version < 1.12. This is due to `gelu` implementation differences in versions prior to 1.12.

Thanks @cmikeh2, @mrwyattii.