### PR TITLE
fix pop off grad mistakenly

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -1009,7 +1009,7 @@ class PipelineEngine(DeepSpeedEngine):
         # a grad that needs to be communicated. We free the buffer immediately
         # after, so no need to restore it. The receiver also has a hack that skips
         # the recv. This is because NCCL does not let us send torch.BoolTensor :-(.
-        if self.has_attention_mask or self.has_bool_tensors:
+        if len(inputs) > 2 and (self.has_attention_mask or self.has_bool_tensors):
             inputs = list(inputs)
             inputs.pop()
             inputs = tuple(inputs)


### PR DESCRIPTION
In my case, `inputs[0]` and `inputs[1]` are partitioned grads, and there is no `mask` in the `inputs`, which pops up grads and causes an error