### PR TITLE
Specify language=python in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     -   id: check-torchdist
         name: check-torchdist
         entry: ./scripts/check-torchdist.py
-        language: script
+        language: python
         exclude: ^(deepspeed/comm/|docs/|benchmarks/|scripts/check-torchdist.py|deepspeed/moe/sharded_moe.py|deepspeed/runtime/comm/coalesced_collectives.py|deepspeed/elasticity/elastic_agent.py|deepspeed/launcher/launch.py|tests/unit/comm/test_dist.py)
         # Specific deepspeed/ files are excluded for now until we wrap ProcessGroup in deepspeed.comm
 
@@ -47,7 +47,7 @@ repos:
     -   id: check-license
         name: check-license
         entry: ./scripts/check-license.py
-        language: script
+        language: python
         files: \.(py|c|cpp|cu|cc|h|hpp|cuh|hip|tr)$
 
 -   repo: https://github.com/codespell-project/codespell
@@ -74,6 +74,6 @@ repos:
     -   id: check-torchcuda
         name: check-torchcuda
         entry: ./scripts/check-torchcuda.py
-        language: script
+        language: python
         exclude: ^(.github/workflows/|scripts/check-torchcuda.py|docs/_tutorials/accelerator-abstraction-interface.md|accelerator/cuda_accelerator.py|deepspeed/inference/engine.py|deepspeed/model_implementations/transformers/clip_encoder.py|deepspeed/model_implementations/diffusers/vae.py|deepspeed/model_implementations/diffusers/unet.py|op_builder/spatial_inference.py|op_builder/transformer_inference.py|op_builder/builder.py|setup.py|tests/unit/ops/sparse_attention/test_sparse_attention.py)
         # Specific deepspeed/ files are excluded for now until we wrap ProcessGroup in deepspeed.comm


### PR DESCRIPTION
Three python script are currently specified with language: system. As as result, `/usr/bin/env python3` (which is bundled with system and usually of old version) will be launched to execute these script. I am using Cent OS 7 and the system python 3 are too old to support syntax `from __future__ import annotation`, thus cause pre-commit-hook failure. 

By specifying `language: python`, pre-commit-hook will utilize the python in virtualenv to execute these scripts, which gives better compatibility. 