### PR TITLE
Conditionally Make Op Building More Verbose

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -693,6 +693,8 @@ class CUDAOpBuilder(OpBuilder):
                 '-U__CUDA_NO_HALF_CONVERSIONS__',
                 '-U__CUDA_NO_HALF2_OPERATORS__'
             ]
+            if os.environ.get('DS_DEBUG_CUDA_BUILD', '0') == '1':
+                args.append('--ptxas-options=-v')
             args += self.compute_capability_args()
         return args
 


### PR DESCRIPTION
This PR introduces a `DS_DEBUG_CUDA_BUILD` environment variable that when set enables more verbose compilation of CUDA ops by dumping information from the PTX assembler. I chose an environment variable to introduce this for a couple of reasons:

1. The compilation pipeline already has a flag for `verbose` compilation that defaults to true. The level of detail exposed with this flag is a step beyond what I would consider to be appropriate for a default behavior.
2. Using an environment variable makes this emerge as a feature of the environment. Since it's use should be primarily (exclusively?) in development environments, this matches that semantic and minimizes the chances an argument to enable it is inadvertently left in code.

All in all, it's a relatively minor feature to add that will probably only impact a handful of people. If we don't want to open the door to potentially more environment variables (and can rely on manual code tweaking to enable this behavior), feel free to close the PR.