### PR TITLE
fix MegatronLayerPolicy to be compatible with the newest ParallelTransformerLayer

### DIFF
--- a/deepspeed/module_inject/containers/megatron_gpt.py
+++ b/deepspeed/module_inject/containers/megatron_gpt.py
@@ -51,14 +51,21 @@ class MegatronLayerPolicy(TransformerPolicy):
                 try:
                     from megatron.model.transformer import ParallelTransformerLayer
                     MegatronLayerPolicy._orig_layer_class = ParallelTransformerLayer
+                    MegatronLayerPolicy.version = 1
                 except ImportError:
                     MegatronLayerPolicy._orig_layer_class = None
 
     def get_hidden_heads(self):
-        return self.client_module.attention.query_key_value.weight.shape[1], \
-                self.client_module.attention.num_attention_heads, \
-                self.client_module.input_layernorm.eps, \
-                DEFAULT_INTERMEDIATE_SIZE
+        if MegatronLayerPolicy.version == 0:
+            return self.client_module.attention.query_key_value.weight.shape[1], \
+                    self.client_module.attention.num_attention_heads, \
+                    self.client_module.input_layernorm.eps, \
+                    DEFAULT_INTERMEDIATE_SIZE
+        else:
+            return self.client_module.self_attention.query_key_value.weight.shape[1], \
+                    self.client_module.self_attention.num_attention_heads, \
+                    self.client_module.input_layernorm.eps, \
+                    DEFAULT_INTERMEDIATE_SIZE
 
     def attention(self, enable_training=False):
         if self.inference:


### PR DESCRIPTION
### Problem

Currently in DeepSpeed, will try to get `client_module.attention` while the actual `ParallelTransformerLayer` has no `attention` but `self_attention` according to this file https://github.com/microsoft/Megatron-DeepSpeed/blob/main/megatron/model/transformer.py#L927

The whole structure is:
![image](https://github.com/microsoft/DeepSpeed/assets/5948851/e0220149-0dd4-43a2-b8de-a1480241530e)

### Solution

I followed existed way by modifying version attribute to make it compatible with the newest `ParallelTransformerLayer`, and change `attention` to `self_attention`.

But I'm not sure whether `ParallelTransformerLayer` is changed or it's a new module, which means changing `MegatronLayerPolicy.version` is correct.