### PR TITLE
Pin transformers

### DIFF
--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -36,7 +36,7 @@ jobs:
           git clone https://github.com/huggingface/transformers
           cd transformers
           # if needed switch to the last known good SHA until transformers@master is fixed
-          # git checkout 1cc453d33
+          git checkout e7e9261a2
           git rev-parse --short HEAD
           pip install .
 


### PR DESCRIPTION
latest `transformers` commits are breaking our unit tests. Pinning to last known good version until we find a fix.