### PR TITLE
Fix local rank mismatch error when training on nodes with different number of GPUs

### DIFF
--- a/deepspeed/launcher/launch.py
+++ b/deepspeed/launcher/launch.py
@@ -299,9 +299,10 @@ def main():
                     raise ValueError(f"unable to create directory {args.enable_each_rank_log} for each rank log.")
             log_name_prefix = time.strftime("%Y%m%d%H%M%S", time.localtime())
 
-        for local_rank in range(0, num_local_procs):
+        for local_proc in range(0, num_local_procs):
             # each process's rank
-            dist_rank = global_rank_mapping[local_node][local_rank]
+            dist_rank = global_rank_mapping[local_node][local_proc]
+            local_rank = dist_rank % num_local_procs
             current_env["RANK"] = str(dist_rank)
             current_env["LOCAL_RANK"] = str(local_rank)
 


### PR DESCRIPTION
Fix #3408. 

Specifically, this PR fixes local rank mismatch error that occurs when training [Megatron-DeepSpeed](https://github.com/microsoft/Megatron-DeepSpeed) models on a cluster where **each node has different number of GPUs**.

Note that this change has no impact on the existing training scenarios where each node is assumed to have the same number of GPUs: Local ranks set by DeepSpeed remain exactly the same for homogeneous clusters. 

This PR simply makes local rank settings in DeepSpeed compatible with Megatron-DeepSpeed for more general cluster configurations, enabling DeepSpeed to work successfully even on nodes with different GPU counts. 

Local rank compatibility b/w DeepSpeed and Megatron-DeepSpeed: 
- AS-IS: only works for homogeneous nodes
- TO-BE: works for both homogeneous and heterogeneous nodes