### PR TITLE
fix HF inference benchmark

### DIFF
--- a/benchmarks/inference/bert-bench.py
+++ b/benchmarks/inference/bert-bench.py
@@ -86,10 +86,12 @@ for i in range(args.trials):
     end = time.time()
     responses.append(r)
     times.append((end - start))
-    mtimes += pipe.model.model_times()
+    if args.deepspeed:
+        mtimes += pipe.model.model_times()
     #print(f"{pipe.model.model_times()=}")
 
 print_latency(times, "e2e latency")
-print_latency(mtimes, "model latency")
+if args.deepspeed:
+    print_latency(mtimes, "model latency")
 
 print(responses[0:3])

--- a/benchmarks/inference/gpt-bench.py
+++ b/benchmarks/inference/gpt-bench.py
@@ -96,11 +96,13 @@ for i in range(args.trials):
     end = time.time()
     responses.append(r)
     times.append(end - start)  # / (args.max_tokens - 3))
-    mtimes.append(sum(pipe.model.model_times()))
+    if args.deepspeed:
+        mtimes.append(sum(pipe.model.model_times()))
 
 if args.local_rank == 0:
     print_latency(times, "(e2e) latency")
-    print_latency(mtimes, "(model-only) latency")
+    if args.deepspeed:
+        print_latency(mtimes, "(model-only) latency")
     print_latency(map(lambda t: t / (args.max_tokens - 3), times), "(e2e) per token latency")
     print(f"RESPONSE 0:")
     print("-" * 30)


### PR DESCRIPTION
`pipe.model.model_times())` is only for deepspeed inference.
So, introducing under if condition.