### PR TITLE
Allow dict datatype for checkpoints (inference)

### DIFF
--- a/deepspeed/inference/config.py
+++ b/deepspeed/inference/config.py
@@ -181,7 +181,7 @@ class DeepSpeedInferenceConfig(DeepSpeedConfigModel):
     """
 
     #todo: refactor the following 3 into the new checkpoint_config
-    checkpoint: str = None
+    checkpoint: Union[str, Dict] = None
     """
     Path to deepspeed compatible checkpoint or path to JSON with load policy.
     """


### PR DESCRIPTION
When we refactored DeepSpeed-inference config, we made it so that checkpoint always had to be a string to a json file. However, the code supports passing a dictionary directly. Adding support for passing a Dict again.

Fixes https://github.com/microsoft/DeepSpeed-MII/issues/156