### PR TITLE
fix "undefined symbol: curandCreateGenerator" for quantizer op

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -623,7 +623,8 @@ class CUDAOpBuilder(OpBuilder):
                                     sources=self.strip_empty_entries(self.sources()),
                                     include_dirs=self.strip_empty_entries(self.include_paths()),
                                     libraries=self.strip_empty_entries(self.libraries_args()),
-                                    extra_compile_args=compile_args)
+                                    extra_compile_args=compile_args,
+                                    extra_link_args=self.strip_empty_entries(self.extra_ldflags()))
 
         if self.is_rocm_pytorch():
             # hip converts paths to absolute, this converts back to relative


### PR DESCRIPTION
I met this error when I used deepspeed v0.9.5 with torch 2.0.

```
ImportError: /root/miniconda3/lib/python3.8/site-packages/deepspeed/ops/quantizer/quantizer_op.cpython-38-x86_64-linux-gnu.so: undefined symbol: curandCreateGenerator
```

And I found that `extra_ldflags` (which contains `-lcurand`) is not used. This PR can fix it.

