### PR TITLE
[zero] prevent poor configs from running w. zero-offload

### DIFF
--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -502,6 +502,12 @@ def get_zero_allow_untested_optimizer(param_dict):
                             ZERO_ALLOW_UNTESTED_OPTIMIZER_DEFAULT)
 
 
+def get_zero_force_ds_cpu_optimizer(param_dict):
+    return get_scalar_param(param_dict,
+                            ZERO_FORCE_DS_CPU_OPTIMIZER,
+                            ZERO_FORCE_DS_CPU_OPTIMIZER_DEFAULT)
+
+
 def get_scheduler_name(param_dict):
     if SCHEDULER in param_dict.keys() and TYPE in param_dict[SCHEDULER].keys():
         return param_dict[SCHEDULER][TYPE]
@@ -858,6 +864,8 @@ class DeepSpeedConfig(object):
 
         self.zero_allow_untested_optimizer = get_zero_allow_untested_optimizer(
             param_dict)
+
+        self.zero_force_ds_cpu_optimizer = get_zero_force_ds_cpu_optimizer(param_dict)
 
         self.scheduler_name = get_scheduler_name(param_dict)
         self.scheduler_params = get_scheduler_params(param_dict)

--- a/deepspeed/runtime/constants.py
+++ b/deepspeed/runtime/constants.py
@@ -73,6 +73,8 @@ MAX_GRAD_NORM = 'max_grad_norm'
 #############################################
 ZERO_ALLOW_UNTESTED_OPTIMIZER = "zero_allow_untested_optimizer"
 ZERO_ALLOW_UNTESTED_OPTIMIZER_DEFAULT = False
+ZERO_FORCE_DS_CPU_OPTIMIZER = "zero_force_ds_cpu_optimizer"
+ZERO_FORCE_DS_CPU_OPTIMIZER_DEFAULT = True
 
 # Steps
 STEPS_PER_PRINT = "steps_per_print"

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -719,6 +719,9 @@ class DeepSpeedEngine(Module):
     def zero_allow_untested_optimizer(self):
         return self._config.zero_allow_untested_optimizer
 
+    def zero_force_ds_cpu_optimizer(self):
+        return self._config.zero_force_ds_cpu_optimizer
+
     def zero_reduce_scatter(self):
         return self._config.zero_config.reduce_scatter
 
@@ -1265,6 +1268,13 @@ class DeepSpeedEngine(Module):
             else:
                 basic_optimizer = client_optimizer(model_parameters)
                 log_dist('Using client callable to create basic optimizer', ranks=[0])
+
+            if self.zero_use_cpu_optimizer() and not isinstance(
+                    basic_optimizer,
+                    deepspeed.ops.adam.DeepSpeedCPUAdam):
+                if self.zero_force_ds_cpu_optimizer():
+                    msg = f'You are using ZeRO-Offload with a client provided optimizer ({type(basic_optimizer)}) which in most cases will yield poor performance. Please either use deepspeed.ops.adam.DeepSpeedCPUAdam or set an optimizer in your ds-config (https://www.deepspeed.ai/docs/config-json/#optimizer-parameters). If you really want to use a custom optimizer w. ZeRO-Offload and understand the performance impacts you can also set <"zero_force_ds_cpu_optimizer": false> in your configuration file.'
+                    raise ZeRORuntimeException(msg)
         else:
             basic_optimizer = self._configure_basic_optimizer(model_parameters)
             log_dist(

--- a/tests/unit/runtime/half_precision/test_fp16.py
+++ b/tests/unit/runtime/half_precision/test_fp16.py
@@ -466,7 +466,8 @@ class TestZeroAllowUntestedOptimizer(DistributedTest):
                 "stage": zero_stage,
                 "cpu_offload": use_cpu_offload
             },
-            "zero_allow_untested_optimizer": False
+            "zero_allow_untested_optimizer": False,
+            "zero_force_ds_cpu_optimizer": False
         }
         hidden_dim = 10
 


### PR DESCRIPTION
We have noticed several users have tried to use ZeRO-Offload but have not been using `DeepSpeedCPUAdam`. This PR attempts to raise an exception for these cases to advise users on the best performing path. We have also included a way around this check in case the user knows what they are doing, etc.