### PR TITLE
Add contribution images to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,12 @@ All DeepSpeed documentation, tutorials, and blogs can be found on our website: [
 # Contributing
 DeepSpeed welcomes your contributions! Please see our
 [contributing](CONTRIBUTING.md) guide for more details on formatting, testing,
-etc.
+etc.<br/>
+Thanks so much to all of our amazing contributors!
+
+<a href="https://github.com/microsoft/DeepSpeed/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=microsoft/DeepSpeed"  width="800px"/>
+</a>
 
 ## Contributor License Agreement
 This project welcomes contributions and suggestions. Most contributions require you to


### PR DESCRIPTION
Add the contributor's avatar to the README.md file. 
I believe it would be an honor for contributors.
After adjustment
![image](https://user-images.githubusercontent.com/55081697/232709830-58443b81-8a1a-4117-b775-8db02907d185.png)
