### PR TITLE
Extend DeepSpeed inference initialization API with a 'quantize_groups' argument

### DIFF
--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -291,6 +291,7 @@ def replace_transformer_layer(orig_layer_impl, model, checkpoint_dict, config, m
     # defining globals as internally defined functions inherit these everywhere
     fp16 = (config.dtype == torch.float16 or config.dtype == torch.int8)
     quantize = (config.dtype == torch.int8)
+    quantize_groups = config.quant.weight.q_groups if quantize else 0
     # todo: Refactor later. In future, let's minimize the style used above and use config.** instead
 
     linear_layer_setting = None
@@ -336,7 +337,7 @@ def replace_transformer_layer(orig_layer_impl, model, checkpoint_dict, config, m
             _container.convert_to_required_dtype(dtype=torch.half)
 
         # 5. Set the quantization config
-        quantizer = GroupQuantizer(q_int8=quantize)
+        quantizer = GroupQuantizer(q_int8=quantize, num_groups=quantize_groups)
         _container.set_quantization_config(quantize, quantizer)
 
         # 6. create a DS Inference config object
@@ -500,7 +501,7 @@ def replace_transformer_layer(orig_layer_impl, model, checkpoint_dict, config, m
                                      replace_fn=replace_fn,
                                      _replace_policy=config.injection_policy_tuple)
 
-    quantizer = GroupQuantizer(q_int8=quantize)
+    quantizer = GroupQuantizer(q_int8=quantize, num_groups=quantize_groups)
     world_size = dist.get_world_size() if dist.is_initialized() else 1
     rank = dist.get_rank() if dist.is_initialized() else 0
     if checkpoint_dict is not None:


### PR DESCRIPTION
This PR allows setting the number of quantization groups to be used during inference for the given model weights. Once merged, one should be able to control this number by passing the `quantize_groups` argument to a `deepseed.init_inference` call, e.g., like is done in this inference test script: https://github.com/microsoft/DeepSpeedExamples/compare/master...sakogan:DeepSpeedExamples:inference-test-enhance
(Note that the latter example will be submitted to the DeepSpeedExamples repo as a separate PR if this PR is merged.)

Setting 'quantize_groups' is allowed only when the quantization is enabled, i.e., when `dtype` is set to `int8`.