### PR TITLE
remove megatron-lm, no longer pip installable

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -2,7 +2,6 @@ clang-format==16.0.2
 docutils<0.18
 future
 importlib-metadata>=4
-megatron-lm==1.1.5
 pre-commit>=2.20.0
 pytest
 pytest-forked


### PR DESCRIPTION
- [x] remove megatron-lm from dev reqs
- [ ] either get megatron from source install or fix unit tests that depend on it