### PR TITLE
[MoE] remove deepcopy to avoid incompatible torch.jit.script modules.

### DIFF
--- a/deepspeed/moe/experts.py
+++ b/deepspeed/moe/experts.py
@@ -4,7 +4,6 @@
 # DeepSpeed Team
 
 import torch
-import copy
 
 
 class Experts(torch.nn.Module):
@@ -12,7 +11,10 @@ class Experts(torch.nn.Module):
     def __init__(self, expert, num_local_experts=1, expert_group_name=None):
         super(Experts, self).__init__()
 
-        self.deepspeed_experts = torch.nn.ModuleList([copy.deepcopy(expert) for i in range(num_local_experts)])
+        self.deepspeed_experts = []
+        for _ in range(num_local_experts):
+            self.deepspeed_experts.append(expert())
+
         self.num_local_experts = num_local_experts
 
         # TODO: revisit allreduce for moe.gate...

--- a/deepspeed/moe/experts.py
+++ b/deepspeed/moe/experts.py
@@ -4,12 +4,17 @@
 # DeepSpeed Team
 
 import torch
+import types
 
 
 class Experts(torch.nn.Module):
 
     def __init__(self, expert, num_local_experts=1, expert_group_name=None):
         super(Experts, self).__init__()
+
+        assert isinstance(
+            expert, types.FunctionType
+        ), f"`expert` should be a function, instead received a {type(expert)}, this API changed in v0.9.4"
 
         self.deepspeed_experts = []
         for _ in range(num_local_experts):

--- a/deepspeed/moe/layer.py
+++ b/deepspeed/moe/layer.py
@@ -10,6 +10,7 @@ from deepspeed.utils import log_dist
 from deepspeed.utils import groups
 from .sharded_moe import MOELayer, TopKGate
 from .experts import Experts
+import types
 import typing
 
 
@@ -18,7 +19,7 @@ class MoE(torch.nn.Module):
 
     Arguments:
         hidden_size (int): the hidden dimension of the model, importantly this is also the input and output dimension.
-        expert (torch.nn.Module): the torch module that defines the expert (e.g., MLP, torch.linear).
+        expert (types.FunctionType): a function returning a torch module that defines the expert (e.g., MLP, torch.linear).
         num_experts (int, optional): default=1, the total number of experts per layer.
         ep_size (int, optional): default=1, number of ranks in the expert parallel world or group.
         k (int, optional): default=1, top-k gating value, only supports k=1 or k=2.
@@ -50,6 +51,10 @@ class MoE(torch.nn.Module):
                  enable_expert_tensor_parallelism: bool = False):
 
         super(MoE, self).__init__()
+
+        assert isinstance(
+            expert, types.FunctionType
+        ), f"`expert` should be a function, instead received a {type(expert)}, this API changed in v0.9.4"
 
         self.use_residual = use_residual
         self.enable_expert_tensor_parallelism = enable_expert_tensor_parallelism

--- a/deepspeed/moe/layer.py
+++ b/deepspeed/moe/layer.py
@@ -75,7 +75,7 @@ class MoE(torch.nn.Module):
                                       self.num_local_experts,
                                       use_tutel=use_tutel)
         if self.use_residual:
-            self.mlp = expert
+            self.mlp = expert()
             # coefficient is used for weighted sum of the output of expert and mlp
             self.coefficient = torch.nn.Linear(hidden_size, 2)
 

--- a/tests/unit/moe/test_moe.py
+++ b/tests/unit/moe/test_moe.py
@@ -11,10 +11,10 @@ from unit.simple_model import SimplePRMoEModel, SimpleMoEModel, sequence_dataloa
 from unit.util import required_torch_version
 
 
-@pytest.mark.parametrize("ep_size", [2, 4])
+@pytest.mark.parametrize("ep_size", [2])
 @pytest.mark.parametrize("use_residual", [True, False])
 class TestMoE(DistributedTest):
-    world_size = 4
+    world_size = 2
 
     def test(self, ep_size, use_residual):
         if not required_torch_version():

--- a/tests/unit/simple_model.py
+++ b/tests/unit/simple_model.py
@@ -74,7 +74,10 @@ class SimpleMoEModel(torch.nn.Module):
         self.linear = torch.nn.Linear(hidden_dim, hidden_dim)
 
         def create_expert():
-            expert = torch.nn.Linear(hidden_dim, hidden_dim, device='cuda', dtype=torch.half)
+            expert = torch.nn.Linear(hidden_dim,
+                                     hidden_dim,
+                                     device=get_accelerator().current_device(),
+                                     dtype=torch.half)
             return expert
 
         # using two MoE layers to check implications of sharing a single storage

--- a/tests/unit/simple_model.py
+++ b/tests/unit/simple_model.py
@@ -72,16 +72,20 @@ class SimpleMoEModel(torch.nn.Module):
     def __init__(self, hidden_dim, num_experts=4, ep_size=1, use_residual=False):
         super(SimpleMoEModel, self).__init__()
         self.linear = torch.nn.Linear(hidden_dim, hidden_dim)
-        expert = torch.nn.Linear(hidden_dim, hidden_dim)
+
+        def create_expert():
+            expert = torch.nn.Linear(hidden_dim, hidden_dim, device='cuda', dtype=torch.half)
+            return expert
+
         # using two MoE layers to check implications of sharing a single storage
         self.linear2 = MoE(hidden_size=hidden_dim,
-                           expert=expert,
+                           expert=create_expert,
                            ep_size=ep_size,
                            use_residual=use_residual,
                            num_experts=num_experts,
                            k=1)
         self.linear3 = MoE(hidden_size=hidden_dim,
-                           expert=expert,
+                           expert=create_expert,
                            ep_size=ep_size,
                            use_residual=use_residual,
                            num_experts=num_experts,


### PR DESCRIPTION
> **Warning**
> This is a breaking change for the MoE API, instead of passing an nn.Module representing an `expert` we now instead require passing a function that creates the expert. This gets around the deepcopy issues discussed below.

Some user modules can use torch.jit.script for their MLP/experts which will lead to compatibility problems. See this for more details; https://github.com/pytorch/pytorch/issues/18106

This PR tries to remove deepcopy with a slight change to the DS MoE API. 