### PR TITLE
Fix Hybrid Engine for BLOOM

### DIFF
--- a/deepspeed/module_inject/containers/bloom.py
+++ b/deepspeed/module_inject/containers/bloom.py
@@ -15,7 +15,7 @@ from ..policy import maybe_get_lora
 supported_models = {None}
 
 
-class DS_BloomContainer(MetaTensorContainer, BaseTransformerContainer):
+class DS_BloomContainer(MetaTensorContainer, HybridEngineContainer, BaseTransformerContainer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -33,6 +33,17 @@ class DS_BloomContainer(MetaTensorContainer, BaseTransformerContainer):
     def attention_qkv_mp(self, mp_replace, reversed_dim=False):
         self.module.attention.attn_qkvw = mp_replace.copy(self.module.attention.attn_qkvw, self.qkvw)
         self.module.attention.attn_qkvb = mp_replace.copy(self.module.attention.attn_qkvb, self.qkvb)
+
+    def set_lora_params(self):
+        """
+        Necessary to implement for `HybridEngineContainer`
+        """
+        self.lora_params = [
+            maybe_get_lora(p) for p in [
+                self.policy.client_module.mlp.dense_h_to_4h, self.policy.client_module.mlp.dense_4h_to_h, self.policy.
+                client_module.self_attention.query_key_value, self.policy.client_module.self_attention.dense
+            ]
+        ]
 
     def load_params(self, module, sd, weight_quantizer, mp_replace, prefix):
         param_names = (
@@ -107,14 +118,3 @@ class BLOOMLayerPolicy(TransformerPolicy):
                self.client_module.post_attention_layernorm.bias, \
                self.client_module.input_layernorm.weight, \
                self.client_module.input_layernorm.bias
-
-    def get_lora_params(self):
-        all_lora_params = []
-        for p in [
-            self.client_module.mlp.dense_h_to_4h, \
-            self.client_module.mlp.dense_4h_to_h, \
-            self.client_module.self_attention.query_key_value, \
-            self.client_module.self_attention.dense
-            ]:
-            all_lora_params.append(maybe_get_lora(p))
-        return all_lora_params

--- a/deepspeed/module_inject/containers/bloom.py
+++ b/deepspeed/module_inject/containers/bloom.py
@@ -5,6 +5,7 @@
 
 from .base import *
 from .features.meta_tensor import MetaTensorContainer
+from .features.hybrid_engine import HybridEngineContainer
 from deepspeed.model_implementations.transformers.ds_bloom import DeepSpeedBloomInference
 from ..policy import TransformerPolicy
 from ..policy import transformer_param_names

--- a/deepspeed/module_inject/containers/gptneox.py
+++ b/deepspeed/module_inject/containers/gptneox.py
@@ -136,19 +136,3 @@ class GPTNEOXLayerPolicy(TransformerPolicy):
                self.client_module.post_attention_layernorm.bias, \
                self.client_module.input_layernorm.weight, \
                self.client_module.input_layernorm.bias
-
-    def get_lora_params(self):
-        if GPTNEOXLayerPolicy.version == 0:
-            attention = self.client_module.attention
-        else:
-            attention = self.client_module.self_attention
-
-        all_lora_params = []
-        for p in [
-            self.client_module.mlp.dense_h_to_4h, \
-            self.client_module.mlp.dense_4h_to_h, \
-            attention.query_key_value, \
-            attention.dense
-            ]:
-            all_lora_params.append(maybe_get_lora(p))
-        return all_lora_params


### PR DESCRIPTION
This PR fixes Hybrid Engine (HE) support for the BLOOM model, which was accidentally broken during the HE refactor in GH-3425.

The BLOOM container now inherits the `HybridEngineContainer` feature and defines a `set_lora_params()` function necessary for the feature to work. `get_lora_params()` is correspondingly removed from the BLOOM policy class as well.

GPT-NeoX was also cleaned up by removing a `get_lora_params()` function from its policy due to it no longer being used.