### PR TITLE
[zero_to_fp32] 3x less cpu memory requirements

### DIFF
--- a/deepspeed/utils/zero_to_fp32.py
+++ b/deepspeed/utils/zero_to_fp32.py
@@ -145,7 +145,8 @@ def parse_optim_states(files, ds_checkpoint_dir):
     for f in files:
         state_dict = torch.load(f, map_location=device)
         # immediately discard the potentially huge 2 optimizer states as we only care for fp32 master weights
-        del state_dict["optimizer_state_dict"]["optimizer_state_dict"]
+        # and also handle the case where it was already removed by another helper script
+        state_dict["optimizer_state_dict"].pop("optimizer_state_dict", None)      
         state_dicts.append(state_dict)
 
     if not ZERO_STAGE in state_dicts[0][OPTIMIZER_STATE_DICT]:

--- a/deepspeed/utils/zero_to_fp32.py
+++ b/deepspeed/utils/zero_to_fp32.py
@@ -146,7 +146,7 @@ def parse_optim_states(files, ds_checkpoint_dir):
         state_dict = torch.load(f, map_location=device)
         # immediately discard the potentially huge 2 optimizer states as we only care for fp32 master weights
         # and also handle the case where it was already removed by another helper script
-        state_dict["optimizer_state_dict"].pop("optimizer_state_dict", None)      
+        state_dict["optimizer_state_dict"].pop("optimizer_state_dict", None)
         state_dicts.append(state_dict)
 
     if not ZERO_STAGE in state_dicts[0][OPTIMIZER_STATE_DICT]:

--- a/deepspeed/utils/zero_to_fp32.py
+++ b/deepspeed/utils/zero_to_fp32.py
@@ -143,7 +143,10 @@ def parse_optim_states(files, ds_checkpoint_dir):
     total_files = len(files)
     state_dicts = []
     for f in files:
-        state_dicts.append(torch.load(f, map_location=device))
+        state_dict = torch.load(f, map_location=device)
+        # immediately discard the potentially huge 2 optimizer states as we only care for fp32 master weights
+        del state_dict["optimizer_state_dict"]["optimizer_state_dict"]
+        state_dicts.append(state_dict)
 
     if not ZERO_STAGE in state_dicts[0][OPTIMIZER_STATE_DICT]:
         raise ValueError(f"{files[0]} is not a zero checkpoint")


### PR DESCRIPTION
As we have just discovered converting an 80B param model Z3 checkpoint requires more than 1TB of cpu memory as the original script stores the complete `state_dict` of optim files into the memory.

As we don't need the actual 2 optim states (2x4 bytes) but only the fp32 weights (4 bytes) this PR discards the former immediately on loading each shard. This reduces peak memory requirements 3x times.

Unfortunately it still takes a really long time to load each of these files. So it'll still be slow, but require 3x less cpu memory. Possible solutions:

1. If deepspeed switches to https://github.com/huggingface/safetensors/ it should be possible to load only the wanted parts from each shard. (fwiw, we are gradually moving all `transformers` models on the hub to `safetensors`)
2. Alternatively, perhaps the optim states and fp32 master weights could live in 2 separate files. In which case it'd very fast to load just the fp32 weight files. feature request: https://github.com/microsoft/DeepSpeed/issues/4029 as it's probably a low-hanging fruit as compared to solution (1)

@tjruwase 