### PR TITLE
fix user args parsing of string with spaces on runner

### DIFF
--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -390,7 +390,7 @@ def main(args=None):
     args = parse_args(args)
 
     # For when argparse interprets remaining args as a single string
-    args.user_args = shlex.split(" ".join(args.user_args))
+    args.user_args = shlex.split(" ".join(list(map(lambda x: x if x.startswith("-") else f"'{x}'", args.user_args))))
 
     if args.elastic_training:
         assert args.master_addr != "", "Master Addr is required when elastic training is enabled"


### PR DESCRIPTION
After updating my DeepSpeed version and rerunning my program, I noticed that string arguments with spaces in user_args are not being parsed correctly as before. For example:
```shell
deepspeed --include=localhost:0,1 --master_port=12345 generate.py --arg1 "Hello world!"
```
It will cause error that `error: unrecognized arguments: world!`, i think it is caused by [#4007](https://github.com/microsoft/DeepSpeed/pull/4007). It concates all the user args then split to solve the [bug](https://github.com/microsoft/DeepSpeed/issues/3967). I have fixed the above issue by implementing a conditional check.