### PR TITLE
Update pytorch-lightning version in CI

### DIFF
--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install pytorch
         run: |
-          pip install -U --cache-dir /blob/torch_cache torch==1.9.1+cu111 torchvision==0.10.1+cu111 torchaudio==0.9.1 -f https://download.pytorch.org/whl/torch_stable.html
+          pip install -U --cache-dir /blob/torch_cache torch torchvision --extra-index-url https://download.pytorch.org/whl/cu116
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -40,8 +40,7 @@ jobs:
       - name: PyTorch Lightning Tests
         run: |
           if [[ -d ./torch-extensions ]]; then rm -rf ./torch-extensions; fi
-          # Pin pytorch-lightning version to latest pre-2.0.0+ as these require updating the pinned torch versions above.
-          pip install pytorch-lightning==1.9.4
+          pip install pytorch-lightning
           pip install "protobuf<4.21.0"
           cd tests
           TORCH_EXTENSIONS_DIR=./torch-extensions pytest --color=yes --durations=0 --verbose lightning/


### PR DESCRIPTION
We pinned `pytorch-lightning` to a pre-2.0.0 version to address CI issues in #3047. Removing that pin now so we can test latest versions of `pytorch` & `pytorch-lightning`

@loadams 