### PR TITLE
zero_to_fp32 script adds support for tag argument

### DIFF
--- a/deepspeed/utils/zero_to_fp32.py
+++ b/deepspeed/utils/zero_to_fp32.py
@@ -574,9 +574,14 @@ if __name__ == "__main__":
         "output_file",
         type=str,
         help="path to the pytorch fp32 state_dict output file (e.g. path/checkpoint-12/pytorch_model.bin)")
+    parser.add_argument("-t",
+                        "--tag",
+                        type=str,
+                        default=None,
+                        help="checkpoint tag used as a unique identifier for checkpoint. e.g., global_step1")
     parser.add_argument("-d", "--debug", action='store_true', help="enable debug")
     args = parser.parse_args()
 
     debug = args.debug
 
-    convert_zero_checkpoint_to_fp32_state_dict(args.checkpoint_dir, args.output_file)
+    convert_zero_checkpoint_to_fp32_state_dict(args.checkpoint_dir, args.output_file, tag=args.tag)


### PR DESCRIPTION
Add support for a zero_to_fp32 script that generates a specified tag model.  Cause I often look at some monitor to choose the right model for the tag, if I write the tag together in the checkpoint_dir parameter, it will report an error: `ValueError: Unable to find 'latest' file at a path`.