### PR TITLE
Add DSE branch input to nv-ds-chat

### DIFF
--- a/.github/workflows/nv-ds-chat.yml
+++ b/.github/workflows/nv-ds-chat.yml
@@ -42,7 +42,11 @@ jobs:
 
       - name: DS-Chat unit tests
         run: |
-          git clone -b dse_branch https://github.com/microsoft/DeepSpeedExamples.git
+          BRANCH="master"
+          if [[ ! -z "${{ github.event.inputs.dse_branch }}" ]]; then
+              BRANCH="${{ github.event.inputs.dse_branch }}"
+          fi
+          git clone -b $BRANCH https://github.com/microsoft/DeepSpeedExamples.git
           cd DeepSpeedExamples/applications/DeepSpeed-Chat
           pip install -r requirements.txt
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch

--- a/.github/workflows/nv-ds-chat.yml
+++ b/.github/workflows/nv-ds-chat.yml
@@ -46,6 +46,7 @@ jobs:
           if [[ ! -z "${{ github.event.inputs.dse_branch }}" ]]; then
               BRANCH="${{ github.event.inputs.dse_branch }}"
           fi
+          echo "DeepSpeedExamples Branch: $BRANCH"
           git clone -b $BRANCH https://github.com/microsoft/DeepSpeedExamples.git
           cd DeepSpeedExamples/applications/DeepSpeed-Chat
           pip install -r requirements.txt

--- a/.github/workflows/nv-ds-chat.yml
+++ b/.github/workflows/nv-ds-chat.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+    inputs:
+      dse_branch:
+        description: 'DeepSpeedExamples Branch'
+        required: false
+        default: 'master'
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,7 +42,7 @@ jobs:
 
       - name: DS-Chat unit tests
         run: |
-          git clone https://github.com/microsoft/DeepSpeedExamples.git
+          git clone -b dse_branch https://github.com/microsoft/DeepSpeedExamples.git
           cd DeepSpeedExamples/applications/DeepSpeed-Chat
           pip install -r requirements.txt
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch


### PR DESCRIPTION
This PR creates a `dse_branch` input to the `workflow_dispatch` trigger on the `nv-ds-chat` workflow. This input will specify which branch to clone `DeepSpeedExamples` with and is set to `master` by default.