### PR TITLE
add lm_head and embed_out tensor parallel

### DIFF
--- a/deepspeed/module_inject/auto_tp.py
+++ b/deepspeed/module_inject/auto_tp.py
@@ -443,7 +443,7 @@ class AutoTP():
     def _replace_last_linear_module(self, r_module):
         for name, child in r_module.named_children():
             if name == "lm_head" or name == 'embed_out':
-                checking_key = name
+                checking_key = name + '.'
                 if child.__class__ in [nn.Linear, nn.Embedding, nn.LayerNorm] and state_dict != None:
                     if any(checking_key in item for item in state_dict):
                         load(child, state_dict, checking_key, mp_group)

--- a/deepspeed/module_inject/layers.py
+++ b/deepspeed/module_inject/layers.py
@@ -29,6 +29,36 @@ class LinearAllreduce(nn.Module):
         return output
 
 
+class LmHeadLinearAllreduce(nn.Module):
+
+    def __init__(
+        self,
+        weight,
+        rank,
+        world_size,
+        bias=None,
+        mp_group=None,
+    ):
+        super(LmHeadLinearAllreduce, self).__init__()
+        self.weight = weight
+        self.bias = bias
+        self.mp_group = mp_group
+        self.rank = rank
+        self.world_size = world_size
+
+    def forward(self, input):
+        assert input.shape[
+            -1] % self.world_size == 0, 'Please ensure that self.world_size is divisible by input.shape[-1]'
+        input_shard = input.shape[-1] // self.world_size
+        output = torch.matmul(input[:, :, self.rank * input_shard:(self.rank + 1) * input_shard],
+                              self.weight.transpose(-1, -2))
+        if self.mp_group is not None:
+            dist.all_reduce(output, group=self.mp_group)
+        if self.bias is not None:
+            output += self.bias
+        return output
+
+
 class LinearLayer(nn.Module):
 
     def __init__(self, weight_shape=None, dtype=torch.half, weight=None, bias=None):

--- a/deepspeed/module_inject/layers.py
+++ b/deepspeed/module_inject/layers.py
@@ -53,7 +53,7 @@ class LmHeadLinearAllreduce(nn.Module):
         output = torch.matmul(input[:, :, self.rank * input_shard:(self.rank + 1) * input_shard],
                               self.weight.transpose(-1, -2))
         if self.mp_group is not None:
-            dist.all_reduce(output, group=self.mp_group)
+            dist.inference_all_reduce(output, group=self.mp_group)
         if self.bias is not None:
             output += self.bias
         return output


### PR DESCRIPTION
This PR aims to add lm_head and embed_out layer tensor parallel. This applies to models whose last layer is named lm_head/embed_out, such as llama, gpt-j, bloom, opt, and so on.