### PR TITLE
Support num_key_value_heads configuration for grouped-query attention.

### DIFF
--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -428,7 +428,7 @@ def replace_transformer_layer(orig_layer_impl, model, checkpoint_dict, config, m
                 return
             for param in [
                     "n_heads", "inner_dim", "num_heads", "num_kv", "num_attention_heads", "num_attn_heads",
-                    "all_head_size", "embed_dim", "hidden_size"
+                    "all_head_size", "embed_dim", "hidden_size", "num_key_value_heads"
             ]:
                 if hasattr(child, param):
                     param_val = getattr(child, param)


### PR DESCRIPTION
This patch fixes the issue described in https://github.com/microsoft/DeepSpeed/issues/4027

In summary the llama2 model uses grouped query attention therefore it has a new configuration for key value heads in addition to num_heads.
The configurations for llama2-13b-chat model is as follows:
{
  "_name_or_path": null,
  "architectures": [
    "LlamaForCausalLM"
  ],
  "bos_token_id": 1,
  "eos_token_id": 2,
  "hidden_act": "silu",
  "hidden_size": 5120,
  "initializer_range": 0.02,
  "intermediate_size": 13824,
  "max_position_embeddings": 2048,
  "model_type": "llama",
  "num_attention_heads": 40,
  "num_hidden_layers": 40,
  "num_key_value_heads": 40,
  "pad_token_id": 0,
  "pretraining_tp": 1,
  "rms_norm_eps": 1e-05,
  "rope_scaling": null,
  "tie_word_embeddings": false,
  "torch_dtype": "float16",
  "transformers_version": "4.31.0.dev0",
  "use_cache": true,
  "vocab_size": 32000
}