### PR TITLE
Fix Bloom logits mismatch

### DIFF
--- a/deepspeed/ops/transformer/inference/ds_attention.py
+++ b/deepspeed/ops/transformer/inference/ds_attention.py
@@ -244,8 +244,7 @@ class BloomSelfAttention(DeepSpeedSelfAttention):
         ) * self.num_attention_heads_per_partition if dist.is_initialized() else 0
         attention_probs = self.softmax_func(
             attn_scores=attention_scores,
-            attn_mask=((1 - input_mask).half() *
-                       minus_inf) if input_mask.dtype == torch.int64 else input_mask,
+            attn_mask=((1 - input_mask).half() * minus_inf),
             alibi=alibi,
             triangular=(self.config.triangular_masking
                         and (attention_scores.shape[-2] > 1)),


### PR DESCRIPTION
Bloom with kernel injection was showing significant logits mismatch compared to Transformer's baseline as reported by issue https://github.com/microsoft/DeepSpeed/issues/2730. 

Softmax input_mask is float32, not int64, and needs to be converted to half.

@RezaYazdaniAminabadi 