### PR TITLE
Fix permissions issue with pip upgrade

### DIFF
--- a/.github/workflows/setup-venv/action.yml
+++ b/.github/workflows/setup-venv/action.yml
@@ -7,14 +7,13 @@ runs:
       run: |
         sudo apt-get update && sudo apt-get -y upgrade
         sudo apt-get install -y libaio-dev
-        pip install --upgrade pip
-        python -m pip install -U virtualenv
+        sudo pip install --upgrade pip
+        sudo python -m pip install --upgrade virtualenv
       shell: bash
     - id: create-venv
       run: |
         python -m venv unit-test-venv
         source ./unit-test-venv/bin/activate
-        pip install --upgrade pip
         echo PATH=$PATH >> $GITHUB_ENV # Make it so venv is inherited for other steps
       shell: bash
     - id: print-env

--- a/.github/workflows/setup-venv/action.yml
+++ b/.github/workflows/setup-venv/action.yml
@@ -22,13 +22,15 @@ runs:
         which python
         python --version
         if [[ -z "${AISC_NODE_INSTANCE_ID}" ]]; then
+          echo "Not on self-hosted node"
+        else
           echo "JobID: ${AISC_NODE_INSTANCE_ID}"
         fi
         if command -v nvidia-smi; then
           nvidia-smi
           which nvcc
           nvcc --version
-        elif command -c rocm-smi; then
+        elif command -v rocm-smi; then
           rocm-smi --showhw
           which hipcc
           hipcc --version

--- a/.github/workflows/setup-venv/action.yml
+++ b/.github/workflows/setup-venv/action.yml
@@ -7,8 +7,8 @@ runs:
       run: |
         sudo apt-get update && sudo apt-get -y upgrade
         sudo apt-get install -y libaio-dev
-        sudo pip install --upgrade pip
-        sudo python -m pip install --upgrade virtualenv
+        pip install --user --upgrade pip
+        python -m pip install --user --upgrade virtualenv
       shell: bash
     - id: create-venv
       run: |

--- a/.github/workflows/setup-venv/action.yml
+++ b/.github/workflows/setup-venv/action.yml
@@ -13,8 +13,8 @@ runs:
     - id: create-venv
       run: |
         python -m venv unit-test-venv
-        python -m pip install --upgrade pip
         source ./unit-test-venv/bin/activate
+        python -m pip install --upgrade pip
         echo PATH=$PATH >> $GITHUB_ENV # Make it so venv is inherited for other steps
       shell: bash
     - id: print-env

--- a/.github/workflows/setup-venv/action.yml
+++ b/.github/workflows/setup-venv/action.yml
@@ -7,12 +7,13 @@ runs:
       run: |
         sudo apt-get update && sudo apt-get -y upgrade
         sudo apt-get install -y libaio-dev
-        pip install --user --upgrade pip
+        python -m pip install --user --upgrade pip
         python -m pip install --user --upgrade virtualenv
       shell: bash
     - id: create-venv
       run: |
         python -m venv unit-test-venv
+        python -m pip install --upgrade pip
         source ./unit-test-venv/bin/activate
         echo PATH=$PATH >> $GITHUB_ENV # Make it so venv is inherited for other steps
       shell: bash


### PR DESCRIPTION
On some CI runs, we were seeing the following error:
```
ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: 'euctwprober.cpython-38.pyc'
Consider using the `--user` option or check the permissions.
```