### PR TITLE
fix: remove unnessary `#` punct in the second `sed` command

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -154,7 +154,7 @@ RUN pip install psutil \
 ###############################################################################
 ENV SSH_PORT=2222
 RUN cat /etc/ssh/sshd_config > ${STAGE_DIR}/sshd_config && \
-        sed "0,/^#Port 22/s//Port ${SSH_PORT}/" ${STAGE_DIR}/sshd_config > /etc/ssh/sshd_config
+        sed "0,/^Port 22/s//Port ${SSH_PORT}/" ${STAGE_DIR}/sshd_config > /etc/ssh/sshd_config
 
 ##############################################################################
 # PyTorch


### PR DESCRIPTION
* the command at line 37:38 of `docker/Dockerfile` has already changed the `# Port 22` to `Port 22` for the `/etc/ssh/sshd_config`
* the pre-modified command at line 156:157 would try to replace the already changed `# Port 22`, which will fail to change anything and cause the sshd port still listen to 22 rather than 2222.
* this PR ask to remove the `#` in the sed command at line 157 to make its purpose work.