### PR TITLE
Fixing bf16 test 

### DIFF
--- a/tests/unit/runtime/half_precision/test_bf16.py
+++ b/tests/unit/runtime/half_precision/test_bf16.py
@@ -27,6 +27,7 @@ class TestAdamBF16ZeroOneCycleCompatibility(DistributedTest):
             pytest.skip("cpu-adam is not compatible")
 
         config_dict = {
+            "train_batch_size": 4,
             "steps_per_print": 1,
             "optimizer": {
                 "type": "Adam",

--- a/tests/unit/runtime/half_precision/test_bf16.py
+++ b/tests/unit/runtime/half_precision/test_bf16.py
@@ -27,7 +27,7 @@ class TestAdamBF16ZeroOneCycleCompatibility(DistributedTest):
             pytest.skip("cpu-adam is not compatible")
 
         config_dict = {
-            "train_batch_size": 4,
+            "train_micro_batch_size_per_gpu": 1,
             "steps_per_print": 1,
             "optimizer": {
                 "type": "Adam",
@@ -88,7 +88,7 @@ class TestZeroAllowUntestedOptimizer(DistributedTest):
             pytest.skip("cpu-adam is not compatible")
 
         config_dict = {
-            "train_batch_size": 4,
+            "train_micro_batch_size_per_gpu": 4,
             "steps_per_print": 1,
             "fp16": {
                 "enabled": False,
@@ -181,7 +181,7 @@ class TestZeroSupportedClientOptimizer(DistributedTest):
             )
 
         config_dict = {
-            "train_batch_size": 2,
+            "train_micro_batch_size_per_gpu": 2,
             "steps_per_print": 1,
             "fp16": {
                 "enabled": False
@@ -210,7 +210,7 @@ class TestZero2ReduceScatterOff(DistributedTest):
             )
 
         config_dict = {
-            "train_batch_size": 2,
+            "train_micro_batch_size_per_gpu": 2,
             "steps_per_print": 1,
             "optimizer": {
                 "type": "Adam",
@@ -302,7 +302,7 @@ class TestZeroDtypeCocktail(DistributedTest):
         type_str = {torch.float16: "fp16", torch.bfloat16: "bfp16"}
 
         config_dict = {
-            "train_batch_size": 2,
+            "train_micro_batch_size_per_gpu": 2,
             "steps_per_print": 1,
             "fp16": {
                 "enabled": comp_type == torch.float16

--- a/tests/unit/runtime/half_precision/test_bf16.py
+++ b/tests/unit/runtime/half_precision/test_bf16.py
@@ -259,7 +259,7 @@ class TestZeroEmptyGrad(DistributedTest):
             )
 
         config_dict = {
-            "train_batch_size": 1,
+            "train_micro_batch_size_per_gpu": 1,
             "steps_per_print": 1,
             "fp16": {
                 "enabled": False


### PR DESCRIPTION
The test TestAdamBF16ZeroOneCycleCompatibility was failing do to missing `train_batch_size` in its config.