### PR TITLE
Fix handling of (CUDA,ROCR)_VISIBLE_DEVICES

### DIFF
--- a/deepspeed/comm/comm.py
+++ b/deepspeed/comm/comm.py
@@ -610,6 +610,11 @@ def mpi_discovery(distributed_port=TORCH_DISTRIBUTED_DEFAULT_PORT, verbose=True)
     all_procs = comm.allgather(proc_name)
     local_rank = sum([i == proc_name for i in all_procs[:rank]])
 
+    if 'CUDA_VISIBLE_DEVICES' in os.environ:
+        local_rank %= len(os.environ['CUDA_VISIBLE_DEVICES'].split(','))
+    elif 'ROCR_VISIBLE_DEVICES' in os.environ:
+        local_rank %= len(os.environ['ROCR_VISIBLE_DEVICES'].split(','))
+
     os.environ['RANK'] = str(rank)
     os.environ['WORLD_SIZE'] = str(world_size)
     os.environ['LOCAL_RANK'] = str(local_rank)


### PR DESCRIPTION
Currently, the value of `LOCAL_RANK` is calculated wrong when `CUDA_VISIBLE_DEVICES` or `ROCR_VISIBLE_DEVICES` are set on multi-GPU nodes, which leads to PyTorch distributed being initialized with a non-existent logical device id.

This change set fixes the issue when `CUDA_VISIBLE_DEVICES` or `ROCR_VISIBLE_DEVICES` are set on multi-GPU nodes, to a subset of the available local GPUs, assuming that GPUs are evenly split across processes.

For instance,

- 8 GPUs in a node
- slurm assigns one task per GPU (`--gpus-per-task=1`) and 8 tasks per node (`--tasks-per-node=8`)
- the current version would still set `LOCAL_RANK` to the local process index (between 0 and 7), whereas with this change it will always assign the correct logical device 0, because that one is being mapped onto the actual device index using `{CUDA,ROCR}_VISBLE_DEVICES` 

https://slurm.schedmd.com/gres.html
