### PR TITLE
non-JIT build fix on ROCm

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -601,7 +601,8 @@ class CUDAOpBuilder(OpBuilder):
 
     def builder(self):
         try:
-            assert_no_cuda_mismatch(self.name)
+            if not self.is_rocm_pytorch():
+                assert_no_cuda_mismatch(self.name)
             self.build_for_cpu = False
         except BaseException:
             self.build_for_cpu = True


### PR DESCRIPTION
This PR is to call `assert_no_cuda_mismatch` if `not self.is_rocm_pytorch()`.

This is one of the reasons for https://github.com/microsoft/DeepSpeed/issues/3091 

cc: @jithunnair-amd 