### PR TITLE
Container param cleanup + remove qkv_merging

### DIFF
--- a/deepspeed/model_implementations/transformers/ds_bert.py
+++ b/deepspeed/model_implementations/transformers/ds_bert.py
@@ -14,12 +14,10 @@ class DeepSpeedBERTInference(DeepSpeedTransformerInference):
                  quantize_scales=None,
                  quantize_groups=1,
                  merge_count=1,
-                 mlp_extra_grouping=False,
-                 qkv_merging=False):
+                 mlp_extra_grouping=False):
         super().__init__(config,
                          mp_group,
                          quantize_scales,
                          quantize_groups,
                          merge_count,
-                         mlp_extra_grouping,
-                         qkv_merging)
+                         mlp_extra_grouping)

--- a/deepspeed/model_implementations/transformers/ds_bloom.py
+++ b/deepspeed/model_implementations/transformers/ds_bloom.py
@@ -14,12 +14,10 @@ class DeepSpeedBloomInference(DeepSpeedTransformerInference):
                  quantize_scales=None,
                  quantize_groups=1,
                  merge_count=1,
-                 mlp_extra_grouping=False,
-                 qkv_merging=False):
+                 mlp_extra_grouping=False):
         super().__init__(config,
                          mp_group,
                          quantize_scales,
                          quantize_groups,
                          merge_count,
-                         mlp_extra_grouping,
-                         qkv_merging)
+                         mlp_extra_grouping)

--- a/deepspeed/model_implementations/transformers/ds_gpt.py
+++ b/deepspeed/model_implementations/transformers/ds_gpt.py
@@ -14,12 +14,10 @@ class DeepSpeedGPTInference(DeepSpeedTransformerInference):
                  quantize_scales=None,
                  quantize_groups=1,
                  merge_count=1,
-                 mlp_extra_grouping=False,
-                 qkv_merging=False):
+                 mlp_extra_grouping=False):
         super().__init__(config,
                          mp_group,
                          quantize_scales,
                          quantize_groups,
                          merge_count,
-                         mlp_extra_grouping,
-                         qkv_merging)
+                         mlp_extra_grouping)

--- a/deepspeed/model_implementations/transformers/ds_megatron_gpt.py
+++ b/deepspeed/model_implementations/transformers/ds_megatron_gpt.py
@@ -14,12 +14,10 @@ class DeepSpeedMegatronGPTInference(DeepSpeedTransformerInference):
                  quantize_scales=None,
                  quantize_groups=1,
                  merge_count=1,
-                 mlp_extra_grouping=False,
-                 qkv_merging=False):
+                 mlp_extra_grouping=False):
         super().__init__(config,
                          mp_group,
                          quantize_scales,
                          quantize_groups,
                          merge_count,
-                         mlp_extra_grouping,
-                         qkv_merging)
+                         mlp_extra_grouping)

--- a/deepspeed/model_implementations/transformers/ds_opt.py
+++ b/deepspeed/model_implementations/transformers/ds_opt.py
@@ -14,12 +14,10 @@ class DeepSpeedOPTInference(DeepSpeedTransformerInference):
                  quantize_scales=None,
                  quantize_groups=1,
                  merge_count=1,
-                 mlp_extra_grouping=False,
-                 qkv_merging=False):
+                 mlp_extra_grouping=False):
         super().__init__(config,
                          mp_group,
                          quantize_scales,
                          quantize_groups,
                          merge_count,
-                         mlp_extra_grouping,
-                         qkv_merging)
+                         mlp_extra_grouping)

--- a/deepspeed/model_implementations/transformers/ds_transformer.py
+++ b/deepspeed/model_implementations/transformers/ds_transformer.py
@@ -39,8 +39,7 @@ class DeepSpeedTransformerInference(nn.Module):
                  quantize_scales=None,
                  quantize_groups=1,
                  merge_count=1,
-                 mlp_extra_grouping=False,
-                 qkv_merging=False):
+                 mlp_extra_grouping=False):
         super(DeepSpeedTransformerInference, self).__init__()
 
         self.config = config
@@ -61,15 +60,13 @@ class DeepSpeedTransformerInference(nn.Module):
                                                 mp_group,
                                                 quantize_scales,
                                                 quantize_groups,
-                                                merge_count,
-                                                qkv_merging)
+                                                merge_count)
         else:
             self.attention = DeepSpeedSelfAttention(self.config,
                                                     mp_group,
                                                     quantize_scales,
                                                     quantize_groups,
-                                                    merge_count,
-                                                    qkv_merging)
+                                                    merge_count)
         self.mlp = DeepSpeedMLP(self.config,
                                 mp_group,
                                 quantize_scales,

--- a/deepspeed/module_inject/containers/base.py
+++ b/deepspeed/module_inject/containers/base.py
@@ -71,13 +71,13 @@ class BaseTransformerContainer(ABC):
         self.input_nw = None
         self.input_nb = None
 
-    def create_ds_inf_config(self):
+    def create_ds_model_config(self):
         self.set_hidden_heads(*self.policy.get_hidden_heads())
         assert self.num_attention_heads % self.mp_size == 0,\
                 "To run the model parallel across the GPUs, the attention_heads require to be divisible by the world_size!" +\
                 "This is because the attention computation is partitioned evenly among the parallel GPUs."
 
-        self.ds_inf_config = DeepSpeedInferenceConfig(
+        self.ds_model_config = DeepSpeedInferenceConfig(
             hidden_size=self.hidden_size,
             heads=self.num_attention_heads,
             layer_norm_eps=self.layer_norm_eps,
@@ -100,7 +100,7 @@ class BaseTransformerContainer(ABC):
             return_single_tuple=self.return_single_tuple,
         )
 
-        return self.ds_inf_config
+        return self.ds_model_config
 
     def initialize_tensors(self):
         # Set the tensors from policy (user module) to container (DS module)

--- a/deepspeed/module_inject/containers/base.py
+++ b/deepspeed/module_inject/containers/base.py
@@ -71,13 +71,13 @@ class BaseTransformerContainer(ABC):
         self.input_nw = None
         self.input_nb = None
 
-    def create_config(self):
+    def create_ds_inf_config(self):
         self.set_hidden_heads(*self.policy.get_hidden_heads())
         assert self.num_attention_heads % self.mp_size == 0,\
                 "To run the model parallel across the GPUs, the attention_heads require to be divisible by the world_size!" +\
                 "This is because the attention computation is partitioned evenly among the parallel GPUs."
 
-        self.config = DeepSpeedInferenceConfig(
+        self.ds_inf_config = DeepSpeedInferenceConfig(
             hidden_size=self.hidden_size,
             heads=self.num_attention_heads,
             layer_norm_eps=self.layer_norm_eps,
@@ -100,7 +100,7 @@ class BaseTransformerContainer(ABC):
             return_single_tuple=self.return_single_tuple,
         )
 
-        return self.config
+        return self.ds_inf_config
 
     def initialize_tensors(self):
         # Set the tensors from policy (user module) to container (DS module)

--- a/deepspeed/module_inject/containers/base_moe.py
+++ b/deepspeed/module_inject/containers/base_moe.py
@@ -31,13 +31,13 @@ class BaseTransformerMoEContainer(BaseTransformerContainer):
         self._res_4hh_b = None
         self._res_coef = None
 
-    def create_ds_inf_config(self):
+    def create_ds_model_config(self):
         self.set_hidden_heads(*self.policy.get_hidden_heads())
         assert self.num_attention_heads % self.mp_size == 0,\
                 "To run the model parallel across the GPUs, the attention_heads require to be divisible by the world_size!" +\
                 "This is because the attention computation is partitioned evenly among the parallel GPUs."
 
-        self.ds_inf_config = transformer_inference.DeepSpeedMoEInferenceConfig(
+        self.ds_model_config = transformer_inference.DeepSpeedMoEInferenceConfig(
             hidden_size=self.hidden_size,
             heads=self.num_attention_heads,
             layer_norm_eps=self.layer_norm_eps,
@@ -51,7 +51,7 @@ class BaseTransformerMoEContainer(BaseTransformerContainer):
             scale_attn_by_inverse_layer_idx=self.scale_attn_by_inverse_layer_idx,
         )
 
-        return self.ds_inf_config
+        return self.ds_model_config
 
     def initialize_tensors(self):
         # Set the tensors from policy (user module) to container (DS module)

--- a/deepspeed/module_inject/containers/base_moe.py
+++ b/deepspeed/module_inject/containers/base_moe.py
@@ -31,13 +31,13 @@ class BaseTransformerMoEContainer(BaseTransformerContainer):
         self._res_4hh_b = None
         self._res_coef = None
 
-    def create_config(self):
+    def create_ds_inf_config(self):
         self.set_hidden_heads(*self.policy.get_hidden_heads())
         assert self.num_attention_heads % self.mp_size == 0,\
                 "To run the model parallel across the GPUs, the attention_heads require to be divisible by the world_size!" +\
                 "This is because the attention computation is partitioned evenly among the parallel GPUs."
 
-        self.config = transformer_inference.DeepSpeedMoEInferenceConfig(
+        self.ds_inf_config = transformer_inference.DeepSpeedMoEInferenceConfig(
             hidden_size=self.hidden_size,
             heads=self.num_attention_heads,
             layer_norm_eps=self.layer_norm_eps,
@@ -51,7 +51,7 @@ class BaseTransformerMoEContainer(BaseTransformerContainer):
             scale_attn_by_inverse_layer_idx=self.scale_attn_by_inverse_layer_idx,
         )
 
-        return self.config
+        return self.ds_inf_config
 
     def initialize_tensors(self):
         # Set the tensors from policy (user module) to container (DS module)

--- a/deepspeed/module_inject/containers/bert.py
+++ b/deepspeed/module_inject/containers/bert.py
@@ -14,7 +14,7 @@ class DS_BERTContainer(BaseTransformerContainer):
         self.triangular_masking = False
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.ds_inf_config
+        _config = config if config is not None else self.ds_model_config
         self.module = DeepSpeedBERTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module

--- a/deepspeed/module_inject/containers/bert.py
+++ b/deepspeed/module_inject/containers/bert.py
@@ -14,7 +14,7 @@ class DS_BERTContainer(BaseTransformerContainer):
         self.triangular_masking = False
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.config
+        _config = config if config is not None else self.ds_inf_config
         self.module = DeepSpeedBERTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module

--- a/deepspeed/module_inject/containers/bert.py
+++ b/deepspeed/module_inject/containers/bert.py
@@ -15,9 +15,7 @@ class DS_BERTContainer(BaseTransformerContainer):
 
     def create_module(self, config=None):
         _config = config if config is not None else self.config
-        self.module = DeepSpeedBERTInference(_config,
-                                             mp_group=self.mp_group,
-                                             qkv_merging=True)
+        self.module = DeepSpeedBERTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module
 

--- a/deepspeed/module_inject/containers/bloom.py
+++ b/deepspeed/module_inject/containers/bloom.py
@@ -14,7 +14,7 @@ class DS_BloomContainer(MetaTensorContainer, BaseTransformerContainer):
         self.bigscience_bloom = True
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.config
+        _config = config if config is not None else self.ds_inf_config
 
         self.module = DeepSpeedBloomInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention

--- a/deepspeed/module_inject/containers/bloom.py
+++ b/deepspeed/module_inject/containers/bloom.py
@@ -14,7 +14,7 @@ class DS_BloomContainer(MetaTensorContainer, BaseTransformerContainer):
         self.bigscience_bloom = True
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.ds_inf_config
+        _config = config if config is not None else self.ds_model_config
 
         self.module = DeepSpeedBloomInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention

--- a/deepspeed/module_inject/containers/clip.py
+++ b/deepspeed/module_inject/containers/clip.py
@@ -12,7 +12,7 @@ class DS_CLIPContainer(BaseTransformerContainer):
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.config
+        _config = config if config is not None else self.ds_inf_config
         self.module = DeepSpeedGPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module

--- a/deepspeed/module_inject/containers/clip.py
+++ b/deepspeed/module_inject/containers/clip.py
@@ -12,7 +12,7 @@ class DS_CLIPContainer(BaseTransformerContainer):
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.ds_inf_config
+        _config = config if config is not None else self.ds_model_config
         self.module = DeepSpeedGPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module

--- a/deepspeed/module_inject/containers/distil_bert.py
+++ b/deepspeed/module_inject/containers/distil_bert.py
@@ -15,9 +15,7 @@ class DS_DistilBERTContainer(BaseTransformerContainer):
 
     def create_module(self, config=None):
         _config = config if config is not None else self.config
-        self.module = DeepSpeedBERTInference(_config,
-                                             mp_group=self.mp_group,
-                                             qkv_merging=True)
+        self.module = DeepSpeedBERTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module
 

--- a/deepspeed/module_inject/containers/distil_bert.py
+++ b/deepspeed/module_inject/containers/distil_bert.py
@@ -14,7 +14,7 @@ class DS_DistilBERTContainer(BaseTransformerContainer):
         self.return_single_tuple = True
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.config
+        _config = config if config is not None else self.ds_inf_config
         self.module = DeepSpeedBERTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module

--- a/deepspeed/module_inject/containers/distil_bert.py
+++ b/deepspeed/module_inject/containers/distil_bert.py
@@ -14,7 +14,7 @@ class DS_DistilBERTContainer(BaseTransformerContainer):
         self.return_single_tuple = True
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.ds_inf_config
+        _config = config if config is not None else self.ds_model_config
         self.module = DeepSpeedBERTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module

--- a/deepspeed/module_inject/containers/gpt2.py
+++ b/deepspeed/module_inject/containers/gpt2.py
@@ -10,7 +10,7 @@ class DS_GPT2Container(BaseTransformerContainer):
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.config
+        _config = config if config is not None else self.ds_inf_config
         self.module = DeepSpeedGPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module

--- a/deepspeed/module_inject/containers/gpt2.py
+++ b/deepspeed/module_inject/containers/gpt2.py
@@ -10,7 +10,7 @@ class DS_GPT2Container(BaseTransformerContainer):
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.ds_inf_config
+        _config = config if config is not None else self.ds_model_config
         self.module = DeepSpeedGPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module

--- a/deepspeed/module_inject/containers/gptj.py
+++ b/deepspeed/module_inject/containers/gptj.py
@@ -13,7 +13,7 @@ class DS_GPTJContainer(MetaTensorContainer, BaseTransformerContainer):
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.config
+        _config = config if config is not None else self.ds_inf_config
         self.module = DeepSpeedGPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module

--- a/deepspeed/module_inject/containers/gptj.py
+++ b/deepspeed/module_inject/containers/gptj.py
@@ -13,7 +13,7 @@ class DS_GPTJContainer(MetaTensorContainer, BaseTransformerContainer):
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.ds_inf_config
+        _config = config if config is not None else self.ds_model_config
         self.module = DeepSpeedGPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module

--- a/deepspeed/module_inject/containers/gptneo.py
+++ b/deepspeed/module_inject/containers/gptneo.py
@@ -13,7 +13,7 @@ class DS_GPTNEOContainer(MetaTensorContainer, BaseTransformerContainer):
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.ds_inf_config
+        _config = config if config is not None else self.ds_model_config
         self.module = DeepSpeedGPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module

--- a/deepspeed/module_inject/containers/gptneo.py
+++ b/deepspeed/module_inject/containers/gptneo.py
@@ -13,7 +13,7 @@ class DS_GPTNEOContainer(MetaTensorContainer, BaseTransformerContainer):
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.config
+        _config = config if config is not None else self.ds_inf_config
         self.module = DeepSpeedGPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module

--- a/deepspeed/module_inject/containers/gptneox.py
+++ b/deepspeed/module_inject/containers/gptneox.py
@@ -16,7 +16,7 @@ class DS_GPTNEOXContainer(MetaTensorContainer,
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.ds_inf_config
+        _config = config if config is not None else self.ds_model_config
         self.module = DeepSpeedGPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
 

--- a/deepspeed/module_inject/containers/gptneox.py
+++ b/deepspeed/module_inject/containers/gptneox.py
@@ -16,7 +16,7 @@ class DS_GPTNEOXContainer(MetaTensorContainer,
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.config
+        _config = config if config is not None else self.ds_inf_config
         self.module = DeepSpeedGPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
 

--- a/deepspeed/module_inject/containers/megatron_gpt.py
+++ b/deepspeed/module_inject/containers/megatron_gpt.py
@@ -13,7 +13,7 @@ class DS_MegatronGPTContainer(MegatronContainer, BaseTransformerContainer):
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.config
+        _config = config if config is not None else self.ds_inf_config
         self.module = DeepSpeedMegatronGPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
 

--- a/deepspeed/module_inject/containers/megatron_gpt.py
+++ b/deepspeed/module_inject/containers/megatron_gpt.py
@@ -13,7 +13,7 @@ class DS_MegatronGPTContainer(MegatronContainer, BaseTransformerContainer):
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.ds_inf_config
+        _config = config if config is not None else self.ds_model_config
         self.module = DeepSpeedMegatronGPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
 

--- a/deepspeed/module_inject/containers/megatron_gpt_moe.py
+++ b/deepspeed/module_inject/containers/megatron_gpt_moe.py
@@ -14,7 +14,7 @@ class DS_MegatronGPTMoEContainer(MegatronContainer, BaseTransformerMoEContainer)
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.ds_inf_config
+        _config = config if config is not None else self.ds_model_config
         self.module = DeepSpeedMegatronGPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
 

--- a/deepspeed/module_inject/containers/megatron_gpt_moe.py
+++ b/deepspeed/module_inject/containers/megatron_gpt_moe.py
@@ -14,7 +14,7 @@ class DS_MegatronGPTMoEContainer(MegatronContainer, BaseTransformerMoEContainer)
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.config
+        _config = config if config is not None else self.ds_inf_config
         self.module = DeepSpeedMegatronGPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
 

--- a/deepspeed/module_inject/containers/opt.py
+++ b/deepspeed/module_inject/containers/opt.py
@@ -14,7 +14,7 @@ class DS_OPTContainer(MetaTensorContainer, BaseTransformerContainer):
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.ds_inf_config
+        _config = config if config is not None else self.ds_model_config
         self.module = DeepSpeedOPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module

--- a/deepspeed/module_inject/containers/opt.py
+++ b/deepspeed/module_inject/containers/opt.py
@@ -14,7 +14,7 @@ class DS_OPTContainer(MetaTensorContainer, BaseTransformerContainer):
         # All model specific things should be defined here instead of the base class.
 
     def create_module(self, config=None):
-        _config = config if config is not None else self.config
+        _config = config if config is not None else self.ds_inf_config
         self.module = DeepSpeedOPTInference(_config, mp_group=self.mp_group)
         self.module.config.scale_attention = self.scale_attention
         return self.module

--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -373,7 +373,7 @@ def replace_transformer_layer(orig_layer_impl,
         _container.set_quantization_config(quantize, quantizer)
 
         # 6. create a DS Inference config object
-        _container.create_config()
+        _container.create_ds_inf_config()
 
         # 7. use the config and create the module
         _container.create_module()
@@ -396,7 +396,7 @@ def replace_transformer_layer(orig_layer_impl,
             selected_policy_g = _container.policy
 
         megatron_v2_g = _container.megatron_v2
-        transformer_config_g = _container.config
+        transformer_config_g = _container.ds_inf_config
 
         return _container.module
 

--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -373,7 +373,7 @@ def replace_transformer_layer(orig_layer_impl,
         _container.set_quantization_config(quantize, quantizer)
 
         # 6. create a DS Inference config object
-        _container.create_ds_inf_config()
+        _container.create_ds_model_config()
 
         # 7. use the config and create the module
         _container.create_module()
@@ -396,7 +396,7 @@ def replace_transformer_layer(orig_layer_impl,
             selected_policy_g = _container.policy
 
         megatron_v2_g = _container.megatron_v2
-        transformer_config_g = _container.ds_inf_config
+        transformer_config_g = _container.ds_model_config
 
         return _container.module
 

--- a/deepspeed/ops/transformer/inference/ds_attention.py
+++ b/deepspeed/ops/transformer/inference/ds_attention.py
@@ -15,13 +15,7 @@ minus_inf = -10000.0
 class DeepSpeedSelfAttention(nn.Module):
     num_layers = 0
 
-    def __init__(self,
-                 config,
-                 mp_group=None,
-                 q_scales=None,
-                 q_groups=1,
-                 merge_count=1,
-                 qkv_merging=False):
+    def __init__(self, config, mp_group=None, q_scales=None, q_groups=1, merge_count=1):
         super(DeepSpeedSelfAttention, self).__init__()
         self.config = config
         data_type = torch.int8 if config.q_int8 else torch.half if config.fp16 else torch.float
@@ -66,7 +60,6 @@ class DeepSpeedSelfAttention(nn.Module):
         self.norm_factor = math.sqrt(self.config.hidden_size // self.config.heads)
         if not config.use_mup:
             self.norm_factor = math.sqrt(self.norm_factor)
-        self.qkv_merging = qkv_merging
 
         if self.config.scale_attn_by_inverse_layer_idx is True:
             self.norm_factor *= math.sqrt(self.config.layer_id + 1)

--- a/deepspeed/ops/transformer/inference/moe_inference.py
+++ b/deepspeed/ops/transformer/inference/moe_inference.py
@@ -232,8 +232,7 @@ class DeepSpeedMoEInference(nn.Module):
                  quantize_scales=None,
                  quantize_groups=1,
                  merge_count=1,
-                 mlp_extra_grouping=False,
-                 qkv_merging=False):
+                 mlp_extra_grouping=False):
         super(DeepSpeedMoEInference, self).__init__()
 
         self.config = config
@@ -256,8 +255,7 @@ class DeepSpeedMoEInference(nn.Module):
                                                 mp_group,
                                                 quantize_scales,
                                                 quantize_groups,
-                                                merge_count,
-                                                qkv_merging)
+                                                merge_count)
         self.attn_nw = nn.Parameter(torch.Tensor(self.config.hidden_size))
         self.attn_nb = nn.Parameter(torch.Tensor(self.config.hidden_size))
 


### PR DESCRIPTION
This PR cleans up some container items and removes an unused `qkv_merging` parameter:
* Remove `qkv_merging=True` from BERT containers
* Change containers `config` object to `ds_model_config`
* Remove `qkv_merging` param