### PR TITLE
Fix broken kernel inject bug

### DIFF
--- a/deepspeed/inference/engine.py
+++ b/deepspeed/inference/engine.py
@@ -126,7 +126,7 @@ class InferenceEngine(Module):
                 self._apply_injection_policy(config, client_module)
         elif config.replace_method == 'auto':
             self._apply_injection_policy(config)
-        else:
+        elif not config.replace_with_kernel_inject:
             # Automatic Tensor Parallelism
             parser_dict = AutoTP.tp_parser(model)
             for client_module, injection_policy in parser_dict:


### PR DESCRIPTION
Kernel injection was broken by auto tensor parallelism. Need to ensure kernel injection is not enabled before attempting tensor parallelism.