### PR TITLE
Fix Meta Tensor checkpoint load for BLOOM models

### DIFF
--- a/deepspeed/module_inject/load_checkpoint.py
+++ b/deepspeed/module_inject/load_checkpoint.py
@@ -29,10 +29,12 @@ def load_model_with_checkpoint(r_module,
     error_msgs = []
 
     def prefix_check():
-        # if keys start with 'model.', don't skip level 0 prefix
+        # if keys start with 'model.' or 'transformer.', don't skip level 0 prefix
         for key in sd[0].keys():
+            # OPT models
             if re.match("^model[.]", key):
                 return False
+            # BLOOM models
             if re.match("^transformer[.]", key):
                 return False
         return True

--- a/deepspeed/module_inject/load_checkpoint.py
+++ b/deepspeed/module_inject/load_checkpoint.py
@@ -33,6 +33,8 @@ def load_model_with_checkpoint(r_module,
         for key in sd[0].keys():
             if re.match("^model[.]", key):
                 return False
+            if re.match("^transformer[.]", key):
+                return False
         return True
 
     skip_level_0_prefix = prefix_check() and container.policy.use_load_prefix


### PR DESCRIPTION
This PR fixes Meta Tensor checkpoint loading for BLOOM models where the SD keys start with `transformer.`.

Command:
```
deepspeed --num_gpus 1 inference-test.py --name <model_name> --dtype <dtype> --use_meta_tensor --replace_method "auto" --use_kernel --ds_inference
```


BLOOM Model | SD Key | Before Fix | After Fix
-- | -- | -- | --
TigerResearch/tigerbot-7b-sft | transformer.ln_f.weight | FAIL | PASS
bigscience/bloom-3b | ln_f.weight | PASS | PASS

This PR addresses this issue:
https://github.com/microsoft/DeepSpeedExamples/issues/580