### PR TITLE
Fix a type error on bf16+Pipeline Parallelism

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -243,7 +243,7 @@ class PipelineEngine(DeepSpeedEngine):
         self._force_grad_boundary = True
         if self.pipeline_enable_backward_allreduce:
             if self.bfloat16_enabled():
-                if self.zero_optimization_stage() < ZeroStageEnum().gradients:
+                if self.zero_optimization_stage() < ZeroStageEnum.gradients:
                     self._bf16_reduce_grads()
                 else:
                     raise NotImplementedError("PP+BF16 only work for ZeRO Stage 1")


### PR DESCRIPTION
While verified ZeRO 1 support to PP for BF16, found a this typo error, the ZeroStageEnum().gradients should be fixed to ZeroStageEnum.gradients to get the value, can limit the zero_stage less than 2 for PP. 