### PR TITLE
add /dev/shm size to ds_report

### DIFF
--- a/deepspeed/env_report.py
+++ b/deepspeed/env_report.py
@@ -3,6 +3,7 @@
 
 # DeepSpeed Team
 
+import os
 import torch
 import deepspeed
 import subprocess
@@ -79,6 +80,29 @@ def nvcc_version():
     return ".".join(release)
 
 
+def get_shm_size():
+    try:
+        shm_stats = os.statvfs('/dev/shm')
+    except (OSError, FileNotFoundError, ValueError):
+        return "UNKNOWN", None
+
+    shm_size = shm_stats.f_frsize * shm_stats.f_blocks
+    shm_hbytes = human_readable_size(shm_size)
+    warn = None
+    if shm_size < 512 * 1024**2:
+        warn = f" {YELLOW} [WARNING] /dev/shm size might be too small, if running in docker increase to at least --shm-size='1gb' {END}"
+    return shm_hbytes, warn
+
+
+def human_readable_size(size):
+    units = ['B', 'KB', 'MB', 'GB', 'TB']
+    i = 0
+    while size >= 1024 and i < len(units) - 1:
+        size /= 1024
+        i += 1
+    return f'{size:.2f} {units[i]}'
+
+
 def debug_report():
     max_dots = 33
 
@@ -95,9 +119,16 @@ def debug_report():
     else:
         report.extend([("deepspeed wheel compiled w.", f"torch {torch_info['version']} ")])
 
+    report.append(("shared memory (/dev/shm) size", get_shm_size()))
+
     print("DeepSpeed general environment info:")
     for name, value in report:
+        warn = None
+        if isinstance(value, tuple):
+            value, warn = value
         print(name, "." * (max_dots - len(name)), value)
+        if warn:
+            print(warn)
 
 
 def parse_arguments():


### PR DESCRIPTION
We've been seeing a number of GH issues where folks are running docker with the default shared memory setting of 64MB. In many cases this limited value causes all sorts of cryptic errors: 

This PR adds a check and warning to `ds_report` to help guide users that have small /dev/shm sizes that they may need to increase this value.

See new line at bottom of screenshot:

<img width="853" alt="image" src="https://github.com/microsoft/DeepSpeed/assets/645595/5fb47798-d79d-45a4-b5fa-64b28a2d5dae">
