### PR TITLE
[comms] fix deprecations

### DIFF
--- a/deepspeed/comm/comm.py
+++ b/deepspeed/comm/comm.py
@@ -269,10 +269,10 @@ def reduce_scatter_fn(output_tensor,
                                    debug=debug)
     else:
         utils.logger.warning_once(
-                "unable to find neither torch.distributed.reduce_scatter_tensor nor "
-                "torch.distributed._reduce_scatter_base. will fall back to "
-                "torch.distributed.all_gather which will result in suboptimal performance. "
-                "please consider upgrading your pytorch installation.")
+            "unable to find neither torch.distributed.reduce_scatter_tensor nor "
+            "torch.distributed._reduce_scatter_base. will fall back to "
+            "torch.distributed.all_gather which will result in suboptimal performance. "
+            "please consider upgrading your pytorch installation.")
         input_tensor_lst = list(torch.chunk(tensor, cdb.get_world_size(group)))
         return reduce_scatter(output_tensor,
                               input_tensor_lst,

--- a/deepspeed/comm/comm.py
+++ b/deepspeed/comm/comm.py
@@ -275,7 +275,8 @@ def reduce_scatter_fn(output_tensor,
     else:
         if not has_warned_reduce_scatter:
             utils.logger.warning(
-                "unable to find torch.distributed._reduce_scatter_base. will fall back to "
+                "unable to find neither torch.distributed.reduce_scatter_tensor nor "
+                "torch.distributed._reduce_scatter_base. will fall back to "
                 "torch.distributed.all_gather which will result in suboptimal performance. "
                 "please consider upgrading your pytorch installation.")
             has_warned_reduce_scatter = True

--- a/deepspeed/comm/utils.py
+++ b/deepspeed/comm/utils.py
@@ -27,11 +27,28 @@ def has_allgather_base():
     return hasattr(torch.distributed, "_all_gather_base")
 
 
-def has_reduce_scatter_base():
+def get_allgather_base_fn():
     '''
-        Helper to check if torch.distributed has _reduce_scatter_base
+    Returns torch.distributed.all_gather_into_tensor if it exists (most recent pytorch)
+    or torch.distributed.allgather_base._allgather_base if it exists (older pytorch)
+    or None (very old pytorch)
     '''
-    return hasattr(torch.distributed, "_reduce_scatter_base")
+    if hasattr(torch.distributed, "all_gather_into_tensor"):
+        return torch.distributed.all_gather_into_tensor
+    else:
+        return getattr(torch.distributed, "_allgather_base", None)
+
+
+def get_reduce_scatter_base_fn():
+    '''
+    Returns torch.distributed.reduce_scatter_tensor if it exists (most recent pytorch)
+    or torch.distributed.reduce_scatter_base._reduce_scatter_base if it exists (older pytorch)
+    or None (very old pytorch)
+    '''
+    if hasattr(torch.distributed, "reduce_scatter_tensor"):
+        return torch.distributed.reduce_scatter_tensor
+    else:
+        return getattr(torch.distributed, "_reduce_scatter_base", None)
 
 
 def get_local_rank_from_launcher():

--- a/deepspeed/comm/utils.py
+++ b/deepspeed/comm/utils.py
@@ -20,13 +20,6 @@ def older_torch():
         return False
 
 
-def has_allgather_base():
-    '''
-        Helper to check if torch.distributed has _all_gather_base
-    '''
-    return hasattr(torch.distributed, "_all_gather_base")
-
-
 def get_allgather_base_fn():
     '''
     Returns torch.distributed.all_gather_into_tensor if it exists (most recent pytorch)


### PR DESCRIPTION
This PR Fixes:

```
/home/stas/anaconda3/envs/py38-pt113/lib/python3.8/site-packages/torch/distributed/distributed_c10d.py:2387: UserWarning: 
torch.distributed._all_gather_base is a private function and will be deprecated. 
Please use torch.distributed.all_gather_into_tensor instead.
  warnings.warn(
/home/stas/anaconda3/envs/py38-pt113/lib/python3.8/site-packages/torch/distributed/distributed_c10d.py:2849: UserWarning: 
torch.distributed._reduce_scatter_base is a private function and will be deprecated. 
Please use torch.distributed.reduce_scatter_tensor instead.
  warnings.warn(
```

Tested with pt-2.0-rc and pt-1.13

@tjruwase 