### PR TITLE
Return nn.parameter type for weights and biases

### DIFF
--- a/deepspeed/module_inject/auto_tp.py
+++ b/deepspeed/module_inject/auto_tp.py
@@ -367,7 +367,7 @@ class AutoTP():
         else:
             data = child.weight.data.split(child.weight.shape[1] // self.mp_size, dim=1)
         data = data[mp_replace.gpu_index].to(get_accelerator().current_device_name())
-        data =  torch.nn.parameter.Parameter(data, requires_grad=False)
+        data = torch.nn.parameter.Parameter(data, requires_grad=False)
 
         new_embedding = nn.Embedding(child.weight.shape[0], child.weight.shape[1] // self.mp_size)
         new_embedding.weight.data.copy_(data)

--- a/deepspeed/module_inject/auto_tp.py
+++ b/deepspeed/module_inject/auto_tp.py
@@ -350,12 +350,13 @@ class AutoTP():
                     bias_data = child.bias.data.split(
                         (weight_shape[1] if self.conv_linear_layer else weight_shape[0]) // self.mp_size, dim=0)
                     bias_data = bias_data[mp_replace.gpu_index].to(get_accelerator().current_device_name())
+                    bias_data = torch.nn.parameter.Parameter(bias_data, requires_grad=False)
                 else:
                     bias_data = None
 
             setattr(child, "replaced", True)
             return LinearLayer(weight=torch.nn.parameter.Parameter(data.to(get_accelerator().current_device_name()), requires_grad=False), \
-                        bias=torch.nn.parameter.Parameter(bias_data, requires_grad=False))
+                        bias=bias_data)
 
     def _slice_embedding(self, child, name, conv_linear_layer):
         if getattr(child, "replaced", False) == True:


### PR DESCRIPTION
Return weights and biases as nn.parameters so they are saved with model and can be reloaded. The types were accidentally changed when swapping TensorSlicing.copy with Torch.split.