### PR TITLE
Fix batch checking

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -795,7 +795,7 @@ class PipelineEngine(DeepSpeedEngine):
                 loaded = batch[0].clone().to(self.device).detach()
                 loaded.requires_grad = loaded.is_floating_point()
             else:
-                assert isinstance(batch[0], tuple)
+                assert isinstance(batch[0], tuple) or isinstance(batch[0], list)
                 # Assume list or tuple
                 loaded = []
                 for x in batch[0]:


### PR DESCRIPTION
`batch` may be a `list`, depending on the behavior of the dataset, and it has no effect on subsequent execution