### PR TITLE
Enable AMD MI200 and H100 to run on branches for testing

### DIFF
--- a/.github/workflows/amd-mi200.yml
+++ b/.github/workflows/amd-mi200.yml
@@ -3,6 +3,7 @@ name: amd-mi200
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/nv-h100.yml
+++ b/.github/workflows/nv-h100.yml
@@ -3,6 +3,7 @@ name: nv-h100
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Adds the option to run two tests that both run in CI only on branches before they're merged into the master branch without needing to modify the YML to accomodate the testing.