### PR TITLE
Fix AttributeError: 'NoneType' object has no attribute 'data' in grad_accum

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1236,6 +1236,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         if self.cpu_offload:
 
             if self.gradient_accumulation_steps > 1:
+                if param.grad_accum is None:
+                    param.grad_accum = param.grad
                 self.async_accumulate_grad_in_cpu_via_gpu(param)
 
             if self.is_gradient_accumulation_boundary:


### PR DESCRIPTION
Fix: #4183

I think that when self.async_accumulate_grad_in_cpu_via_gpu(param), only grad_accum should be computed, so it would be nice to check for the presence of grad_accum in that part.