### PR TITLE
Fix a typo of global variable in comm.py

### DIFF
--- a/deepspeed/comm/comm.py
+++ b/deepspeed/comm/comm.py
@@ -488,7 +488,7 @@ def all_reduce_coalesced(tensors,
                          prof=False,
                          log_name='all_reduce',
                          debug=get_caller_func()):
-    global cbd
+    global cdb
     return cdb.all_reduce_coalesced(tensors, op, group, async_op)
 
 


### PR DESCRIPTION
This is a bugfix for https://github.com/microsoft/DeepSpeed/issues/3851, global variable cdb is mistakenly written as cbd. There's no local variable of the same name in this function, so no effect on functionality yet.

