### PR TITLE
Update engine.py

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -3299,8 +3299,11 @@ class DeepSpeedEngine(Module):
         dst = os.path.join(save_path, script)
         #logger.info(f"creating recovery script {dst}")
         copyfile(src, dst)
-        # make executable
-        os.chmod(dst, os.stat(dst).st_mode | stat.S_IEXEC)
+        # make executable (safeguard for file shares - Azure as example)
+        try:
+            os.chmod(dst, os.stat(dst).st_mode | stat.S_IEXEC)
+        except Exception as e:
+            print(f"Warning: Could not change permissions for {dst} due to error: {e}. Continuing without changing permissions.")
 
     def _save_zero_checkpoint(self, save_path, tag):
         zero_checkpoint_name = self._get_zero_ckpt_name(save_path, tag)


### PR DESCRIPTION
This Pull Request introduces a try-except block around the os.chmod call used to change file permissions in the DeepSpeed engine. The change ensures that a PermissionError (or any other unexpected exception) does not halt the program's execution but instead logs a warning message. This is particularly relevant when working with read-only filesystems or shared storage where permission modification might not be allowed.

The new exception handling allows for greater robustness in various environments without compromising the overall functionality of the system. A detailed warning message has been added to inform the user of any issues encountered during the chmod operation, aiding in debugging and future refinement of the code.