### PR TITLE
Fix optimizer saving with BF16 + PP + ZeRO-1

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -3161,7 +3161,7 @@ class DeepSpeedEngine(Module):
         # if we don't use it, we get parameters ordered incorrectly
         if hasattr(self.optimizer, "round_robin_bit16_groups"):
             bit16_groups = self.optimizer.round_robin_bit16_groups
-        elif self.bfloat16_enabled() and not self.zero_optimization():
+        elif hasattr(self.optimizer, "bf16_groups"):
             bit16_groups = self.optimizer.bf16_groups
         else:
             bit16_groups = self.optimizer.bit16_groups if self.zero_optimization_stage(


### PR DESCRIPTION
ZeRO-1 is supported with PP and BF16 in #3399. However, the corresponding optimizer saving function in does not consider BF16Optimizer under ZeRO-1. This PR fix the issue.