### PR TITLE
[ROCm] Enable TestCUDABackward::test_backward unit tests

### DIFF
--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -26,6 +26,8 @@ DEEPSPEED_UNIT_WORKER_TIMEOUT = 120
 # Worker timeout for tests that hang
 DEEPSPEED_TEST_TIMEOUT = 600
 
+def is_rocm_pytorch():
+    return  hasattr(torch.version, 'hip') and torch.version.hip is not None
 
 def get_xdist_worker_id():
     xdist_worker = os.environ.get('PYTEST_XDIST_WORKER', None)
@@ -52,8 +54,7 @@ def set_accelerator_visible():
         # CUDA_VISIBLE_DEVICES is not set, discover it using accelerator specific command instead
         import subprocess
         if get_accelerator().device_name() == 'cuda':
-            is_rocm_pytorch = hasattr(torch.version, 'hip') and torch.version.hip is not None
-            if is_rocm_pytorch:
+            if is_rocm_pytorch():
                 rocm_smi = subprocess.check_output(['rocm-smi', '--showid'])
                 gpu_ids = filter(lambda s: 'GPU' in s, rocm_smi.decode('utf-8').strip().split('\n'))
                 num_accelerators = len(list(gpu_ids))

--- a/tests/unit/ops/accelerators/test_accelerator_backward.py
+++ b/tests/unit/ops/accelerators/test_accelerator_backward.py
@@ -8,12 +8,13 @@ import torch
 import pytest
 import random
 import copy
+import os
 from torch import nn
 from deepspeed import DeepSpeedTransformerLayer, DeepSpeedTransformerConfig
 from deepspeed.accelerator import get_accelerator
 from unit.modeling import BertConfig, BertLayerNorm, BertEncoder as BertEncoderPostln
 from unit.modelingpreln import BertEncoder as BertEncoderPreln
-from unit.common import DistributedTest
+from unit.common import DistributedTest, is_rocm_pytorch
 
 #if not deepspeed.ops.__installed_ops__['transformer']:
 #pytest.skip(
@@ -262,7 +263,6 @@ def run_backward(ds_config, seq_len, atol=1e-2, verbose=False):
                          ]) # yapf: disable
 class TestCUDABackward(DistributedTest):
     world_size = 1
-    is_rocm_pytorch = hasattr(torch.version, 'hip') and torch.version.hip is not None
     if is_rocm_pytorch:
         #This is to flush denorms in forward pass. Please refer to https://github.com/pytorch/pytorch/blob/main/docs/source/notes/numerical_accuracy.rst#reduced-precision-fp16-and-bf16-gemms-and-convolutions-on-amd-instinct-mi200-devices
         os.environ['ROCBLAS_INTERNAL_FP16_ALT_IMPL']='1'

--- a/tests/unit/ops/accelerators/test_accelerator_backward.py
+++ b/tests/unit/ops/accelerators/test_accelerator_backward.py
@@ -262,6 +262,10 @@ def run_backward(ds_config, seq_len, atol=1e-2, verbose=False):
                          ]) # yapf: disable
 class TestCUDABackward(DistributedTest):
     world_size = 1
+    is_rocm_pytorch = hasattr(torch.version, 'hip') and torch.version.hip is not None
+    if is_rocm_pytorch:
+        #This is to flush denorms in forward pass. Please refer to https://github.com/pytorch/pytorch/blob/main/docs/source/notes/numerical_accuracy.rst#reduced-precision-fp16-and-bf16-gemms-and-convolutions-on-amd-instinct-mi200-devices
+        os.environ['ROCBLAS_INTERNAL_FP16_ALT_IMPL']='1'
 
     def test_backward(self, batch_size, hidden_size, seq_len, heads, num_layers, is_preln, use_fp16, atol):
         # Only run fp16 test cases on devices with FP16 capability.


### PR DESCRIPTION
This PR is required to flush the denorms in inputs to Linear layer due to which TestCUDABackward::test_backward unit tests are failing on MI200.
Here we are making use of ROCBLAS_INTERNAL_FP16_ALT_IMPL=1 (meaning alt_impl for both forward and backward) flag to pass the unit tests.
Background on the MI200 denorm issue: https://pytorch.org/docs/stable/notes/numerical_accuracy.html#reduced-precision-fp16-and-bf16-gemms-and-convolutions-on-amd-instinct-mi200-devices

cc: @jithunnair-amd @loadams @jeffra 