### PR TITLE
add reproducible compilation environment

### DIFF
--- a/docs/_tutorials/advanced-install.md
+++ b/docs/_tutorials/advanced-install.md
@@ -123,6 +123,16 @@ fail. Therefore, if you need to you can override the default location with the h
  TORCH_EXTENSIONS_DIR=./torch-extensions deepspeed ...
 ```
 
+### conda environment for building from source
+
+If you encounter difficulties during compilation using the default system environment, you can try the conda environment we provide, which includes the necessary compilation toolchain and PyTorch. 
+
+```bash
+conda env create -n deepspeed -f environment.yml --force
+```
+
+and try above install commmands after activating it.
+
 ## Building for the correct architectures
 
 If you're getting the following error:

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,20 @@
+channels:
+  - nvidia/label/cuda-11.8.0
+  - pytorch # or pytorch-nightly
+  - conda-forge
+dependencies:
+  - pytorch
+  - torchvision
+  - torchaudio
+  - cuda
+  - pytorch-cuda=11.8
+  - compilers
+  - sysroot_linux-64==2.17
+  - gcc==11.4
+  - ninja
+  - py-cpuinfo
+  - libaio
+  - ca-certificates
+  - certifi
+  - openssl
+  - python=3.10


### PR DESCRIPTION
Currently, deepspeed only verifies the compilation process on Docker, which may not work on many clusters or not have the permission to install deepspeed using Docker. This makes precompiled deepspeed ops very challenging, especially considering that the compilation chain tools can vary significantly between different systems. There have been many issues complaining about their inability to compile ops in their own environment, say https://github.com/microsoft/DeepSpeed/issues/3890 https://github.com/pytorch/pytorch/pull/100557 https://github.com/microsoft/DeepSpeed/issues/3358 https://github.com/microsoft/DeepSpeed/issues/3067

Conda-forge provides a cross-platform compilation toolchain that, if we maintain a robust Conda environment, can make precompiled ops available to everyone and solve the issue of reproducibility.

I verify the environment on Arch LInux and Ubuntu 20.04 for pytorch and pytorch-nightly. For pytorch nightly, `DS_BUILD_AIO` should be used as it seems that op doesn't support `c++17` yet. And parallel parallel build option should be disabled as https://github.com/microsoft/DeepSpeed/issues/2885

