### PR TITLE
Pipe Engine Reduce High Dimension Output tensor fix

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -474,7 +474,7 @@ class PipelineEngine(DeepSpeedEngine):
             else:
                 assert isinstance(outputs, (list, tuple))
                 reduced = [torch.zeros_like(o) for o in outputs[0]]
-                for idx, out in outputs:
+                for idx, out in enumerate(outputs):
                     reduced[idx] += out
 
             # Average over the microbatches

--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -474,8 +474,9 @@ class PipelineEngine(DeepSpeedEngine):
             else:
                 assert isinstance(outputs, (list, tuple))
                 reduced = [torch.zeros_like(o) for o in outputs[0]]
-                for idx, out in enumerate(outputs):
-                    reduced[idx] += out
+                for outs in outputs:
+                    for idx, out in enumerate(outs):
+                        reduced[idx] += out
 
             # Average over the microbatches
             reduced = self._scale_loss_by_gas(reduced)


### PR DESCRIPTION
Motivation for the PR:
For pipe engine in eval_batch, for high dimension output tensors, there needs to be an enumerate call to allocate the correct values to the indices in reduction array. (https://github.com/microsoft/DeepSpeed/blob/044dd0e2c3bf44b98163f15f42343a72b5541078/deepspeed/runtime/pipe/engine.py#L474)
Without it  an error pops up (for the case when output[0] is not a single dimension torch tensor) :
```bash
TypeError: iteration over a 0-d tensor
```

@jeffra  requesting review 
(PS:CLA is signed).