### PR TITLE
add llama2 autoTP support in replace_module

### DIFF
--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -428,7 +428,7 @@ def replace_transformer_layer(orig_layer_impl, model, checkpoint_dict, config, m
                 return
             for param in [
                     "n_heads", "inner_dim", "num_heads", "num_kv", "num_attention_heads", "num_attn_heads",
-                    "all_head_size", "embed_dim", "hidden_size"
+                    "all_head_size", "embed_dim", "hidden_size", "num_key_value_heads"
             ]:
                 if hasattr(child, param):
                     param_val = getattr(child, param)


### PR DESCRIPTION
### Problem
After llama2 update in transformers [[Llama2] Add support for Llama 2](https://github.com/huggingface/transformers/pull/24891), the autoTP for llama is broken.
![image](https://github.com/microsoft/DeepSpeed/assets/5948851/4db295ff-0132-4d69-87c6-441aa6daebc0)


### Reason
After dig into transformers modification, I noticed that there is another `self.num_key_value_heads` attribute in the attention module:
![image](https://github.com/microsoft/DeepSpeed/assets/5948851/9d04435a-2bdc-452e-986a-996b4be10859)
https://github.com/huggingface/transformers/pull/24891/files#diff-06392bad3b9e97be9ade60d4ac46f73b6809388f4d507c2ba1384ab872711c51R253

### Solution
In DeepSpeed, this part is controlled by a hardcoded name list in `update_mp_params` of autoTP's `replace_wo_policy`(see this PR's modification). So I added one more key in this list, and the problem is fixed.

@tjruwase @jeffra please kindly review, thanks~