### PR TITLE
fix zero_sd_list judgment

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -2863,7 +2863,7 @@ class DeepSpeedEngine(Module):
                     "currently supported.")
             checkpoint_folder = None
             zero_sd_list = self._get_all_zero_checkpoints(load_dir, tag)
-            if zero_sd_list is None:
+            if not zero_sd_list:
                 return False
 
         self.optimizer.load_state_dict(state_dict_list=zero_sd_list,


### PR DESCRIPTION
when dp_world_size is 0, zero_sd_list will return empty list [], then the judgment is wrong.