### PR TITLE
fix(cpu_accelerator): :bug: Convert LOCAL_SIZE to integer

### DIFF
--- a/accelerator/cpu_accelerator.py
+++ b/accelerator/cpu_accelerator.py
@@ -40,7 +40,7 @@ class CPU_Accelerator(DeepSpeedAccelerator):
     def device_count(self):
         device_count = int(os.environ.get('LOCAL_SIZE', 0))
         if device_count > 0:
-            return os.environ.get('LOCAL_SIZE')
+            return device_count
         else:
             from deepspeed.utils.numa import get_numa_cores
             # Count NUMA node for number of cpu accelerators. On machine with HBM


### PR DESCRIPTION
Currently, when using the CPU accelerator with the LOCAL_SIZE env var returns this error

```
'str' object cannot be interpreted as an integer
```

This is because in the `device_count` method we are returning a string instead of an integer. This PR fixes the issue https://github.com/microsoft/DeepSpeed/issues/3970