### PR TITLE
Remove incorrect async-io library checking code.

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -229,14 +229,6 @@ class OpBuilder(ABC):
     def extra_ldflags(self):
         return []
 
-    def libraries_installed(self, libraries):
-        valid = False
-        check_cmd = 'dpkg -l'
-        for lib in libraries:
-            result = subprocess.Popen(f'{check_cmd} {lib}', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-            valid = valid or result.wait() == 0
-        return valid
-
     def has_function(self, funcname, libraries, verbose=False):
         '''
         Test for existence of a function within a tuple of libraries.


### PR DESCRIPTION
This code path was previously only used for checking is lib-asyncio was installed, but that code was refactored and this code remained, unused.  This PR removes it.