### PR TITLE
Diffusers 0.15.0 bug fix

### DIFF
--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -233,7 +233,10 @@ def generic_injection(module, fp16=False, enable_cuda_graph=True):
 
         try:
             import diffusers
-            cross_attention = diffusers.models.attention.CrossAttention
+            if hasattr(diffusers.models.attention, 'CrossAttention'):
+                cross_attention = diffusers.models.attention.CrossAttention
+            else:
+                cross_attention = diffusers.models.attention_processor.Attention
             attention_block = diffusers.models.attention.BasicTransformerBlock
             new_policies = {
                 cross_attention: replace_attn,

--- a/deepspeed/ops/transformer/inference/diffusers_attention.py
+++ b/deepspeed/ops/transformer/inference/diffusers_attention.py
@@ -55,7 +55,7 @@ class DeepSpeedDiffusersAttentionFunction(Function):
             if config.fp16 and input.dtype == torch.float32:
                 input = input.half()
             head_size = input.shape[-1] // config.heads
-            do_flash_attn = (head_size <= 128)
+            do_flash_attn = False  #(head_size <= 128)
             scale = (1 / norm_factor) * (1 / norm_factor)
             if do_flash_attn and context == None:
                 qkv_out = linear_func(input, attn_qkvw, attn_qkvb if attn_qkvb is not None else attn_qkvw, attn_qkvb

--- a/deepspeed/ops/transformer/inference/diffusers_attention.py
+++ b/deepspeed/ops/transformer/inference/diffusers_attention.py
@@ -55,7 +55,7 @@ class DeepSpeedDiffusersAttentionFunction(Function):
             if config.fp16 and input.dtype == torch.float32:
                 input = input.half()
             head_size = input.shape[-1] // config.heads
-            do_flash_attn = False  #(head_size <= 128)
+            do_flash_attn = (head_size <= 128)
             scale = (1 / norm_factor) * (1 / norm_factor)
             if do_flash_attn and context == None:
                 qkv_out = linear_func(input, attn_qkvw, attn_qkvb if attn_qkvb is not None else attn_qkvw, attn_qkvb


### PR DESCRIPTION
Diffusers 0.15.0 moves cross attention layer class from attention.py to attention_processor.py.
This PR fixes error https://github.com/microsoft/DeepSpeed/issues/2968#issuecomment-1511217338 when using 0.15.0.