### PR TITLE
fix autoTP checkpoint load for OPT models

### DIFF
--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -801,7 +801,7 @@ def skip_level_0_prefix(model, name):
         key = re.search(r": (.*?)Stack", model)
     if key is None:
         key = re.match(r"(.*?)Model", model)
-    if key is not None and key.group(1).lower() in "bloom":
+    if key is not None and key.group(1).lower() in ["bloom", "opt"]:
         # if keys start with 'model.', don't skip level 0 prefix
         if not re.match("^model[.]", name):
             return True


### PR DESCRIPTION
For OPT-30B or other OPT series model, state_dict keys is: `(['decoder.embed_tokens.wei ght', 'decoder.embed_positions.weight', 'decoder.project_out.weight', 'decoder.project_in.weight', 'decoder.layers.0.self_attn.k_proj.weight', ' decoder.layers.0.self_attn.k_proj.bias'`

While the model start with a extra level0 `model`:
![image](https://github.com/microsoft/DeepSpeed/assets/5948851/bc70f770-aa02-417d-97b2-d9c36c54f063)

So we need to skip the level0 when load checkpoint for OPT series models like BLOOM series models.

Please kindly review @tjruwase @jeffra  cc @sywangyi @delock 
