### PR TITLE
fix memory leak with zero-3

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -369,10 +369,6 @@ class DeepSpeedEngine(Module):
         if self.optimizer is not None and hasattr(self.optimizer, 'destroy'):
             self.optimizer.destroy()
 
-    def __del__(self):
-        self.destroy()
-        del self
-
     def _get_model_parameters(self):
         if self.autotuning_profile_model_info():
             self.autotuning_model_info = {}

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -369,6 +369,10 @@ class DeepSpeedEngine(Module):
         if self.optimizer is not None and hasattr(self.optimizer, 'destroy'):
             self.optimizer.destroy()
 
+    def __del__(self):
+        self.destroy()
+        del self
+
     def _get_model_parameters(self):
         if self.autotuning_profile_model_info():
             self.autotuning_model_info = {}

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -357,6 +357,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
 
     def destroy(self):
         self.parameter_offload.destroy()
+        del self.__ipg_bucket_flat_buffer
 
     def initialize_ds_offload(
         self,


### PR DESCRIPTION
* Explicitly delete `__ipg_bucket_flat_buffer` in zero 3 optimizer, this field is not being deleted via garbage collection and was causing memory leaks when creating z3 managed models back to back.