### PR TITLE
Fixes `AttributeError` in #2853

### DIFF
--- a/deepspeed/monitor/monitor.py
+++ b/deepspeed/monitor/monitor.py
@@ -33,9 +33,9 @@ class MonitorMaster(Monitor):
             if monitor_config.tensorboard.enabled:
                 self.tb_monitor = TensorBoardMonitor(monitor_config.tensorboard)
             if monitor_config.wandb.enabled:
-                self.wandb_monitor = WandbMonitor(monitor_config.csv_monitor)
+                self.wandb_monitor = WandbMonitor(monitor_config.wandb)
             if monitor_config.csv_monitor.enabled:
-                self.csv_monitor = csvMonitor(monitor_config.wandb)
+                self.csv_monitor = csvMonitor(monitor_config.csv_monitor)
 
     def write_events(self, event_list):
         if dist.get_rank() == 0:


### PR DESCRIPTION
Updates `deepspeed/monitor/monitor.py` to instantiate objects with correct configs

Specifically, fixes issue when trying to use W&B

```Shell
  File "/soft/datascience/conda/2023-01-10/mconda3/lib/python3.10/site-packages/deepspeed/monitor/wandb.py", line 14, in __init__
    self.group = wandb_config.group
AttributeError: 'CSVConfig' object has no attribute 'group'
```

Relevant issue:
https://github.com/microsoft/DeepSpeed/issues/2853