### PR TITLE
Update workflows for merge queue

### DIFF
--- a/.github/workflows/cpu-inference.yml
+++ b/.github/workflows/cpu-inference.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'blogs/**'
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cpu-inference.yml
+++ b/.github/workflows/cpu-inference.yml
@@ -6,6 +6,7 @@ on:
       - 'docs/**'
       - 'blogs/**'
   merge_group:
+    branches: [ master ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -5,6 +5,7 @@ on:
     branches:
       '**'
   merge_group:
+    branches: [ master ]
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       '**'
+  merge_group:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-accelerate-v100.yml
+++ b/.github/workflows/nv-accelerate-v100.yml
@@ -6,6 +6,7 @@ on:
       - 'docs/**'
       - 'blogs/**'
   merge_group:
+    branches: [ master ]
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-accelerate-v100.yml
+++ b/.github/workflows/nv-accelerate-v100.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'blogs/**'
+  merge_group:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -6,6 +6,7 @@ on:
       - 'docs/**'
       - 'blogs/**'
   merge_group:
+    branches: [ master ]
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'blogs/**'
+  merge_group:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -6,6 +6,7 @@ on:
       - 'docs/**'
       - 'blogs/**'
   merge_group:
+    branches: [ master ]
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'blogs/**'
+  merge_group:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-megatron.yml
+++ b/.github/workflows/nv-megatron.yml
@@ -6,6 +6,7 @@ on:
       - 'docs/**'
       - 'blogs/**'
   merge_group:
+    branches: [ master ]
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-megatron.yml
+++ b/.github/workflows/nv-megatron.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'blogs/**'
+  merge_group:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-mii.yml
+++ b/.github/workflows/nv-mii.yml
@@ -6,6 +6,7 @@ on:
       - 'docs/**'
       - 'blogs/**'
   merge_group:
+    branches: [ master ]
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-mii.yml
+++ b/.github/workflows/nv-mii.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'blogs/**'
+  merge_group:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-pre-compile-ops.yml
+++ b/.github/workflows/nv-pre-compile-ops.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'blogs/**'
+  merge_group:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-pre-compile-ops.yml
+++ b/.github/workflows/nv-pre-compile-ops.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/**'
       - 'blogs/**'
   merge_group:
+    branches: [ master ]
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-torch-latest-cpu.yml
+++ b/.github/workflows/nv-torch-latest-cpu.yml
@@ -6,6 +6,7 @@ on:
       - 'docs/**'
       - 'blogs/**'
   merge_group:
+    branches: [ master ]
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-torch-latest-cpu.yml
+++ b/.github/workflows/nv-torch-latest-cpu.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'blogs/**'
+  merge_group:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -6,6 +6,7 @@ on:
       - 'docs/**'
       - 'blogs/**'
   merge_group:
+    branches: [ master ]
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'blogs/**'
+  merge_group:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -6,6 +6,7 @@ on:
       - 'docs/**'
       - 'blogs/**'
   merge_group:
+    branches: [ master ]
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'blogs/**'
+  merge_group:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'blogs/**'
+  merge_group:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/**'
       - 'blogs/**'
   merge_group:
+    branches: [ master ]
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
In order to run the CI on the recently enabled Merge Queue, we need to add a trigger to our workflows:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group