### PR TITLE
fix llama lm_head load wrong weight error

### DIFF
--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -305,7 +305,8 @@ def replace_transformer_layer(orig_layer_impl, model, checkpoint_dict, config, m
                                              orig_class=orig_layer_impl,
                                              replace_fn=replace_fn,
                                              _replace_policy=config.injection_policy_tuple,
-                                             checkpoint=checkpoint[i])
+                                             checkpoint=checkpoint[i],
+                                             is_last_cp=(i==(len(checkpoint) - 1)))
             pbar.update(1)
             gc.collect()
     else:
@@ -523,7 +524,7 @@ def revert_transformer_layer(orig_layer_impl, model, config, preln=False):
                           _replace_policy=None)
 
 
-def replace_module(model, orig_class, replace_fn, _replace_policy, checkpoint=None):
+def replace_module(model, orig_class, replace_fn, _replace_policy, checkpoint=None, is_last_cp=False):
     """ Scan the model for instances of ``orig_clas:`` to replace using ``replace_fn``.
     Arguments:
         model (torch.nn.Module): the model to augment
@@ -559,7 +560,7 @@ def replace_module(model, orig_class, replace_fn, _replace_policy, checkpoint=No
             if "word_embeddings." in n or "embed_tokens." in n or "wte." in n:
                 embedding_weight = p
         if embedding_weight is not None and hasattr(replaced_module, "lm_head") and hasattr(
-                replaced_module.lm_head, "weight") and replaced_module.lm_head.weight.is_meta:
+                replaced_module.lm_head, "weight") and replaced_module.lm_head.weight.is_meta and is_last_cp:
             replaced_module.lm_head.weight = embedding_weight
     return replaced_module
 


### PR DESCRIPTION
Hi, 
I have found that when we do AutoTP shard loading, if there are more than one checkpoint file, we will get a wrong lm_head weight in llama model. 

Because when we replace module we will use embedding_weight as lm_head.weight in advance. In other word, we use embedding_weight as lm_head.weight before we load lm_head.weight when we have more than one checkpoint file. 

So I add is_last_cp flag to avoid this situation. 

<img width="608" alt="image" src="https://github.com/microsoft/DeepSpeed/assets/82791803/de628ba4-6c56-4b0c-9ca9-e2774ea39c8e">
<img width="1082" alt="image" src="https://github.com/microsoft/DeepSpeed/assets/82791803/c5843fe4-ddff-471f-9142-a490078b6638">
