### PR TITLE
Del comment deepspeed.zero.Init() can be used as a decorator

### DIFF
--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -761,15 +761,6 @@ class Init(InsertPostInitMethodToModuleSubClasses):
             See :meth:`deepspeed.init_distributed` for more information.
 
         .. note::
-            Can also be used as a decorator:
-
-            .. code-block:: python
-
-                @deepspeed.zero.Init()
-                def get_model():
-                    return MyLargeModel()
-
-        .. note::
             Only applicable to training with ZeRO-3.
 
         Examples


### PR DESCRIPTION
Object deepspeed.zero.Init() is not callable, it can't be used as a decorator. Delete this code comment to avoid misunderstanding.

Please close this PR if I am wrong.