### PR TITLE
Check for local CUDA graphs when enable_cuda_graph=True

### DIFF
--- a/deepspeed/inference/engine.py
+++ b/deepspeed/inference/engine.py
@@ -532,8 +532,6 @@ class InferenceEngine(Module):
             for name in module.__dict__.keys():
                 sub_module = getattr(module, name)
 
-                print(f"DEBUG: sub_module_cuda_graph = {sub_module_cuda_graph}")
-                print(f"DEBUG: sub_module = {sub_module}")
                 if self._module_match(sub_module) and hasattr(sub_module,
                                                               "enable_cuda_graph"):
                     sub_module_cuda_graph = True

--- a/deepspeed/inference/engine.py
+++ b/deepspeed/inference/engine.py
@@ -24,6 +24,8 @@ from deepspeed.accelerator import get_accelerator
 from ..module_inject.policy import TransformerPolicy
 from ..module_inject.auto_tp import AutoTP
 
+from ..module_inject.replace_policy import generic_policies
+
 DS_INFERENCE_ENABLED = False
 from torch import nn
 
@@ -154,6 +156,9 @@ class InferenceEngine(Module):
 
         if config.tensor_parallel.tp_size > 1:
             assert not config.enable_cuda_graph, "Cuda graph is not supported for model parallelism"
+
+        # Check if local CUDA graphs can be created in replacement modules
+        self.local_cuda_graph = self._local_cuda_graph_used(self.module)
 
     def profile_model_time(self, use_cuda_events=True):
         if not self.model_profile_enabled and not self._config.enable_cuda_graph:
@@ -512,6 +517,29 @@ class InferenceEngine(Module):
         self._model_times = []
         return model_times
 
+    def _module_match(self, module):
+        for policy in generic_policies:
+            policy = policy()
+            if policy.match_replaced(module):
+                return True
+        return False
+
+    def _local_cuda_graph_used(self, module):
+        if isinstance(module, torch.nn.Module):
+            return False
+        else:
+            sub_module_cuda_graph = False
+            for name in module.__dict__.keys():
+                sub_module = getattr(module, name)
+
+                print(f"DEBUG: sub_module_cuda_graph = {sub_module_cuda_graph}")
+                print(f"DEBUG: sub_module = {sub_module}")
+                if self._module_match(sub_module) and hasattr(sub_module,
+                                                              "enable_cuda_graph"):
+                    sub_module_cuda_graph = True
+
+            return sub_module_cuda_graph
+
     def forward(self, *inputs, **kwargs):
         """Execute forward propagation
 
@@ -525,7 +553,8 @@ class InferenceEngine(Module):
             get_accelerator().synchronize()
             start = time.time()
 
-        if get_accelerator().device_name() == 'cuda' and self._config.enable_cuda_graph:
+        if get_accelerator().device_name(
+        ) == 'cuda' and self._config.enable_cuda_graph and not self.local_cuda_graph:
             if self.cuda_graph_created:
                 outputs = self._graph_replay(*inputs, **kwargs)
             else:

--- a/deepspeed/model_implementations/diffusers/unet.py
+++ b/deepspeed/model_implementations/diffusers/unet.py
@@ -2,11 +2,12 @@
 Copyright 2022 The Microsoft DeepSpeed Team
 '''
 import torch
+from ..features.cuda_graph import CUDAGraph
 
 
-class DSUNet(torch.nn.Module):
+class DSUNet(CUDAGraph, torch.nn.Module):
     def __init__(self, unet, enable_cuda_graph=True):
-        super().__init__()
+        super().__init__(enable_cuda_graph=enable_cuda_graph)
         self.unet = unet
         # SD pipeline accesses this attribute
         self.in_channels = unet.in_channels
@@ -17,7 +18,6 @@ class DSUNet(torch.nn.Module):
         self.unet.requires_grad_(requires_grad=False)
         self.unet.to(memory_format=torch.channels_last)
         self.cuda_graph_created = False
-        self.enable_cuda_graph = enable_cuda_graph
 
     def _graph_replay(self, *inputs, **kwargs):
         for i in range(len(inputs)):

--- a/deepspeed/model_implementations/features/__init__.py
+++ b/deepspeed/model_implementations/features/__init__.py
@@ -1,0 +1,1 @@
+'''Copyright The Microsoft DeepSpeed Team'''

--- a/deepspeed/model_implementations/features/cuda_graph.py
+++ b/deepspeed/model_implementations/features/cuda_graph.py
@@ -1,0 +1,24 @@
+'''
+Copyright 2023 The Microsoft DeepSpeed Team
+'''
+from abc import ABC, abstractmethod
+
+
+class CUDAGraph(ABC):
+    def __init__(self, enable_cuda_graph=False):
+        super().__init__()
+        self.enable_cuda_graph = enable_cuda_graph
+
+    @abstractmethod
+    def _create_cuda_graph(self):
+        """
+        Create CUDA graph(s)
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _graph_replay(self):
+        """
+        Replay CUDA graph(s)
+        """
+        raise NotImplementedError

--- a/deepspeed/model_implementations/transformers/clip_encoder.py
+++ b/deepspeed/model_implementations/transformers/clip_encoder.py
@@ -3,11 +3,12 @@ Copyright 2022 The Microsoft DeepSpeed Team
 '''
 import torch
 from deepspeed.accelerator import get_accelerator
+from ..features.cuda_graph import CUDAGraph
 
 
-class DSClipEncoder(torch.nn.Module):
+class DSClipEncoder(CUDAGraph, torch.nn.Module):
     def __init__(self, enc, enable_cuda_graph=False):
-        super().__init__()
+        super().__init__(enable_cuda_graph=enable_cuda_graph)
         enc.text_model._build_causal_attention_mask = self._build_causal_attention_mask
         self.enc = enc
         self.device = self.enc.device
@@ -18,7 +19,6 @@ class DSClipEncoder(torch.nn.Module):
         self.static_output = [None, None]
         self._cuda_graphs = [None, None]
         self.iter = 0
-        self.enable_cuda_graph = enable_cuda_graph
         self.config = self.enc.config
 
     def _build_causal_attention_mask(self, bsz, seq_len, dtype):
@@ -44,7 +44,6 @@ class DSClipEncoder(torch.nn.Module):
 
     def forward(self, *inputs, **kwargs):
         if self.enable_cuda_graph:
-            #import pdb; pdb.set_trace()
             if self.cuda_graph_created[self.iter]:
                 outputs = self._graph_replay(*inputs, **kwargs)
             else:

--- a/deepspeed/model_implementations/transformers/clip_encoder.py
+++ b/deepspeed/model_implementations/transformers/clip_encoder.py
@@ -44,6 +44,7 @@ class DSClipEncoder(torch.nn.Module):
 
     def forward(self, *inputs, **kwargs):
         if self.enable_cuda_graph:
+            #import pdb; pdb.set_trace()
             if self.cuda_graph_created[self.iter]:
                 outputs = self._graph_replay(*inputs, **kwargs)
             else:

--- a/deepspeed/module_inject/containers/unet.py
+++ b/deepspeed/module_inject/containers/unet.py
@@ -5,6 +5,7 @@ import torch
 from torch.nn.parameter import Parameter
 
 from ..policy import DSPolicy
+from ...model_implementations.diffusers.unet import DSUNet
 
 
 class UNetPolicy(DSPolicy):
@@ -19,9 +20,11 @@ class UNetPolicy(DSPolicy):
     def match(self, module):
         return isinstance(module, self._orig_layer_class)
 
+    def match_replaced(self, module):
+        return isinstance(module, DSUNet)
+
     def apply(self, module, enable_cuda_graph=True):
         # TODO(cmikeh2): Enable cuda graph should be an inference configuration
-        from ...model_implementations.diffusers.unet import DSUNet
         return DSUNet(module, enable_cuda_graph=enable_cuda_graph)
 
     def attention(self, client_module):

--- a/deepspeed/module_inject/containers/vae.py
+++ b/deepspeed/module_inject/containers/vae.py
@@ -2,6 +2,7 @@
 Copyright 2022 The Microsoft DeepSpeed Team
 '''
 from ..policy import DSPolicy
+from ...model_implementations.diffusers.vae import DSVAE
 
 
 class VAEPolicy(DSPolicy):
@@ -20,9 +21,11 @@ class VAEPolicy(DSPolicy):
     def match(self, module):
         return isinstance(module, self._orig_layer_class)
 
+    def match_replaced(self, module):
+        return isinstance(module, DSVAE)
+
     def apply(self, module, enable_cuda_graph=True):
         # TODO(cmikeh2): Enable cuda graph should be an inference configuration
-        from ...model_implementations.diffusers.vae import DSVAE
         return DSVAE(module, enable_cuda_graph=enable_cuda_graph)
 
     # NOTE (lekurile): Should we have a diffusers policy class?


### PR DESCRIPTION
This PR addresses issue #2717.

Currently, if `enable_cuda_graph=True`, the `InferenceEngine` will attempt to create a CUDA graph on the entire `forward()` function. However, if DeepSpeed implementations contain _local_ CUDA graphs, capturing the entire `forward()` function is not possible and instead the local CUDA graphs should take precedence.

This PR updates the way the `InferenceEngine` builds its CUDA graphs by checking to see if any of the submodules contain CUDA graph implementations during the engine `__init__` phase and storing the result in `self.local_cuda_graph`. If local CUDA graph implementations are detected and `enable_cuda_graph=True`, the `InferenceEngine` forward function will not attempt to capture a CUDA graph and instead will simply call `self.module()`, allowing local CUDA graph implementations be created and used.

A new ABC `CUDAGraph` "feature" class is added to `deepspeed/model_implementations/features` that's inherited by DSVAE, DSUNet, and DSClipEncoder implemenations. This ensures that implementations using the `CUDAGraph` class will have the same naming for `self.enable_cuda_graph`, which is searched for during `InferenceEngine` initialization to detect if local CUDA graphs are used.

After these changes, the `"runwayml/stable-diffusion-v1-5"` model was tested with `enable_cuda_graph=True` across 10 prompts and showed a ~4% performance improvement.

Thanks to @cmikeh2 for the support on this.