### PR TITLE
Fix apex install bugs

### DIFF
--- a/.github/workflows/nv-megatron.yml
+++ b/.github/workflows/nv-megatron.yml
@@ -41,7 +41,8 @@ jobs:
 
       - name: Install apex
         run: |
-          pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext" --config-settings "--build-option=--cuda_ext" git+https://github.com/NVIDIA/apex.git
+          # Install 82ee367 specifically before pyproject.toml changes due to incomplete dependencies causing errors.
+          pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" git+https://github.com/NVIDIA/apex.git@82ee367
 
       - name: Python environment
         run: |


### PR DESCRIPTION
apex updated their repo to be PEP 517 compliant, but their pyproject.toml didn't completely specify all dependencies, causing build errors.  There looks to be a bit more work there with getting all dependencies handled with things like torch from the right feed for those (like us) who build the cuda_ext.

For now, this PR just forces us to use the latest commit prior to these changes in apex.