### PR TITLE
add flash_attn as deepspeed ops

### DIFF
--- a/deepspeed/ops/__init__.py
+++ b/deepspeed/ops/__init__.py
@@ -13,4 +13,6 @@ from . import transformer
 
 from .transformer import DeepSpeedTransformerLayer, DeepSpeedTransformerConfig
 
+from .flash_attention import DeepSpeedFlashAttn
+
 from ..git_version_info import compatible_ops as __compatible_ops__

--- a/deepspeed/ops/flash_attention/__init__.py
+++ b/deepspeed/ops/flash_attention/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from .flash_self_attention import DeepSpeedFlashAttn

--- a/deepspeed/ops/flash_attention/flash_self_attention.py
+++ b/deepspeed/ops/flash_attention/flash_self_attention.py
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import torch.nn as nn
+from deepspeed.accelerator import get_accelerator
+
+# currently there is no cuda version, so we have to get builder like this
+FlashAttentionBuilder = get_accelerator().get_op_builder("FlashAttentionBuilder")
+
+flash_attn_builder = None
+
+
+class DeepSpeedFlashAttn(nn.Module):
+    """Initialize the DeepSpeed Flash Attention.
+
+        Arguments:
+            causal: bool. Whether to apply causal attention mask. (default: True)
+
+            softmax_scale: float. The temperature to use for the softmax attention. (default: 1/sqrt(head_size))
+
+            dropout_p: float. The dropout rate to apply to the attention (default: 0.0)
+
+            return_softmax: bool. return softmax result or not, only for testing. (default: False)
+    """
+
+    def __init__(self, causal=True, softmax_scale=None, dropout_p=0.0, return_softmax=False):
+        super().__init__()
+        self.causal = causal
+        self.softmax_scale = softmax_scale
+        self.dropout_p = dropout_p
+        self.return_softmax = return_softmax
+
+        # check if builder available
+        assert (FlashAttentionBuilder is not None)
+
+        global flash_attn_builder
+        if flash_attn_builder is None:
+            flash_attn_builder = FlashAttentionBuilder().load()
+
+    def forward(self, q, k, v):
+        return flash_attn_builder.flash_attn_func(q, k, v, self.dropout_p, self.softmax_scale, self.causal,
+                                                  self.return_softmax)


### PR DESCRIPTION
Hi, we would like to add flash attention mentioned by paper https://arxiv.org/abs/2205.14135 as a deepspeed op.

This PR is to create an interface for developers to implement fmha on their own devices.