### PR TITLE
fix ccl_backend and residual_add problems

### DIFF
--- a/deepspeed/comm/ccl.py
+++ b/deepspeed/comm/ccl.py
@@ -24,6 +24,11 @@ def build_ccl_op():
 class CCLBackend(TorchBackend):
 
     def __init__(self, name='ccl', rank=-1, world_size=-1, mpu=None, timeout=None, init_method=None):
+        self.ccl_comm_op = build_ccl_op()
+        if self.ccl_comm_op == None:
+            # set CCLBackend to uninitialized state if CCLCommBuilder cannot be loaded
+            self.initialized = False
+            return
         super(CCLBackend, self).__init__(backend='ccl',
                                          name='torch',
                                          rank=rank,
@@ -31,11 +36,6 @@ class CCLBackend(TorchBackend):
                                          timeout=timeout,
                                          init_method=init_method)
         self.name = 'ccl'
-        self.ccl_comm_op = build_ccl_op()
-        if self.ccl_comm_op == None:
-            # set CCLBackend to uninitialized state if CCLCommBuilder cannot be loaded
-            self.initialized = False
-            return
         size = self.get_world_size()
         rank = self.get_rank()
         main_kvs = self.ccl_comm_op.get_kvs_addr(rank)

--- a/deepspeed/comm/comm.py
+++ b/deepspeed/comm/comm.py
@@ -145,8 +145,8 @@ def init_deepspeed_backend(ds_backend, timeout, init_method):
     global mpi_backend
     global ccl_backend
 
-    rank = int(os.environ["RANK"])
-    size = int(os.environ["WORLD_SIZE"])
+    rank = int(os.getenv('RANK', '-1'))
+    size = int(os.getenv('WORLD_SIZE', '-1'))
 
     if ds_backend == NCCL_BACKEND:
         utils.logger.warn("NCCL backend in DeepSpeed not yet implemented")

--- a/deepspeed/ops/transformer/inference/op_binding/residual_add.py
+++ b/deepspeed/ops/transformer/inference/op_binding/residual_add.py
@@ -21,9 +21,11 @@ class ResidualAddOp(BaseOp):
                 self.residual_add_func = self.inference_module.residual_add_bias_bf16
             else:
                 self.residual_add_func = self.inference_module.residual_add_bias_fp32
-            self._vector_add = self.inference_module._vector_add
         except AttributeError:
             self.residual_add_func = None
+        try:
+            self._vector_add = self.inference_module._vector_add
+        except AttributeError:
             self._vector_add = None
 
     def forward(self,


### PR DESCRIPTION
This PR fix two problems:
- Currently, when ccl_backend is set but not supported, it will fallback to TorchBackend. But in the `__init__` function of CCLBackend, it will first initialize TorchBackend and then check whether it should fallback.
  - This will wrongly initialize torch distributed environment before fallback.
  - And the `RANK` and `WORLD_SIZE` env may not exist, which will raise error.
- About residual_add op, it contains two kernel. If only one kernel, like _vector_add, raised exception, the other will also be set to None.
  - So I split it into two try-block.

@delock please take a look~