### PR TITLE
[fp16/doc] correct initial_scale_power default value

### DIFF
--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -250,7 +250,7 @@ Example of <i>**scheduler**</i>
 
 | Description                                                                                                                                                                                             | Default |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| <i>**initial_scale_power**</i> is a **fp16** parameter representing the power of the initial dynamic loss scale value. The actual loss scale is computed as 2<sup><i>**initial_scale_power**</i></sup>. | `32`    |
+| <i>**initial_scale_power**</i> is a **fp16** parameter representing the power of the initial dynamic loss scale value. The actual loss scale is computed as 2<sup><i>**initial_scale_power**</i></sup>. | `16`    |
 
 <i>**fp16:loss_scale_window**</i>: [integer]
 


### PR DESCRIPTION
This is a follow up to https://github.com/microsoft/DeepSpeed/pull/2663, fixing the doc's default from 32 to 16.

@tjruwase 