### PR TITLE
deepspeed.init_distributed() support for TCP protocols

### DIFF
--- a/deepspeed/comm/comm.py
+++ b/deepspeed/comm/comm.py
@@ -604,8 +604,8 @@ def init_distributed(dist_backend=None,
                      init_method=None,
                      dist_init_required=None,
                      config=None,
-                     rank=None,
-                     world_size=None):
+                     rank=-1,
+                     world_size=-1):
     ''' Initialize dist backend, potentially performing MPI discovery if needed
 
     Arguments:

--- a/deepspeed/comm/comm.py
+++ b/deepspeed/comm/comm.py
@@ -603,7 +603,9 @@ def init_distributed(dist_backend=None,
                      timeout=default_pg_timeout,
                      init_method=None,
                      dist_init_required=None,
-                     config=None):
+                     config=None,
+                     rank=None,
+                     world_size=None):
     ''' Initialize dist backend, potentially performing MPI discovery if needed
 
     Arguments:
@@ -658,7 +660,7 @@ def init_distributed(dist_backend=None,
                     'Initializing TorchBackend in DeepSpeed with backend {}'.format(
                         dist_backend))
             # Create a torch backend object, initialize torch distributed, and assign to cdb
-            cdb = TorchBackend(dist_backend, timeout, init_method)
+            cdb = TorchBackend(dist_backend, timeout, init_method, rank, world_size)
 
 
 def mpi_discovery(distributed_port=TORCH_DISTRIBUTED_DEFAULT_PORT, verbose=True):


### PR DESCRIPTION
This little fix in the code will let users (e.g. on CSCS Piz Daint) use the Slurm workload manager combined with the init_method for TCP protocols. For init_method with TCPs, the rank and world_size have to be communicated.