### PR TITLE
ckpt: create directories in checkpoint_engine

### DIFF
--- a/deepspeed/runtime/checkpoint_engine/checkpoint_engine.py
+++ b/deepspeed/runtime/checkpoint_engine/checkpoint_engine.py
@@ -1,5 +1,7 @@
 '''Copyright The Microsoft DeepSpeed Team'''
 
+import os
+
 
 class CheckpointEngine(object):
 
@@ -10,6 +12,9 @@ class CheckpointEngine(object):
     def create(self, tag):
         # create checkpoint on give tag for save/load.
         pass
+
+    def makedirs(self, path, exist_ok=False):
+        os.makedirs(path, exist_ok=exist_ok)
 
     def save(self, state_dict, path: str):
         pass

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -79,7 +79,7 @@ from deepspeed.runtime.data_pipeline.data_routing.basic_layer import RandomLayer
 from deepspeed.runtime.checkpoint_engine.torch_checkpoint_engine import TorchCheckpointEngine
 
 from .pipe.module import PipelineModule
-from .utils import ensure_directory_exists, get_ma_status
+from .utils import get_ma_status
 from ..ops.adam import FusedAdam
 from ..moe.sharded_moe import TopKGate, MOELayer
 from ..moe.layer import MoE
@@ -3100,7 +3100,7 @@ class DeepSpeedEngine(Module):
         # There seems to be issue creating them in parallel
 
         # Ensure save_dir directory exists
-        os.makedirs(save_dir, exist_ok=True)
+        self.checkpoint_engine.makedirs(save_dir, exist_ok=True)
         dist.barrier()
 
         if tag is None:
@@ -3278,7 +3278,8 @@ class DeepSpeedEngine(Module):
                          if zero_checkpoint else self._get_ckpt_name)
         try:
             checkpoint_name = name_function(save_dir, tag)
-            ensure_directory_exists(checkpoint_name)
+            path = os.path.dirname(checkpoint_name)
+            self.checkpoint_engine.makedirs(path, exist_ok=True)
         except:
             logger.error(f"Failed saving model checkpoint to {save_dir} with tag {tag}")
             return False
@@ -3528,7 +3529,7 @@ class DeepSpeedEngine(Module):
             state_dict = self.module.state_dict()
 
         if dist.get_rank() == 0:
-            os.makedirs(save_dir, exist_ok=True)
+            self.checkpoint_engine.makedirs(save_dir, exist_ok=True)
             logger.info(f"Saving model weights to {path}")
             self.checkpoint_engine.save(state_dict, path)
 

--- a/deepspeed/runtime/pipe/module.py
+++ b/deepspeed/runtime/pipe/module.py
@@ -587,7 +587,7 @@ class PipelineModule(nn.Module):
             start, end = 0, num_layers
         layer_list = self.forward_funcs[start:end]
 
-        os.makedirs(save_dir, exist_ok=True)
+        checkpoint_engine.makedirs(save_dir, exist_ok=True)
         for idx, layer in enumerate(layer_list):
             model_ckpt_path = self.ckpt_layer_path(save_dir, start + idx)
             if not hasattr(layer, 'state_dict'):


### PR DESCRIPTION
Delegate the task of creating checkpoint directories to the checkpoint engine.  This enables the engine to customize how, where, and when the checkpoint directories are created.

Some checkpoint engines may need to create temporary directories, they may delay directory creation to a later time, or they might not create the directories at all if the corresponding checkpoint is discarded.