### PR TITLE
Decorator to avoid partitioning DeepSpeedEngine

### DIFF
--- a/deepspeed/__init__.py
+++ b/deepspeed/__init__.py
@@ -124,9 +124,6 @@ def initialize(args=None,
                                                                              __git_branch__),
              ranks=[0])
 
-    # Disable zero.Init context if it's currently enabled
-    zero.partition_parameters.shutdown_init_context()
-
     assert model is not None, "deepspeed.initialize requires a model"
 
     global dist

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -26,7 +26,7 @@ from deepspeed import comm as dist
 from deepspeed.runtime.utils import see_memory_usage, DummyOptim
 from .zero.offload_config import OffloadDeviceEnum
 from deepspeed.runtime.zero.stage_1_and_2 import DeepSpeedZeroOptimizer
-from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
+from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus, NoPartitioningDecorator
 from deepspeed.runtime.zero.utils import is_zero_supported_optimizer, ZeRORuntimeException
 from deepspeed.runtime.zero.parameter_offload import DeepSpeedZeRoOffload
 from deepspeed.runtime.zero.config import ZERO_OPTIMIZATION
@@ -178,6 +178,7 @@ class EngineTimers(object):
             ]
 
 
+@NoPartitioningDecorator()
 class DeepSpeedEngine(Module):
     r"""DeepSpeed engine for training."""
 


### PR DESCRIPTION
Following up on #3202 and the discussion in #3592, this introduces a class decorator called ```NoPartitioningDecorator``` that excludes a class from the partitioning hooks installed by the ```Init``` context in ```_enable_class``` and ```_init_subclass```. With this there is no need to manually manage the shutdown of the ```Init``` context inside ```deepspeed.initialize```.