### PR TITLE
PR: FP16 gradient offloaded to CPU from GPU should not be converted t…

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1183,8 +1183,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             num_elements)
 
         src_tensor = param.grad.view(-1).narrow(0, source_offset, num_elements)
-        if not self.fp16_master_weights_and_gradients:
-            src_tensor = src_tensor.float()
+        # Copy gradients of type FP16 CUDA tensor directly into FP32 CPU tensor
+        #if not self.fp16_master_weights_and_gradients:
+        #    src_tensor = src_tensor.float()
 
         dest_tensor.copy_(src_tensor, non_blocking=True)
         param.grad = None  #offload only


### PR DESCRIPTION
…o FP32 in GPU, but rather directly copied into FP32 CPU buffer, or at least sent to CPU then converted to FP32