### PR TITLE
RNNprofiler: fix gates size retrieval logic in _rnn_flops

### DIFF
--- a/deepspeed/profiling/flops_profiler/profiler.py
+++ b/deepspeed/profiling/flops_profiler/profiler.py
@@ -960,11 +960,11 @@ def _reload_tensor_methods():
 
 
 def _rnn_flops(flops, rnn_module, w_ih, w_hh, input_size):
-    input_size, hidden_size = w_ih.shape
+    gates_size = w_ih.shape[0]
     # matrix matrix mult ih state and internal state
-    flops += 2 * input_size * hidden_size - hidden_size
+    flops += 2 * w_ih.shape[0] * w_ih.shape[1] - gates_size
     # matrix matrix mult hh state and internal state
-    flops += 2 * hidden_size * hidden_size - hidden_size
+    flops += 2 * w_hh.shape[0] * w_hh.shape[1] - gates_size
     if isinstance(rnn_module, (nn.RNN, nn.RNNCell)):
         # add both operations
         flops += rnn_module.hidden_size


### PR DESCRIPTION
Hello,

Sorry, this MR fixes a bug I introduced myself by mistaking the shape of `w_ih` to be `(input_size, hidden_size)`, when in reality it is `(N*hidden_size, input_size)`, where `N` differs depending on the RNN cell type (1 if RNN, 3 if GRU, 4 if LSTM).

To avoid complexifying the logic, I went back to something very close to original implementation, simply multiplying by 2 for FLOP (instead of MAC) and subtracting what I called `gates_size = N * hidden_size` to avoid counting the bias twice.

Thanks, and sorry for introducing another bug through my previous fix...

Cheers