### PR TITLE
make parameters status shared by all PartitionedParameterCoordinator instances

### DIFF
--- a/deepspeed/runtime/zero/partitioned_param_coordinator.py
+++ b/deepspeed/runtime/zero/partitioned_param_coordinator.py
@@ -42,6 +42,7 @@ class ZeRoTraceMode(Enum):
 
 class PartitionedParameterCoordinator:
     """Handles partitioning and gathering of parameters."""
+    __inflight_param_registry = None
 
     class __InflightParamRegistry(UserDict):
         """registry for parameters in flight"""
@@ -67,7 +68,7 @@ class PartitionedParameterCoordinator:
         prefetch_nvme: bool = False,
     ) -> None:
         # mapping of param -> handle for each param that is currently in flight
-        self.__inflight_param_registry = __class__.__InflightParamRegistry()
+        self.__inflight_param_registry = self._get_inflight_param_registry()
         # keeps track of the number of submodules invoked so far.
         self.__step_id: int = 0
         # network tracing mode
@@ -113,6 +114,11 @@ class PartitionedParameterCoordinator:
 
     Bookkeeping operations used to track where we are in the forward/backward pass
     """
+
+    def _get_inflight_param_registry(self) -> __InflightParamRegistry:
+        if __class__.__inflight_param_registry == None:
+            __class__.__inflight_param_registry = __class__.__InflightParamRegistry()
+        return __class__.__inflight_param_registry
 
     def _clear_trace_structures(self) -> None:
         self.__submodule_order = []


### PR DESCRIPTION
There could be multiple PartitionedParameterCoordinator instances, yet they currently manage the parameters in a standalone manner. Let's say we have PartitionedParameterCoordinator A and B. When A puts some parameters inflight, B is not aware of that and when B tries to use these parameters it will just error out. This PR addresses this issue by making the __InflightParamRegistry shared among all PartitionedParameterCoordinator instances.

This PR fixes https://github.com/microsoft/DeepSpeed/issues/3068 and hopefully would fix https://github.com/microsoft/DeepSpeed/issues/3156 as well 😉