### PR TITLE
Prevent hangs in CI during parallel run compilation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,14 @@ def validate_version(expected, found):
     return found == expected
 
 
+# This fixture prevents hangs when 2+ pytest processes try to compile the same
+# code at once and causes deadlocks / hangs
+@pytest.fixture(scope="session", autouse=True)
+def set_torch_ext_dir(worker_id):
+    torch_ext_dir = os.environ["TORCH_EXTENSIONS_DIR"]
+    os.environ["TORCH_EXTENSIONS_DIR"] = os.path.join(torch_ext_dir, worker_id)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def check_environment(pytestconfig):
     expected_torch_version = pytestconfig.getoption("torch_ver")

--- a/tests/unit/ops/aio/test_aio.py
+++ b/tests/unit/ops/aio/test_aio.py
@@ -250,7 +250,6 @@ class TestWrite(DistributedTest):
         assert filecmp.cmp(ref_file, aio_file, shallow=False)
 
 
-@pytest.mark.sequential
 @pytest.mark.parametrize("use_cuda_pinned_tensor", [True, False])
 @pytest.mark.parametrize("cuda_device", [True, False])
 class TestAsyncQueue(DistributedTest):


### PR DESCRIPTION
We are seeing random hangs, which we believe are caused by multiple pytest processes trying to compile the same code at once creating a deadlock. This PR sets a seperate `TORCH_EXTENSIONS_DIR` for each pytest process to avoid this.

@tjruwase 