### PR TITLE
Fix for lm head weights for models such as llama

### DIFF
--- a/deepspeed/module_inject/load_checkpoint.py
+++ b/deepspeed/module_inject/load_checkpoint.py
@@ -260,7 +260,8 @@ def load_model_with_checkpoint(r_module,
     for n, p in r_module.named_parameters():
         if "word_embeddings." in n or "embed_tokens." in n or "wte." in n:
             embedding_weight = p
-    if embedding_weight is not None and r_module.lm_head.weight.is_meta:
+    tie_word_embeddings = getattr(r_module.config, 'tie_word_embeddings', True)
+    if embedding_weight is not None and r_module.lm_head.weight.is_meta and tie_word_embeddings:
         r_module.lm_head.weight = embedding_weight
     for sd_ in sd:
         del sd_


### PR DESCRIPTION
Llama has tie word embeddings as False.
When loading from checkpoint, lm head weight is by default set to embedding weight. Add a check of tie word embeddings when setting lm head weight to embedding weight. In case of llama models, this updation of lm head weight with embedding weight won't happen and lm head weights will be correctly  set during load module recursive. Without this fix, llama models may give junk output also.