### PR TITLE
Allow abcmeta types for injection policy for container policies

### DIFF
--- a/deepspeed/inference/config.py
+++ b/deepspeed/inference/config.py
@@ -7,6 +7,7 @@ from typing import Dict, Union
 from enum import Enum
 from abc import ABCMeta
 
+
 class DtypeEnum(Enum):
     # The torch dtype must always be the first value (so we return torch.dtype)
     fp16 = torch.float16, "torch.float16", "fp16", "float16", "half"

--- a/deepspeed/inference/config.py
+++ b/deepspeed/inference/config.py
@@ -5,7 +5,7 @@ from pydantic import Field
 from pydantic import validator
 from typing import Dict, Union
 from enum import Enum
-
+from abc import ABCMeta
 
 class DtypeEnum(Enum):
     # The torch dtype must always be the first value (so we return torch.dtype)
@@ -230,7 +230,8 @@ class DeepSpeedInferenceConfig(DeepSpeedConfigModel):
     policy. e.g., `{BertLayer : deepspeed.inference.HFBertLayerPolicy}`
     """
 
-    injection_policy_tuple: tuple = None
+    #injection_policy_tuple: tuple = None
+    injection_policy_tuple: Union[tuple, ABCMeta] = None
     """ TODO: Add docs """
 
     config: Dict = Field(


### PR DESCRIPTION
Fix "not valid tuple"  when using container policies: https://github.com/microsoft/DeepSpeed/issues/2602

Users have been working around the issue by "tuple-ing" the policy in inference engine then "un-tuple-ing" in replace_module.py. Instead we can allow tuple and ABCMeta types for policies.