### PR TITLE
[CI] follow-up fixes

### DIFF
--- a/.github/workflows/amd.yml
+++ b/.github/workflows/amd.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit-tests:
+  amd-tests:
     # The type of runner that the job will run on
     runs-on: [self-hosted, amd]
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,7 @@
 
 
 # top-level repo folders
-/.github/ @jeffra @mrwyattii
+/.github/ @jeffra @mrwyattii @loadams
 /azure/ @jeffra @awan-10
 /benchmarks/ @jeffra @awan-10 @mrwyattii @molly-smith
 /bin/ @jeffra

--- a/tests/unit/checkpoint/test_pipeline.py
+++ b/tests/unit/checkpoint/test_pipeline.py
@@ -3,21 +3,10 @@
 from deepspeed.runtime.checkpoint_engine.torch_checkpoint_engine import TorchCheckpointEngine
 from unit.common import DistributedTest
 from unit.simple_model import *
-
 from unit.checkpoint.common import checkpoint_correctness_verification
+from util import skip_on_arch
 
 import pytest
-import deepspeed
-import torch
-
-
-def _skip_on_older_arch(arch=7):
-    if deepspeed.accelerator.get_accelerator().device_name() == 'cuda':
-        if torch.cuda.get_device_capability()[0] < arch:
-            pytest.skip("needs higher compute capability than 7")
-    else:
-        assert deepspeed.accelerator.get_accelerator().device_name() == 'xpu'
-        return
 
 
 class TestPipelineCheckpoint(DistributedTest):
@@ -25,7 +14,7 @@ class TestPipelineCheckpoint(DistributedTest):
 
     @pytest.mark.parametrize("zero_stage", [0, 1])
     def test_checkpoint_pipe_engine(self, zero_stage, tmpdir):
-        _skip_on_older_arch()
+        skip_on_arch(min_arch=7)
 
         config_dict = {
             "train_batch_size": 2,

--- a/tests/unit/checkpoint/test_pipeline.py
+++ b/tests/unit/checkpoint/test_pipeline.py
@@ -4,7 +4,7 @@ from deepspeed.runtime.checkpoint_engine.torch_checkpoint_engine import TorchChe
 from unit.common import DistributedTest
 from unit.simple_model import *
 from unit.checkpoint.common import checkpoint_correctness_verification
-from util import skip_on_arch
+from unit.util import skip_on_arch
 
 import pytest
 

--- a/tests/unit/runtime/pipe/test_pipe.py
+++ b/tests/unit/runtime/pipe/test_pipe.py
@@ -4,28 +4,18 @@ import copy
 import torch.nn as nn
 import pytest
 
-import torch
-import deepspeed
 import deepspeed.comm as dist
 from deepspeed.runtime.pipe.topology import PipeDataParallelTopology
 from deepspeed.runtime.pipe.module import PipelineModule
 from unit.alexnet_model import AlexNetPipe, train_cifar
 from unit.common import DistributedTest
+from util import skip_on_arch
 
 PipeTopo = PipeDataParallelTopology
 
 
 def rel_diff(A, B):
     return abs(A - B) / abs(A)
-
-
-def _skip_on_older_arch(arch=7):
-    if deepspeed.accelerator.get_accelerator().device_name() == 'cuda':
-        if torch.cuda.get_device_capability()[0] < arch:
-            pytest.skip("needs higher compute capability than 7")
-    else:
-        assert deepspeed.accelerator.get_accelerator().device_name() == 'xpu'
-        return
 
 
 @pytest.mark.parametrize('topo_config',
@@ -47,7 +37,7 @@ class TestPipeCifar10(DistributedTest):
     world_size = 4
 
     def test(self, topo_config):
-        _skip_on_older_arch()
+        skip_on_arch(min_arch=7)
 
         config_dict = {
             "train_batch_size": 16,

--- a/tests/unit/runtime/pipe/test_pipe.py
+++ b/tests/unit/runtime/pipe/test_pipe.py
@@ -9,7 +9,7 @@ from deepspeed.runtime.pipe.topology import PipeDataParallelTopology
 from deepspeed.runtime.pipe.module import PipelineModule
 from unit.alexnet_model import AlexNetPipe, train_cifar
 from unit.common import DistributedTest
-from util import skip_on_arch
+from unit.util import skip_on_arch
 
 PipeTopo = PipeDataParallelTopology
 

--- a/tests/unit/runtime/sparse_tensor/test_averaging_sparse_gradients.py
+++ b/tests/unit/runtime/sparse_tensor/test_averaging_sparse_gradients.py
@@ -3,6 +3,7 @@
 import torch
 import deepspeed
 from unit.common import DistributedTest
+from util import skip_on_arch
 
 
 class Model(torch.nn.Module):
@@ -49,6 +50,8 @@ class TestSparseAdam(DistributedTest):
     world_size = 2
 
     def test(self):
+        skip_on_arch(min_arch=7)
+
         config_dict = {
             "train_batch_size": 2,
             "steps_per_print": 1,

--- a/tests/unit/runtime/sparse_tensor/test_averaging_sparse_gradients.py
+++ b/tests/unit/runtime/sparse_tensor/test_averaging_sparse_gradients.py
@@ -3,7 +3,7 @@
 import torch
 import deepspeed
 from unit.common import DistributedTest
-from util import skip_on_arch
+from unit.util import skip_on_arch
 
 
 class Model(torch.nn.Module):

--- a/tests/unit/util.py
+++ b/tests/unit/util.py
@@ -1,7 +1,18 @@
 '''Copyright The Microsoft DeepSpeed Team'''
 
+import pytest
 import torch
+import deepspeed
 from deepspeed.git_version_info import torch_info
+
+
+def skip_on_arch(min_arch=7):
+    if deepspeed.accelerator.get_accelerator().device_name() == 'cuda':
+        if torch.cuda.get_device_capability()[0] < min_arch:
+            pytest.skip(f"needs higher compute capability than {min_arch}")
+    else:
+        assert deepspeed.accelerator.get_accelerator().device_name() == 'xpu'
+        return
 
 
 def required_torch_version():


### PR DESCRIPTION
refactor `_skip_on_older_arch` for easier re-use, rename amd workflow, skip sparse grad tests on p40