### PR TITLE
Fix for CI failure on system upgrade

### DIFF
--- a/.github/workflows/setup-venv/action.yml
+++ b/.github/workflows/setup-venv/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - id: update-env
       run: |
-        sudo apt-get update && sudo apt-get -y upgrade
+        sudo apt-get update
         sudo apt-get install -y libaio-dev
         python -m pip install --user --upgrade pip
         python -m pip install --user --upgrade virtualenv


### PR DESCRIPTION
We're seeing errors when doing `sudo apt-get upgrade` on some CI runs. The upgrade isn't necessary as the images we are using are reasonable recent. Removing this so our tests can run.

Error:
```
Errors were encountered while processing:
 grub-efi-amd64-signed
E: Sub-process /usr/bin/dpkg returned an error code (1)
Error: Process completed with exit code 100.
```