### PR TITLE
add type checker ignore

### DIFF
--- a/accelerator/cpu_accelerator.py
+++ b/accelerator/cpu_accelerator.py
@@ -5,7 +5,7 @@
 
 import torch
 from deepspeed.accelerator.abstract_accelerator import DeepSpeedAccelerator
-import oneccl_bindings_for_pytorch  # noqa: F401
+import oneccl_bindings_for_pytorch  # noqa: F401 # type: ignore
 import psutil
 import os
 
@@ -229,7 +229,7 @@ class CPU_Accelerator(DeepSpeedAccelerator):
         try:
             # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed
             # if successful this also means we're doing a local install and not JIT compile path
-            from op_builder import __deepspeed__  # noqa: F401
+            from op_builder import __deepspeed__  # noqa: F401 # type: ignore
             return "op_builder.cpu"
         except ImportError:
             return "deepspeed.ops.op_builder.cpu"
@@ -253,7 +253,7 @@ class CPU_Accelerator(DeepSpeedAccelerator):
         try:
             # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed
             # if successful this also means we're doing a local install and not JIT compile path
-            from op_builder import __deepspeed__  # noqa: F401
+            from op_builder import __deepspeed__  # noqa: F401 # type: ignore
             from op_builder.cpu import CCLCommBuilder, FusedAdamBuilder, CPUAdamBuilder, NotImplementedBuilder
         except ImportError:
             from deepspeed.ops.op_builder.cpu import CCLCommBuilder, FusedAdamBuilder, CPUAdamBuilder, NotImplementedBuilder

--- a/accelerator/cuda_accelerator.py
+++ b/accelerator/cuda_accelerator.py
@@ -217,7 +217,7 @@ class CUDA_Accelerator(DeepSpeedAccelerator):
         try:
             # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed
             # if successful this also means we're doing a local install and not JIT compile path
-            from op_builder import __deepspeed__  # noqa: F401
+            from op_builder import __deepspeed__  # noqa: F401 # type: ignore
             return "op_builder"
         except ImportError:
             return "deepspeed.ops.op_builder"

--- a/accelerator/mps_accelerator.py
+++ b/accelerator/mps_accelerator.py
@@ -200,7 +200,7 @@ class MPS_Accelerator(DeepSpeedAccelerator):
         try:
             # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed
             # if successful this also means we're doing a local install and not JIT compile path
-            from op_builder import __deepspeed__  # noqa: F401
+            from op_builder import __deepspeed__  # noqa: F401 # type: ignore
 
             return "op_builder"
         except ImportError:

--- a/accelerator/npu_accelerator.py
+++ b/accelerator/npu_accelerator.py
@@ -199,7 +199,7 @@ class NPU_Accelerator(DeepSpeedAccelerator):
         try:
             # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed
             # if successful this also means we're doing a local install and not JIT compile path
-            from op_builder import __deepspeed__  # noqa: F401
+            from op_builder import __deepspeed__  # noqa: F401 # type: ignore
             return "op_builder.npu"
         except ImportError:
             return "deepspeed.ops.op_builder.npu"
@@ -216,7 +216,7 @@ class NPU_Accelerator(DeepSpeedAccelerator):
         try:
             # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed
             # if successful this also means we're doing a local install and not JIT compile path
-            from op_builder import __deepspeed__  # noqa: F401
+            from op_builder import __deepspeed__  # noqa: F401 # type: ignore
             from op_builder.npu import NotImplementedBuilder
         except ImportError:
             from deepspeed.ops.op_builder.npu import NotImplementedBuilder

--- a/accelerator/real_accelerator.py
+++ b/accelerator/real_accelerator.py
@@ -55,19 +55,19 @@ def get_accelerator():
         accelerator_name = os.environ["DS_ACCELERATOR"]
         if accelerator_name == "xpu":
             try:
-                from intel_extension_for_deepspeed import XPU_Accelerator  # noqa: F401
+                from intel_extension_for_deepspeed import XPU_Accelerator  # noqa: F401 # type: ignore
             except ImportError as e:
                 raise ValueError(
                     f"XPU_Accelerator requires intel_extension_for_deepspeed, which is not installed on this system.")
         elif accelerator_name == "cpu":
             try:
-                import intel_extension_for_pytorch  # noqa: F401
+                import intel_extension_for_pytorch  # noqa: F401 # type: ignore
             except ImportError as e:
                 raise ValueError(
                     f"CPU_Accelerator requires intel_extension_for_pytorch, which is not installed on this system.")
         elif accelerator_name == "npu":
             try:
-                import torch_npu  # noqa: F401
+                import torch_npu  # noqa: F401 # type: ignore
             except ImportError as e:
                 raise ValueError(f"NPU_Accelerator requires torch_npu, which is not installed on this system.")
             pass
@@ -100,21 +100,21 @@ def get_accelerator():
         #    between installation time and runtime.
 
         try:
-            from intel_extension_for_deepspeed import XPU_Accelerator  # noqa: F401,F811
+            from intel_extension_for_deepspeed import XPU_Accelerator  # noqa: F401,F811 # type: ignore
 
             accelerator_name = "xpu"
         except ImportError as e:
             pass
         if accelerator_name == None:
             try:
-                import intel_extension_for_pytorch  # noqa: F401,F811
+                import intel_extension_for_pytorch  # noqa: F401,F811 # type: ignore
 
                 accelerator_name = "cpu"
             except ImportError as e:
                 pass
         if accelerator_name == None:
             try:
-                import torch_npu  # noqa: F401,F811
+                import torch_npu  # noqa: F401,F811 # type: ignore
 
                 accelerator_name = "npu"
             except ImportError as e:

--- a/deepspeed/__init__.py
+++ b/deepspeed/__init__.py
@@ -13,7 +13,7 @@ from torch.optim.lr_scheduler import _LRScheduler
 from packaging import version as pkg_version
 
 try:
-    import triton  # noqa: F401
+    import triton  # noqa: F401 # type: ignore
     HAS_TRITON = True
 except ImportError:
     HAS_TRITON = False

--- a/deepspeed/env_report.py
+++ b/deepspeed/env_report.py
@@ -59,7 +59,7 @@ def op_report(verbose=True):
 
 def ninja_installed():
     try:
-        import ninja  # noqa: F401
+        import ninja  # noqa: F401 # type: ignore
     except ImportError:
         return False
     return True

--- a/deepspeed/git_version_info.py
+++ b/deepspeed/git_version_info.py
@@ -5,7 +5,7 @@
 
 try:
     #  This is populated by setup.py
-    from .git_version_info_installed import *  # noqa: F401
+    from .git_version_info_installed import *  # noqa: F401 # type: ignore
 except ModuleNotFoundError:
     import os
     if os.path.isfile('version.txt'):

--- a/deepspeed/monitor/utils.py
+++ b/deepspeed/monitor/utils.py
@@ -8,7 +8,7 @@ def check_tb_availability():
     try:
         # torch.utils.tensorboard will fail if `tensorboard` is not available,
         # see their docs for more details: https://pytorch.org/docs/1.8.0/tensorboard.html
-        import tensorboard  # noqa: F401
+        import tensorboard  # noqa: F401 # type: ignore
     except ImportError:
         print('If you want to use tensorboard logging, please `pip install tensorboard`')
         raise
@@ -16,7 +16,7 @@ def check_tb_availability():
 
 def check_wandb_availability():
     try:
-        import wandb  # noqa: F401
+        import wandb  # noqa: F401 # type: ignore
     except ImportError:
         print(
             'If you want to use wandb logging, please `pip install wandb` and follow the instructions at https://docs.wandb.ai/quickstart'

--- a/op_builder/__init__.py
+++ b/op_builder/__init__.py
@@ -15,7 +15,7 @@ __deepspeed__ = True
 
 # List of all available op builders from deepspeed op_builder
 try:
-    import deepspeed.ops.op_builder  # noqa: F401
+    import deepspeed.ops.op_builder  # noqa: F401 # type: ignore
     op_builder_dir = "deepspeed.ops.op_builder"
 except ImportError:
     op_builder_dir = "op_builder"

--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -459,7 +459,7 @@ class OpBuilder(ABC):
                 f"Unable to JIT load the {self.name} op due to it not being compatible due to hardware/software issue. {self.error_log}"
             )
         try:
-            import ninja  # noqa: F401
+            import ninja  # noqa: F401 # type: ignore
         except ImportError:
             raise RuntimeError(f"Unable to JIT load the {self.name} op due to ninja not being installed.")
 

--- a/op_builder/cpu/builder.py
+++ b/op_builder/cpu/builder.py
@@ -6,7 +6,7 @@
 try:
     # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed
     # if successful this also means we're doing a local install and not JIT compile path
-    from op_builder import __deepspeed__  # noqa: F401
+    from op_builder import __deepspeed__  # noqa: F401 # type: ignore
     from op_builder.builder import OpBuilder
 except ImportError:
     from deepspeed.ops.op_builder.builder import OpBuilder

--- a/op_builder/npu/builder.py
+++ b/op_builder/npu/builder.py
@@ -6,7 +6,7 @@
 try:
     # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed
     # if successful this also means we're doing a local install and not JIT compile path
-    from op_builder import __deepspeed__  # noqa: F401
+    from op_builder import __deepspeed__  # noqa: F401 # type: ignore
     from op_builder.builder import OpBuilder
 except ImportError:
     from deepspeed.ops.op_builder.builder import OpBuilder

--- a/tests/benchmarks/flatten_bench.py
+++ b/tests/benchmarks/flatten_bench.py
@@ -110,15 +110,15 @@ def timeme():
 def line_profileme():
     print("--------------- line_profiler -----------------")
     print("py")
-    profile(py)()  # noqa: F821
+    profile(py)()  # noqa: F821 # type: ignore
     gc.collect()
     get_accelerator().empty_cache()
     print("cpp")
-    profile(cpp)()  # noqa: F821
+    profile(cpp)()  # noqa: F821 # type: ignore
     gc.collect()
     get_accelerator().empty_cache()
     print("apex")
-    profile(apex)()  # noqa: F821
+    profile(apex)()  # noqa: F821 # type: ignore
     gc.collect()
     get_accelerator().empty_cache()
 

--- a/tests/benchmarks/unflatten_bench.py
+++ b/tests/benchmarks/unflatten_bench.py
@@ -119,15 +119,15 @@ def timeme():
 def line_profileme():
     print("--------------- line_profier -----------------")
     print("py")
-    profile(py)()  # noqa: F821
+    profile(py)()  # noqa: F821 # type: ignore
     gc.collect()
     get_accelerator().empty_cache()
     print("cpp")
-    profile(cpp)()  # noqa: F821
+    profile(cpp)()  # noqa: F821 # type: ignore
     gc.collect()
     get_accelerator().empty_cache()
     print("apex")
-    profile(apex)()  # noqa: F821
+    profile(apex)()  # noqa: F821 # type: ignore
     gc.collect()
     get_accelerator().empty_cache()
 

--- a/tests/unit/modeling.py
+++ b/tests/unit/modeling.py
@@ -819,21 +819,21 @@ class BertPreTrainedModel(nn.Module):
             archive_file = PRETRAINED_MODEL_ARCHIVE_MAP[pretrained_model_name_or_path]
         else:
             archive_file = pretrained_model_name_or_path
-        if resolved_archive_file == archive_file:  # noqa: F821
+        if resolved_archive_file == archive_file:  # noqa: F821 # type: ignore
             logger.info("loading archive file {}".format(archive_file))
         else:
-            logger.info("loading archive file {} from cache at {}".format(archive_file,
-                                                                          resolved_archive_file))  # noqa: F821
+            logger.info("loading archive file {} from cache at {}".format(
+                archive_file, resolved_archive_file))  # noqa: F821 # type: ignore
         tempdir = None
-        if os.path.isdir(resolved_archive_file) or from_tf:  # noqa: F821
-            serialization_dir = resolved_archive_file  # noqa: F821
+        if os.path.isdir(resolved_archive_file) or from_tf:  # noqa: F821 # type: ignore
+            serialization_dir = resolved_archive_file  # noqa: F821 # type: ignore
         else:
             # Extract archive to temp dir
             tempdir = tempfile.mkdtemp()
             logger.info("extracting archive file {} to temp dir {}".format(
-                resolved_archive_file,  # noqa: F821
+                resolved_archive_file,  # noqa: F821 # type: ignore
                 tempdir))
-            with tarfile.open(resolved_archive_file, 'r:gz') as archive:  # noqa: F821
+            with tarfile.open(resolved_archive_file, 'r:gz') as archive:  # noqa: F821 # type: ignore
                 archive.extractall(tempdir)
             serialization_dir = tempdir
         # Load config

--- a/tests/unit/modelingpreln.py
+++ b/tests/unit/modelingpreln.py
@@ -914,21 +914,21 @@ class BertPreTrainedModel(nn.Module):
             archive_file = PRETRAINED_MODEL_ARCHIVE_MAP[pretrained_model_name_or_path]
         else:
             archive_file = pretrained_model_name_or_path
-        if resolved_archive_file == archive_file:  # noqa: F821
+        if resolved_archive_file == archive_file:  # noqa: F821 # type: ignore
             logger.info("loading archive file {}".format(archive_file))
         else:
-            logger.info("loading archive file {} from cache at {}".format(archive_file,
-                                                                          resolved_archive_file))  # noqa: F821
+            logger.info("loading archive file {} from cache at {}".format(
+                archive_file, resolved_archive_file))  # noqa: F821 # type: ignore
         tempdir = None
-        if os.path.isdir(resolved_archive_file) or from_tf:  # noqa: F821
-            serialization_dir = resolved_archive_file  # noqa: F821
+        if os.path.isdir(resolved_archive_file) or from_tf:  # noqa: F821 # type: ignore
+            serialization_dir = resolved_archive_file  # noqa: F821 # type: ignore
         else:
             # Extract archive to temp dir
             tempdir = tempfile.mkdtemp()
             logger.info("extracting archive file {} to temp dir {}".format(
-                resolved_archive_file,  # noqa: F821
+                resolved_archive_file,  # noqa: F821 # type: ignore
                 tempdir))
-            with tarfile.open(resolved_archive_file, 'r:gz') as archive:  # noqa: F821
+            with tarfile.open(resolved_archive_file, 'r:gz') as archive:  # noqa: F821 # type: ignore
                 archive.extractall(tempdir)
             serialization_dir = tempdir
         # Load config

--- a/tests/unit/ops/transformer/inference/test_layer_norm.py
+++ b/tests/unit/ops/transformer/inference/test_layer_norm.py
@@ -10,7 +10,7 @@ from deepspeed.accelerator import get_accelerator
 from deepspeed.ops.op_builder import InferenceBuilder
 from .inference_test_utils import allclose, get_dtypes
 try:
-    import triton  # noqa: F401
+    import triton  # noqa: F401 # type: ignore
     from deepspeed.ops.transformer.inference.triton import (
         layer_norm,
         layer_norm_residual,

--- a/tests/unit/runtime/half_precision/test_fp16.py
+++ b/tests/unit/runtime/half_precision/test_fp16.py
@@ -15,7 +15,7 @@ from deepspeed.accelerator import get_accelerator
 from deepspeed.ops.op_builder import CPUAdamBuilder
 
 try:
-    from apex import amp  # noqa: F401
+    from apex import amp  # noqa: F401 # type: ignore
     _amp_available = True
 except ImportError:
     _amp_available = False


### PR DESCRIPTION
 add type checker ignore to resolve that pylance can't resolved noqa annotation. Cause many people use vscode and Pylance. And Pylance isn't a linter, it's a static type checker. It can't support `# noqa`.  So I add some `# type: ignore` to resolve the type checker problems.