### PR TITLE
fix typo name of hybrid engine func

### DIFF
--- a/deepspeed/module_inject/containers/features/split_qkv.py
+++ b/deepspeed/module_inject/containers/features/split_qkv.py
@@ -123,7 +123,7 @@ class HybridSplitQKVContainer(HybridEngineContainer):
         for data in qkv_data:
             del data
 
-    def set_attn_parameters_wo_copy(self, Z3_enabled=False):
+    def set_attn_params_wo_copy(self, Z3_enabled=False):
         self.module.attention.attn_ow = self.dense_w
         self.module.attention.attn_ob = self.dense_b
         if not Z3_enabled:


### PR DESCRIPTION
this name should be the same within base function
https://github.com/microsoft/DeepSpeed/blob/e5fe5f65e8be68364210f0173f1d1c4ab58a4ab7/deepspeed/module_inject/containers/features/hybrid_engine.py#L167-L174

this should resolve bugs within llama