### PR TITLE
Fix Bug in transform.cu

### DIFF
--- a/csrc/transformer/inference/csrc/transform.cu
+++ b/csrc/transformer/inference/csrc/transform.cu
@@ -683,7 +683,7 @@ void launch_transform4d_0213<float>(float* out,
 }
 
 template <typename T>
-void launch_transform4d_0213<T>(T* out,
+void launch_transform4d_0213(T* out,
                                 const T* in,
                                 int batch_size,
                                 int heads,


### PR DESCRIPTION
This is to fix the below error

/opt/conda/lib/python3.8/site-packages/deepspeed/ops/csrc/transformer/inference/csrc/transform.hip:688:6: **error: function template partial specialization is not allowed**
void launch_transform4d_0213<T>(T* out,
     ^                      ~~~


cc: @jithunnair-amd 