### PR TITLE
Improve loss overflow logs

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -1836,12 +1836,6 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
 
         see_memory_usage('After overflow after clearing gradients', force=False)
 
-        if dist.get_rank() == 0:
-            overflow_msg = f"[deepspeed] OVERFLOW! Rank {dist.get_rank()} Skipping step."
-            if self.dtype == torch.half:
-                overflow_msg += f" Attempted loss scale: {prev_scale}, reducing to {self.loss_scale}"
-            logger.info(overflow_msg)
-
     @instrument_w_nvtx
     def _overflow_check_and_loss_scale_update(self):
 

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1777,12 +1777,6 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         prev_scale = self.loss_scale
         self._update_scale(self.overflow)
         if self.overflow:
-            if dist.get_rank() == 0:
-                overflow_msg = f"[deepspeed] OVERFLOW! Rank {dist.get_rank()} Skipping step."
-                if self.dtype == torch.half:
-                    overflow_msg += f" Attempted loss scale: {prev_scale}, reducing to {self.loss_scale}"
-                logger.info(overflow_msg)
-
             see_memory_usage('After overflow before clearing gradients')
             self.zero_grad(set_to_none=True)
             if self.cpu_offload:


### PR DESCRIPTION
This is a small QoL PR that resolves two small issues:

1. The loss overflow code is duplicated across Zero-3 and Zero-1/2
2. The loss overflow log messages don't handle fp16 hysteresis, leading to confusing messages where the loss scale doesn't change such as those reported in https://github.com/microsoft/DeepSpeed/issues/1599: 

```[deepscale] OVERFLOW! Rank 0 Skipping step. Attempted loss scale: 65536, reducing to 65536```

With this PR, loss overflow logs instead look like:

```
...
OVERFLOW! Rank 0 Skipping step. Attempted loss scale: 65536, but hysteresis is 3. Reducing hysteresis to 2
OVERFLOW! Rank 0 Skipping step. Attempted loss scale: 65536, but hysteresis is 2. Reducing hysteresis to 1
OVERFLOW! Rank 0 Skipping step. Attempted loss scale: 65536, reducing to 32768
OVERFLOW! Rank 0 Skipping step. Attempted loss scale: 32768, reducing to 16384
...
```

Fixes: https://github.com/microsoft/DeepSpeed/issues/1599

@stas00 @jeffra @tjruwase 