### PR TITLE
Revert "fix typo name (#3689)"

### DIFF
--- a/deepspeed/module_inject/containers/features/split_qkv.py
+++ b/deepspeed/module_inject/containers/features/split_qkv.py
@@ -123,7 +123,7 @@ class HybridSplitQKVContainer(HybridEngineContainer):
         for data in qkv_data:
             del data
 
-    def set_attn_params_wo_copy(self, Z3_enabled=False):
+    def set_attn_parameters_wo_copy(self, Z3_enabled=False):
         self.module.attention.attn_ow = self.dense_w
         self.module.attention.attn_ob = self.dense_b
         if not Z3_enabled:


### PR DESCRIPTION
This reverts commit f2f5f21b52a82de75c85abd190ecd328ce762c5a that broke the nv-inference tests.