### PR TITLE
Update Dockerfile with newer cuda and torch.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.0-devel-ubuntu18.04
+FROM nvidia/cuda:11.7.0-devel-ubuntu18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -159,8 +159,8 @@ RUN cat /etc/ssh/sshd_config > ${STAGE_DIR}/sshd_config && \
 ##############################################################################
 # PyTorch
 ##############################################################################
-ENV PYTORCH_VERSION=1.2.0
-ENV TORCHVISION_VERSION=0.4.0
+ENV PYTORCH_VERSION=1.9.0
+ENV TORCHVISION_VERSION=0.10.0
 ENV TENSORBOARDX_VERSION=1.8
 RUN pip install torch==${PYTORCH_VERSION}
 RUN pip install torchvision==${TORCHVISION_VERSION}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM nvidia/cuda:10.0-devel-ubuntu18.04
 
+ENV DEBIAN_FRONTEND noninteractive
+
 ##############################################################################
 # Temporary Installation Directory
 ##############################################################################


### PR DESCRIPTION
A few user issues popped up with folks who weren't able to use the dockerfile out of the box either due to the nvidia base image or other ubuntu/torch issues.  I wasn't able to repro and the users hadn't replied, but this updates those dependencies for future users.

```
docker build .
[+] Building 97.2s (33/33) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                             0.1s
 => => transferring dockerfile: 8.32kB                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:11.7.0-devel-ubuntu18.04                                                                                  2.1s
 => [ 1/29] FROM docker.io/nvidia/cuda:11.7.0-devel-ubuntu18.04@sha256:834900a0ac3c1a3bcabe09d91bde2d8c9f074f527e9b0ee74bff957d0fb8c075                          0.0s
 => CACHED [ 2/29] RUN mkdir -p /tmp                                                                                                                             0.0s
 => CACHED [ 3/29] RUN apt-get update &&         apt-get install -y --no-install-recommends         software-properties-common build-essential autotools-dev     0.0s
 => CACHED [ 4/29] RUN add-apt-repository ppa:git-core/ppa -y &&         apt-get update &&         apt-get install -y git &&         git --version               0.0s
 => CACHED [ 5/29] RUN echo "ClientAliveInterval 30" >> /etc/ssh/sshd_config                                                                                     0.0s
 => CACHED [ 6/29] RUN cp /etc/ssh/sshd_config /tmp/sshd_config &&         sed "0,/^#Port 22/s//Port 22/" /tmp/sshd_config > /etc/ssh/sshd_config                0.0s
 => CACHED [ 7/29] RUN apt-get install -y libnuma-dev                                                                                                            0.0s
 => CACHED [ 8/29] RUN cd /tmp &&         wget -q -O - http://www.mellanox.com/downloads/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86  0.0s
 => CACHED [ 9/29] RUN mkdir -p /tmp &&         git clone https://github.com/Mellanox/nv_peer_memory.git --branch 1.1-0 /tmp/nv_peer_memory &&         cd /tmp/  0.0s
 => CACHED [10/29] RUN cd /tmp &&         wget -q -O - https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.1.tar.gz | tar xzf - &&         cd openm  0.0s
 => CACHED [11/29] RUN mv /usr/local/mpi/bin/mpirun /usr/local/mpi/bin/mpirun.real &&         echo '#!/bin/bash' > /usr/local/mpi/bin/mpirun &&         echo 'm  0.0s
 => CACHED [12/29] RUN apt-get install -y python3 python3-dev &&         rm -f /usr/bin/python &&         ln -s /usr/bin/python3 /usr/bin/python &&         cur  0.0s
 => CACHED [13/29] RUN pip install pyyaml                                                                                                                        0.0s
 => CACHED [14/29] RUN pip install ipython                                                                                                                       0.0s
 => CACHED [15/29] RUN pip install tensorflow-gpu==1.15.2                                                                                                        0.0s
 => CACHED [16/29] RUN apt-get update &&         apt-get install -y --no-install-recommends         libsndfile-dev         libcupti-dev         libjpeg-dev      0.0s
 => CACHED [17/29] RUN pip install psutil         yappi         cffi         ipdb         pandas         matplotlib         py3nvml         pyarrow         gra  0.0s
 => CACHED [18/29] RUN cat /etc/ssh/sshd_config > /tmp/sshd_config &&         sed "0,/^#Port 22/s//Port 2222/" /tmp/sshd_config > /etc/ssh/sshd_config           0.0s
 => [19/29] RUN pip install torch==1.9.0                                                                                                                        42.8s
 => [20/29] RUN pip install torchvision==0.10.0                                                                                                                  4.1s
 => [21/29] RUN pip install tensorboardX==1.8                                                                                                                    2.4s
 => [22/29] RUN rm -rf /usr/lib/python3/dist-packages/yaml &&         rm -rf /usr/lib/python3/dist-packages/PyYAML-*                                             0.8s
 => [23/29] RUN useradd --create-home --uid 1000 --shell /bin/bash deepspeed                                                                                     1.0s
 => [24/29] RUN usermod -aG sudo deepspeed                                                                                                                       0.9s
 => [25/29] RUN echo "deepspeed ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers                                                                                         0.8s
 => [26/29] RUN git clone https://github.com/microsoft/DeepSpeed.git /tmp/DeepSpeed                                                                              5.6s
 => [27/29] RUN cd /tmp/DeepSpeed &&         git checkout . &&         git checkout master &&         ./install.sh --pip_sudo                                    8.3s
 => [28/29] RUN rm -rf /tmp/DeepSpeed                                                                                                                            0.9s
 => [29/29] RUN python -c "import deepspeed; print(deepspeed.__version__)"                                                                                       1.7s
 => exporting to image                                                                                                                                          25.2s
 => => exporting layers                                                                                                                                         25.2s
 => => writing image sha256:b90d71127bafe1360b40523a7747f51346897ef7cf0d086692e8e849f5cd10f6                                                                     0.0s
```