### PR TITLE
Add container load checkpoint error reporting + refactor

### DIFF
--- a/deepspeed/module_inject/containers/base.py
+++ b/deepspeed/module_inject/containers/base.py
@@ -21,6 +21,7 @@ class BaseTransformerContainer(ABC):
 
         self.megatron_v2 = self.policy.is_megatron_v2
         self.scale_attention = self.policy.scale_attention
+        self.ckpt_load_enabled = False
 
         # configuration for models. todo: can this be moved to a pydantic model config?
         self.hidden_size = None

--- a/deepspeed/module_inject/containers/bert.py
+++ b/deepspeed/module_inject/containers/bert.py
@@ -77,6 +77,3 @@ class HFBertLayerPolicy(TransformerPolicy):
                attention_layernorm.bias, \
                transformer_layernorm.weight, \
                transformer_layernorm.bias
-
-    def get_param_names(self):
-        pass

--- a/deepspeed/module_inject/containers/bloom.py
+++ b/deepspeed/module_inject/containers/bloom.py
@@ -28,6 +28,22 @@ class DS_BloomContainer(MetaTensorContainer, BaseTransformerContainer):
             self.module.attention.attn_qkvb,
             self.qkvb)
 
+    def get_param_names(self):
+        return 'self_attention.query_key_value.weight', \
+               'self_attention.query_key_value.bias', \
+               'self_attention.dense.weight', \
+               'self_attention.dense.bias', \
+               'mlp.dense_h_to_4h.weight', \
+               'mlp.dense_h_to_4h.bias', \
+               'mlp.dense_4h_to_h.weight', \
+               'mlp.dense_4h_to_h.bias', \
+               'input_layernorm.weight', \
+               'input_layernorm.bias', \
+               'post_attention_layernorm.weight', \
+               'post_attention_layernorm.bias', \
+               self.policy.use_load_prefix, \
+               self.policy.split_qkv
+
 
 class BLOOMLayerPolicy(TransformerPolicy):
     _orig_layer_class = None
@@ -75,19 +91,3 @@ class BLOOMLayerPolicy(TransformerPolicy):
                self.client_module.post_attention_layernorm.bias, \
                self.client_module.input_layernorm.weight, \
                self.client_module.input_layernorm.bias
-
-    def get_param_names(self):
-        return 'self_attention.query_key_value.weight', \
-               'self_attention.query_key_value.bias', \
-               'self_attention.dense.weight', \
-               'self_attention.dense.bias', \
-               'mlp.dense_h_to_4h.weight', \
-               'mlp.dense_h_to_4h.bias', \
-               'mlp.dense_4h_to_h.weight', \
-               'mlp.dense_4h_to_h.bias', \
-               'input_layernorm.weight', \
-               'input_layernorm.bias', \
-               'post_attention_layernorm.weight', \
-               'post_attention_layernorm.bias', \
-               self.use_load_prefix, \
-               self.split_qkv

--- a/deepspeed/module_inject/containers/clip.py
+++ b/deepspeed/module_inject/containers/clip.py
@@ -62,6 +62,3 @@ class HFCLIPLayerPolicy(TransformerPolicy):
                self.client_module.layer_norm2.bias, \
                self.client_module.layer_norm1.weight, \
                self.client_module.layer_norm1.bias
-
-    def get_param_names(self):
-        pass

--- a/deepspeed/module_inject/containers/distil_bert.py
+++ b/deepspeed/module_inject/containers/distil_bert.py
@@ -71,6 +71,3 @@ class HFDistilBertLayerPolicy(TransformerPolicy):
                attention_layernorm.bias, \
                transformer_layernorm.weight, \
                transformer_layernorm.bias
-
-    def get_param_names(self):
-        pass

--- a/deepspeed/module_inject/containers/features/meta_tensor.py
+++ b/deepspeed/module_inject/containers/features/meta_tensor.py
@@ -1,10 +1,11 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 
 
 class MetaTensorContainer(ABC):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.is_meta = False
+        self.ckpt_load_enabled = True
 
     def initialize_tensors(self):
         super().initialize_tensors()
@@ -30,3 +31,31 @@ class MetaTensorContainer(ABC):
     def transpose(self):
         if not self.is_meta:
             super().transpose()
+
+    @abstractmethod
+    def get_param_names(self):
+        """
+        Returns all the transformer parameter names to
+        be loaded from checkpoint files. The order of
+        the names is as follows:
+            1. Attention weights and biases;
+            2. MLP weights and biases;
+            3. LayerNorm weights and biases;
+        In addition to the parameter names, we require two
+        more parameters to help read the the data correctly
+        from the checkpoint and split the qkv heads in the
+        right order:
+            1. `use_load_prefix` (Default: False): this specifies
+                whether we need to use the name of first abstraction
+                layer of the model for searching the parameter's name
+                in a checkpoint file. For more information of how this
+                is used please see
+                https://github.com/microsoft/DeepSpeed/blob/fix-ckpt-loading/deepspeed/module_inject/load_checkpoint.py#L341
+            2. `split_qkv` (Default: True): we use this flag when splitting
+                the qkv parameter into heads. If it is False, it means the heads
+                of q, k, and v are stored together and needs to split in the
+                DeepSpeed-Inference API.
+        """
+        raise NotImplementedError(
+            "A get_param_names() function must be defined in the model container \
+                                  when inheriting the MetaTensorContainer feature")

--- a/deepspeed/module_inject/containers/gpt2.py
+++ b/deepspeed/module_inject/containers/gpt2.py
@@ -50,6 +50,3 @@ class HFGPT2LayerPolicy(TransformerPolicy):
                self.client_module.ln_2.bias, \
                self.client_module.ln_1.weight, \
                self.client_module.ln_1.bias
-
-    def get_param_names(self):
-        pass

--- a/deepspeed/module_inject/containers/gptj.py
+++ b/deepspeed/module_inject/containers/gptj.py
@@ -18,6 +18,20 @@ class DS_GPTJContainer(MetaTensorContainer, BaseTransformerContainer):
         self.module.config.scale_attention = self.scale_attention
         return self.module
 
+    def get_param_names(self):
+        return 'attn.q_proj.weight', \
+               'attn.k_proj.weight', \
+               'attn.v_proj.weight', \
+               'attn.out_proj.weight', \
+               'mlp.fc_in.weight', \
+               'mlp.fc_in.bias', \
+               'mlp.fc_out.weight', \
+               'mlp.fc_out.bias', \
+               'ln_1.weight', \
+               'ln_1.bias', \
+               self.policy.use_load_prefix, \
+               self.policy.split_qkv
+
 
 class HFGPTJLayerPolicy(TransformerPolicy):
     _orig_layer_class = None
@@ -58,17 +72,3 @@ class HFGPTJLayerPolicy(TransformerPolicy):
                None, \
                self.client_module.ln_1.weight, \
                self.client_module.ln_1.bias
-
-    def get_param_names(self):
-        return 'attn.q_proj.weight', \
-               'attn.k_proj.weight', \
-               'attn.v_proj.weight', \
-               'attn.out_proj.weight', \
-               'mlp.fc_in.weight', \
-               'mlp.fc_in.bias', \
-               'mlp.fc_out.weight', \
-               'mlp.fc_out.bias', \
-               'ln_1.weight', \
-               'ln_1.bias', \
-               self.use_load_prefix, \
-               self.split_qkv

--- a/deepspeed/module_inject/containers/gptneo.py
+++ b/deepspeed/module_inject/containers/gptneo.py
@@ -18,6 +18,22 @@ class DS_GPTNEOContainer(MetaTensorContainer, BaseTransformerContainer):
         self.module.config.scale_attention = self.scale_attention
         return self.module
 
+    def get_param_names(self):
+        return 'attention.query_key_value.weight', \
+               'attention.query_key_value.bias', \
+               'attention.dense.weight', \
+               'attention.dense.bias', \
+               'mlp.dense_h_to_4h.weight', \
+               'mlp.dense_h_to_4h.bias', \
+               'mlp.dense_4h_to_h.weight', \
+               'mlp.dense_4h_to_h.bias', \
+               'input_layernorm.weight', \
+               'input_layernorm.bias', \
+               'post_attention_layernorm.weight', \
+               'post_attention_layernorm.bias', \
+               self.policy.use_load_prefix, \
+               self.policy.split_qkv
+
 
 class HFGPTNEOLayerPolicy(TransformerPolicy):
     def __init__(self, client_module, inference=True):
@@ -56,19 +72,3 @@ class HFGPTNEOLayerPolicy(TransformerPolicy):
                self.client_module.ln_2.bias, \
                self.client_module.ln_1.weight, \
                self.client_module.ln_1.bias
-
-    def get_param_names(self):
-        return 'attention.query_key_value.weight', \
-               'attention.query_key_value.bias', \
-               'attention.dense.weight', \
-               'attention.dense.bias', \
-               'mlp.dense_h_to_4h.weight', \
-               'mlp.dense_h_to_4h.bias', \
-               'mlp.dense_4h_to_h.weight', \
-               'mlp.dense_4h_to_h.bias', \
-               'input_layernorm.weight', \
-               'input_layernorm.bias', \
-               'post_attention_layernorm.weight', \
-               'post_attention_layernorm.bias', \
-               self.use_load_prefix, \
-               self.split_qkv

--- a/deepspeed/module_inject/containers/gptneox.py
+++ b/deepspeed/module_inject/containers/gptneox.py
@@ -26,6 +26,22 @@ class DS_GPTNEOXContainer(MetaTensorContainer,
 
         return self.module
 
+    def get_param_names(self):
+        return 'attention.query_key_value.weight', \
+               'attention.query_key_value.bias', \
+               'attention.dense.weight', \
+               'attention.dense.bias', \
+               'mlp.dense_h_to_4h.weight', \
+               'mlp.dense_h_to_4h.bias', \
+               'mlp.dense_4h_to_h.weight', \
+               'mlp.dense_4h_to_h.bias', \
+               'input_layernorm.weight', \
+               'input_layernorm.bias', \
+               'post_attention_layernorm.weight', \
+               'post_attention_layernorm.bias', \
+               self.policy.use_load_prefix, \
+               self.policy.split_qkv
+
 
 class GPTNEOXLayerPolicy(TransformerPolicy):
     _orig_layer_class = None
@@ -75,19 +91,3 @@ class GPTNEOXLayerPolicy(TransformerPolicy):
                self.client_module.post_attention_layernorm.bias, \
                self.client_module.input_layernorm.weight, \
                self.client_module.input_layernorm.bias
-
-    def get_param_names(self):
-        return 'attention.query_key_value.weight', \
-               'attention.query_key_value.bias', \
-               'attention.dense.weight', \
-               'attention.dense.bias', \
-               'mlp.dense_h_to_4h.weight', \
-               'mlp.dense_h_to_4h.bias', \
-               'mlp.dense_4h_to_h.weight', \
-               'mlp.dense_4h_to_h.bias', \
-               'input_layernorm.weight', \
-               'input_layernorm.bias', \
-               'post_attention_layernorm.weight', \
-               'post_attention_layernorm.bias', \
-               self.use_load_prefix, \
-               self.split_qkv

--- a/deepspeed/module_inject/containers/megatron_gpt.py
+++ b/deepspeed/module_inject/containers/megatron_gpt.py
@@ -102,6 +102,3 @@ class MegatronLayerPolicy(TransformerPolicy):
                self.client_module.post_attention_layernorm.bias, \
                self.client_module.input_layernorm.weight, \
                self.client_module.input_layernorm.bias
-
-    def get_param_names(self):
-        pass

--- a/deepspeed/module_inject/containers/megatron_gpt_moe.py
+++ b/deepspeed/module_inject/containers/megatron_gpt_moe.py
@@ -78,6 +78,3 @@ class MegatronMoELayerPolicy(MegatronLayerPolicy):
                     self.client_module.mlp.mlp.dense_4h_to_h.weight, \
                     self.client_module.mlp.mlp.dense_4h_to_h.bias, \
                     self.client_module.mlp.coefficient.weight
-
-    def get_param_names(self):
-        pass

--- a/deepspeed/module_inject/containers/opt.py
+++ b/deepspeed/module_inject/containers/opt.py
@@ -19,6 +19,26 @@ class DS_OPTContainer(MetaTensorContainer, BaseTransformerContainer):
         self.module.config.scale_attention = self.scale_attention
         return self.module
 
+    def get_param_names(self):
+        return 'self_attn.q_proj.weight', \
+               'self_attn.q_proj.bias', \
+               'self_attn.k_proj.weight', \
+               'self_attn.k_proj.bias', \
+               'self_attn.v_proj.weight', \
+               'self_attn.v_proj.bias', \
+               'self_attn.out_proj.weight', \
+               'self_attn.out_proj.bias', \
+               'fc1.weight', \
+               'fc1.bias', \
+               'fc2.weight', \
+               'fc2.bias', \
+               'self_attn_layer_norm.weight', \
+               'self_attn_layer_norm.bias', \
+               'final_layer_norm.weight', \
+               'final_layer_norm.bias', \
+               self.policy.use_load_prefix, \
+               self.policy.split_qkv
+
 
 class HFOPTLayerPolicy(TransformerPolicy):
     _orig_layer_class = None
@@ -73,23 +93,3 @@ class HFOPTLayerPolicy(TransformerPolicy):
                self.client_module.final_layer_norm.bias, \
                self.client_module.self_attn_layer_norm.weight, \
                self.client_module.self_attn_layer_norm.bias
-
-    def get_param_names(self):
-        return 'self_attn.q_proj.weight', \
-               'self_attn.q_proj.bias', \
-               'self_attn.k_proj.weight', \
-               'self_attn.k_proj.bias', \
-               'self_attn.v_proj.weight', \
-               'self_attn.v_proj.bias', \
-               'self_attn.out_proj.weight', \
-               'self_attn.out_proj.bias', \
-               'fc1.weight', \
-               'fc1.bias', \
-               'fc2.weight', \
-               'fc2.bias', \
-               'self_attn_layer_norm.weight', \
-               'self_attn_layer_norm.bias', \
-               'final_layer_norm.weight', \
-               'final_layer_norm.bias', \
-               self.use_load_prefix, \
-               self.split_qkv

--- a/deepspeed/module_inject/policy.py
+++ b/deepspeed/module_inject/policy.py
@@ -86,29 +86,3 @@ class TransformerPolicy(DSPolicy):
         gamma and beta with shape: (hidden)
         """
         raise NotImplementedError
-
-    @abstractmethod
-    def get_param_names(self):
-        """
-        Returns all the transformer parameter names to
-        be loaded from checkpoint files. The order of
-        the names is as follows:
-            1. Attention weights and biases;
-            2. MLP weights and biases;
-            3. LayerNorm weights and biases;
-        In addition to the parameter names, we require two
-        more parameters to help read the the data correctly
-        from the checkpoint and split the qkv heads in the
-        right order:
-            1. `use_load_prefix` (Default: False): this specifies
-                whether we need to use the name of first abstraction
-                layer of the model for searching the parameter's name
-                in a checkpoint file. For more information of how this
-                is used please see
-                https://github.com/microsoft/DeepSpeed/blob/fix-ckpt-loading/deepspeed/module_inject/load_checkpoint.py#L341
-            2. `split_qkv` (Default: True): we use this flag when splitting
-                the qkv parameter into heads. If it is False, it means the heads
-                of q, k, and v are stored together and needs to split in the
-                DeepSpeed-Inference API.
-        """
-        raise NotImplementedError

--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -531,7 +531,7 @@ def replace_transformer_layer(orig_layer_impl,
     rank = dist.get_rank() if dist.is_initialized() else 0
     if checkpoint_dict is not None:
         assert container_g.ckpt_load_enabled, \
-               f"Checkpoint loading not supported in {container_g.__class__.__name__} container"
+               f"Meta Tensor checkpoint loading not supported in {container_g.__class__.__name__} container"
         start_time = time.time()
         checkpoint = checkpoint_dict['checkpoints']
         ckpt_list = checkpoint["tp"] if type(checkpoint) is dict else checkpoint

--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -294,9 +294,7 @@ def generic_injection(module, fp16=False, enable_cuda_graph=True):
                 setattr(module, name, new_module)
 
 
-selected_policy_g = None
-megatron_v2_g = False
-transformer_config_g = None
+container_g = None
 
 
 def replace_transformer_layer(orig_layer_impl,
@@ -388,15 +386,10 @@ def replace_transformer_layer(orig_layer_impl,
         _container.copy_data_to_new_module()
 
         # 11. set globals for generic checkpoint loading
-        global selected_policy_g
-        global megatron_v2_g
-        global transformer_config_g
+        global container_g
 
-        if selected_policy_g is None:
-            selected_policy_g = _container.policy
-
-        megatron_v2_g = _container.megatron_v2
-        transformer_config_g = _container.ds_model_config
+        if container_g is None:
+            container_g = _container
 
         return _container.module
 
@@ -537,6 +530,8 @@ def replace_transformer_layer(orig_layer_impl,
     world_size = dist.get_world_size() if dist.is_initialized() else 1
     rank = dist.get_rank() if dist.is_initialized() else 0
     if checkpoint_dict is not None:
+        assert container_g.ckpt_load_enabled, \
+               f"Checkpoint loading not supported in {container_g.__class__.__name__} container"
         start_time = time.time()
         checkpoint = checkpoint_dict['checkpoints']
         ckpt_list = checkpoint["tp"] if type(checkpoint) is dict else checkpoint
@@ -561,9 +556,9 @@ def replace_transformer_layer(orig_layer_impl,
                     mp_replace,
                     ckpt_type,
                     quantizer,
-                    param_names=selected_policy_g.get_param_names(),
-                    transformer_config=transformer_config_g,
-                    megatron_v2=megatron_v2_g)
+                    param_names=container_g.get_param_names(),
+                    transformer_config=container_g.ds_model_config,
+                    megatron_v2=container_g.megatron_v2)
                 pbar.update(1)
         else:
             import gc
@@ -594,9 +589,9 @@ def replace_transformer_layer(orig_layer_impl,
                     ckpt_type,
                     quantizer,
                     int(rank % tp_split_size),
-                    param_names=selected_policy_g.get_param_names(),
-                    transformer_config=transformer_config_g,
-                    megatron_v2=megatron_v2_g)
+                    param_names=container_g.get_param_names(),
+                    transformer_config=container_g.ds_model_config,
+                    megatron_v2=container_g.megatron_v2)
                 sds = [None for _ in sds]
                 gc.collect()
 
@@ -618,9 +613,9 @@ def replace_transformer_layer(orig_layer_impl,
                         ckpt_type,
                         quantizer,
                         int(rank % tp_split_size),
-                        param_names=selected_policy_g.get_param_names(),
-                        transformer_config=transformer_config_g,
-                        megatron_v2=megatron_v2_g)
+                        param_names=container_g.get_param_names(),
+                        transformer_config=container_g.ds_model_config,
+                        megatron_v2=container_g.megatron_v2)
                     sds = [None for _ in sds]
                     gc.collect()
         print(f"checkpoint loading time at rank {rank}: {time.time()-start_time} sec")


### PR DESCRIPTION
This PR refactors the organization of meta tensor checkpoint loading as follows:
* Move `get_param_names()` abstract method definition from `TransformerPolicy` into `MetaTensorContainer`
* Model-specific `get_param_names()` definitions moved from policy into model-specific container
* `selected_policy_g`, `megatron_v2_g`, and `transformer_config_g` globals replaced with a single `container_g` global, since the container will contain all of the information those globals previously captured
* `ckpt_load_enabled` flag added to containers that's set to `False` by default in the `base.py` container and gets set to `True` when the `MetaTensorContainer` feature is inherited
* Assertion added to `replace_transformer_layer` before performing checkpoint loading to check if `ckpt_load_enabled == True`, otherwise an error message will be printed saying that the container does not support meta tensor checkpoint loading.

The aim of these changes is to more closely couple meta tensor checkpoint loading code to the `MetaTensorContainer` and to allow for better error reporting of load checkpoint use on model types that don't support this feature.