### PR TITLE
Revert to older transformers version

### DIFF
--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -45,7 +45,7 @@ jobs:
           git clone https://github.com/huggingface/transformers
           cd transformers
           # if needed switch to the last known good SHA until transformers@master is fixed
-          git checkout ds-fix-tests
+          #git checkout ds-fix-tests
           git rev-parse --short HEAD
           # scipy/sklearn required for tests, using the 'dev' extra forces torch re-install
           pip install .[testing]


### PR DESCRIPTION
Recent changes [in logging level in HF transformers ](https://github.com/huggingface/transformers/pull/21700)broke DeepSpeed where we relied on certain logging prints that they changed the defaults on:.  There is currently a [PR out](https://github.com/huggingface/transformers/pull/21769) that provides a workaround to keep backwards compatibility.  

