### PR TITLE
Fix initialize_ds_offload invalid keyword argument name in MiCS_Optimizer (offload_optimizer_config --> offload_param_config)

### DIFF
--- a/deepspeed/runtime/zero/mics.py
+++ b/deepspeed/runtime/zero/mics.py
@@ -398,10 +398,10 @@ class MiCS_Optimizer(DeepSpeedZeroOptimizer_Stage3):
 
     def initialize_ds_offload(self, module, timers, ds_config, overlap_comm, prefetch_bucket_size, max_reuse_distance,
                               max_live_parameters, param_persistence_threshold, model_persistence_threshold,
-                              offload_optimizer_config, mpu):
+                              offload_param_config, mpu):
         return MiCS_Offload(module, timers, ds_config, overlap_comm, prefetch_bucket_size, max_reuse_distance,
                             max_live_parameters, param_persistence_threshold, model_persistence_threshold,
-                            offload_optimizer_config, mpu)
+                            offload_param_config, mpu)
 
     def partition_grads(self, params_to_release: List[Parameter], grad_partitions: List[Tensor]) -> None:
         grad_buffers = super().partition_grads(params_to_release, grad_partitions)


### PR DESCRIPTION
The function initialize_ds_offload in MiCS_Optimizer had the argument "offload_optimizer_config" instead of "offload_param_config", this is not aligned with the initialization of "DeepSpeedZeroOptimizer_Stage3", and thus caused an exception (invalid keyword argument)