### PR TITLE
Fix issue between our abstract accelerator and colossalai's version of op_builder

### DIFF
--- a/accelerator/cuda_accelerator.py
+++ b/accelerator/cuda_accelerator.py
@@ -224,8 +224,9 @@ class CUDA_Accelerator(DeepSpeedAccelerator):
 
     def op_builder_dir(self):
         try:
-            # during installation time op_builder is visible as a local path, otherwise return deepspeed.ops.op_builder
-            from .op_builder import builder  # noqa: F401
+            # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed
+            # if successful this also means we're doing a local install and not JIT compile path
+            from op_builder import __deepspeed__  # noqa: F401
             return "op_builder"
         except ImportError:
             return "deepspeed.ops.op_builder"

--- a/accelerator/cuda_accelerator.py
+++ b/accelerator/cuda_accelerator.py
@@ -224,8 +224,8 @@ class CUDA_Accelerator(DeepSpeedAccelerator):
 
     def op_builder_dir(self):
         try:
-            # during installation time op_builder is visible, otherwise return deepspeed.ops.op_builder
-            import op_builder  # noqa: F401
+            # during installation time op_builder is visible as a local path, otherwise return deepspeed.ops.op_builder
+            from .op_builder import builder  # noqa: F401
             return "op_builder"
         except ImportError:
             return "deepspeed.ops.op_builder"

--- a/op_builder/__init__.py
+++ b/op_builder/__init__.py
@@ -8,6 +8,9 @@ import importlib
 
 from .builder import get_default_compute_capabilities, OpBuilder
 
+# Do not remove, required for abstract accelerator to detect if we have a deepspeed or 3p op_builder
+__deepspeed__ = True
+
 # List of all available op builders from deepspeed op_builder
 try:
     import deepspeed.ops.op_builder  # noqa: F401


### PR DESCRIPTION
ColossalAI has an [adapted version of DeepSpeed's op_builder](https://github.com/hpcaitech/ColossalAI/tree/main/op_builder), however it appears they are installing it as a top-level package called `op_builder` as it's [not excluded in their setup.py](https://github.com/hpcaitech/ColossalAI/blob/ea0b52c12ee7598fe126ed0d8b0557f7e8a0e999/setup.py#L154-L164). We have also had similar issues accidentally installing extra packages like this in the past (e.g., https://github.com/microsoft/DeepSpeed/issues/2690). They might be able to just add this to their package exclude list but not sure.

The issue (https://github.com/microsoft/DeepSpeed/issues/2904) occurs when a user has both ColossalAI and DeepSpeed >= 0.8.0 installed. DeepSpeed v0.8.0 introduced the concept of an abstract accelerator. In order to support pre-compilation of ops we attempt to import `op_builder` and we assumed this would import from the local path, however if another package installs `op_bulder` as a package python will pick that up instead. This was made a bit more confusing to debug since ColossalAI's op_builder reuses the same builder names as ours (e.g., `CPUAdamBuilder`).

The fix in this PR forces the `op_builder` import to be relative to the local path in order to detect if we are in a pre-compilation mode or JIT compilation mode.

Tagging core contributors on DeepSpeed's abstract accelerator for awareness/review: @delock, @tjruwase 