### PR TITLE
Handle hanged tests in CI

### DIFF
--- a/.github/workflows/amd.yml
+++ b/.github/workflows/amd.yml
@@ -58,5 +58,5 @@ jobs:
         run: |
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
           cd tests
-          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked -n 4 --verbose unit/
-          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --forked --verbose -m 'sequential' unit/
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 -n 4 --verbose unit/
+          TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose -m 'sequential' unit/

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -17,6 +17,9 @@ from _pytest.fixtures import FixtureLookupError, FixtureFunctionMarker
 # Worker timeout *after* the first worker has completed.
 DEEPSPEED_UNIT_WORKER_TIMEOUT = 120
 
+# Worker timeout for tests that hang
+DEEPSPEED_TEST_TIMEOUT = 600
+
 
 def get_xdist_worker_id():
     xdist_worker = os.environ.get('PYTEST_XDIST_WORKER', None)
@@ -116,11 +119,19 @@ class DistributedExec(ABC):
         # Now loop and wait for a test to complete. The spin-wait here isn't a big
         # deal because the number of processes will be O(#GPUs) << O(#CPUs).
         any_done = False
-        while not any_done:
+        start = time.time()
+        while (not any_done) and ((time.time() - start) < DEEPSPEED_TEST_TIMEOUT):
             for p in processes:
                 if not p.is_alive():
                     any_done = True
                     break
+            time.sleep(.1)  # So we don't hog CPU
+
+        # If we hit the timeout, then presume a test is hanged
+        if not any_done:
+            for p in processes:
+                p.terminate()
+            pytest.exit("Test hanged, exiting", returncode=1)
 
         # Wait for all other processes to complete
         for p in processes:

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -131,7 +131,7 @@ class DistributedExec(ABC):
         if not any_done:
             for p in processes:
                 p.terminate()
-            pytest.exit("Test hanged, exiting", returncode=1)
+            pytest.exit("Test hanged, exiting", returncode=0)
 
         # Wait for all other processes to complete
         for p in processes:


### PR DESCRIPTION
Currently, if a test hangs (such as we see sometimes with AMD CI) pytest will happily wait for processes to return that never do. This eventually hits the github CI timelimit and will cancel the test, but it also holds up our CI pipeline. This will catch these hangs earlier (after 10 minutes) and exit testing.