### PR TITLE
Fix get_param_coordinator() in _end_of_forward_hook()

### DIFF
--- a/deepspeed/runtime/zero/parameter_offload.py
+++ b/deepspeed/runtime/zero/parameter_offload.py
@@ -337,7 +337,7 @@ class DeepSpeedZeRoOffload(object):
         def _end_of_forward_hook(module, *args):
 
             if not torch._C.is_grad_enabled():
-                self.get_param_coordinator(training=False).reset_step()
+                self.get_param_coordinator(training=module.training).reset_step()
 
         #likely one of them should be enough but just to be safe
         self._register_hooks_recursively(self.module)


### PR DESCRIPTION
In DeepSpeed Chat we call the _end_of_forward_hook both in the training and the eval mode so the training should not be always False.