### PR TITLE
Fix Slurm launcher user args

### DIFF
--- a/deepspeed/launcher/multinode_runner.py
+++ b/deepspeed/launcher/multinode_runner.py
@@ -187,7 +187,7 @@ class SlurmRunner(MultiNodeRunner):
             'srun',
             '-n',
             f'{total_process_count}',
-        ]
+        ] + split(self.args.launcher_args)
 
         if getattr(self.args, 'slurm_comment', ''):
             srun_cmd += ['--comment', self.args.slurm_comment]


### PR DESCRIPTION
- Slurm was also missing the connection to add the user provided `--launcher_args` 