### PR TITLE
Refactor check_enabled root validator in DeepSpeedMonitorConfig

### DIFF
--- a/deepspeed/monitor/config.py
+++ b/deepspeed/monitor/config.py
@@ -74,5 +74,6 @@ class DeepSpeedMonitorConfig(DeepSpeedConfigModel):
 
     @root_validator
     def check_enabled(cls, values):
-        values["enabled"] = values.get("tensorboard").enabled or values.get("wandb").enabled or values.get("csv_monitor").enabled
+        values["enabled"] = values.get("tensorboard").enabled or values.get("wandb").enabled or values.get(
+            "csv_monitor").enabled
         return values

--- a/deepspeed/monitor/config.py
+++ b/deepspeed/monitor/config.py
@@ -71,7 +71,7 @@ class DeepSpeedMonitorConfig(DeepSpeedConfigModel):
 
     csv_monitor: CSVConfig = {}
     """ Local CSV output of monitoring data. """
-    
+
     @root_validator
     def check_enabled(cls, values):
         values["enabled"] = values.get("tensorboard").enabled or values.get("wandb").enabled or values.get("csv_monitor").enabled

--- a/deepspeed/monitor/config.py
+++ b/deepspeed/monitor/config.py
@@ -71,10 +71,8 @@ class DeepSpeedMonitorConfig(DeepSpeedConfigModel):
 
     csv_monitor: CSVConfig = {}
     """ Local CSV output of monitoring data. """
-
+    
     @root_validator
     def check_enabled(cls, values):
-        values["enabled"] = False
-        if (values.get("tensorboard").enabled or values.get("wandb").enabled or values.get("csv_monitor").enabled):
-            values["enabled"] = True
+        values["enabled"] = values.get("tensorboard").enabled or values.get("wandb").enabled or values.get("csv_monitor").enabled
         return values


### PR DESCRIPTION
Simplify enabled check in root_validator

The updated root_validator in the `DeepSpeedMonitorConfig` class simplifies the logic by removing the redundant enabled check. Instead, it directly assigns the result of the condition to `values["enabled"]`. This change improves code readability and eliminates unnecessary code.