### PR TITLE
fix typo texts/unit/ops/transformer/interface

### DIFF
--- a/tests/unit/ops/transformer/inference/test_layer_norm.py
+++ b/tests/unit/ops/transformer/inference/test_layer_norm.py
@@ -16,18 +16,18 @@ if not deepspeed.ops.__compatible_ops__[InferenceBuilder.NAME]:
 inference_module = None
 
 
-def ref_implementation(vals, gamma, beta, epsilon, channels, dtype):
+def ref_implementation(vals, gamma, beta, channels, dtype):
     vals_f = vals.to(torch.float32)
     gamma_f = gamma.to(torch.float32)
     beta_f = beta.to(torch.float32)
-    return torch.nn.functional.layer_norm(vals_f, (channels, ), weight=gamma_f, bias=beta_f, eps=epsilon).to(dtype)
+    return torch.nn.functional.layer_norm(vals_f, (channels, ), weight=gamma_f, bias=beta_f).to(dtype)
 
 
-def ds_implementation(vals, gamma, beta, epsilon):
+def ds_implementation(vals, gamma, beta):
     global inference_module
     if inference_module is None:
         inference_module = InferenceBuilder().load()
-    return inference_module.layer_norm(vals, gamma, beta, epsilon)
+    return inference_module.layer_norm(vals, gamma, beta)
 
 
 @pytest.mark.inference_ops
@@ -39,17 +39,16 @@ def test_layer_norm(batch, seq_len, channels, dtype):
     vals = torch.randn((batch, seq_len, channels), dtype=dtype, device=get_accelerator().current_device_name())
     gamma = torch.randn((channels), dtype=dtype, device=get_accelerator().current_device_name())
     beta = torch.rand((channels), dtype=dtype, device=get_accelerator().current_device_name())
-    epsilon = 1e-5
 
-    ref_output = ref_implementation(vals, gamma, beta, epsilon, channels, dtype)
-    new_output = ds_implementation(vals, gamma, beta, epsilon)
+    ref_output = ref_implementation(vals, gamma, beta, channels, dtype)
+    new_output = ds_implementation(vals, gamma, beta)
 
     if not allclose(new_output, ref_output):
         #print(new_output - ref_output)
         assert allclose(new_output, ref_output)
 
 
-def residual_ref_implementation(vals, bias, res, gamma, beta, epsilon, channels, dtype):
+def residual_ref_implementation(vals, bias, res, gamma, beta, channels, dtype):
     vals_f = vals.to(torch.float32)
     bias_f = bias.to(torch.float32).reshape(1, 1, -1)
     res_f = res.to(torch.float32)
@@ -58,11 +57,11 @@ def residual_ref_implementation(vals, bias, res, gamma, beta, epsilon, channels,
     return torch.nn.functional.layer_norm(vals_f + bias_f + res_f, (channels, ), weight=gamma_f, bias=beta_f).to(dtype)
 
 
-def residual_ds_implementation(vals, bias, res, gamma, beta, epsilon):
+def residual_ds_implementation(vals, bias, res, gamma, beta):
     global inference_module
     if inference_module is None:
         inference_module = InferenceBuilder().load()
-    return inference_module._layer_norm_residual(vals, bias, res, gamma, beta, epsilon)
+    return inference_module._layer_norm_residual(vals, bias, res, gamma, beta)
 
 
 @pytest.mark.inference_ops
@@ -76,17 +75,16 @@ def test_layer_norm_residual(batch, seq_len, channels, dtype):
     bias = torch.randn((channels), dtype=dtype, device=get_accelerator().current_device_name())
     gamma = torch.randn((channels), dtype=dtype, device=get_accelerator().current_device_name())
     beta = torch.rand((channels), dtype=dtype, device=get_accelerator().current_device_name())
-    epsilon = 1e-5
 
-    new_output = residual_ds_implementation(vals, bias, residual, gamma, beta, epsilon)
-    ref_output = residual_ref_implementation(vals, bias, residual, gamma, beta, epsilon, channels, dtype)
+    new_output = residual_ds_implementation(vals, bias, residual, gamma, beta)
+    ref_output = residual_ref_implementation(vals, bias, residual, gamma, beta, channels, dtype)
 
     print((new_output - ref_output).abs().max())
 
     assert allclose(new_output, ref_output)
 
 
-def residual_store_ref_implementation(vals, bias, res, gamma, beta, espilon, channels, dtype):
+def residual_store_ref_implementation(vals, bias, res, gamma, beta, channels, dtype):
     vals_f = vals.to(torch.float32)
     bias_f = bias.to(torch.float32).reshape(1, 1, -1)
     res_f = res.to(torch.float32)
@@ -97,11 +95,11 @@ def residual_store_ref_implementation(vals, bias, res, gamma, beta, espilon, cha
     return norm_output, res_output.to(dtype)
 
 
-def residual_store_ds_implementation(vals, bias, res, gamma, beta, epsilon):
+def residual_store_ds_implementation(vals, bias, res, gamma, beta):
     global inference_module
     if inference_module is None:
         inference_module = InferenceBuilder().load()
-    return inference_module.layer_norm_residual_store_pre_ln_res(vals, bias, res, gamma, beta, epsilon)
+    return inference_module.layer_norm_residual_store_pre_ln_res(vals, bias, res, gamma, beta)
 
 
 @pytest.mark.inference_ops
@@ -115,13 +113,10 @@ def test_layer_norm_residual_store_pre_ln_res(batch, seq_len, channels, dtype):
     bias = torch.randn((channels), dtype=dtype, device=get_accelerator().current_device_name())
     gamma = torch.randn((channels), dtype=dtype, device=get_accelerator().current_device_name())
     beta = torch.rand((channels), dtype=dtype, device=get_accelerator().current_device_name())
-    epsilon = 1e-5
 
     # Need to run the reference first since there's an in-place component to ours
-    ref_norm_output, norm_res_output = residual_store_ref_implementation(vals, bias, residual, gamma, beta, epsilon,
-                                                                         channels, dtype)
-
-    ds_norm_output, ds_res_output = residual_store_ds_implementation(vals, bias, residual, gamma, beta, epsilon)
+    ref_norm_output, norm_res_output = residual_store_ref_implementation(vals, bias, residual, gamma, beta,channels, dtype)
+    ds_norm_output, ds_res_output = residual_store_ds_implementation(vals, bias, residual, gamma, beta)
 
     assert allclose(ds_res_output, norm_res_output)
     assert allclose(ds_norm_output, ref_norm_output)


### PR DESCRIPTION
fix typo texts/unit/ops/transformer/interface
change espilon to epsilon
detail info
        modified:   tests/unit/ops/transformer/inference/test_layer_norm.py
        modified:   tests/unit/ops/transformer/inference/test_rms_norm.py
