### PR TITLE
fix parser bug in launcher/runner.py

### DIFF
--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -162,7 +162,7 @@ def parse_args(args=None):
                         "Useful when launching deepspeed processes programmatically.")
 
     parser.add_argument("--enable_each_rank_log",
-                        default="None",
+                        default=None,
                         type=str,
                         help="redirect the stdout and stderr from each rank into different log files")
 


### PR DESCRIPTION
Is this a bug? It is a string instead of "None" type. If it is a str="None", it will go through in runner.py:504

```
        if args.enable_each_rank_log:
            deepspeed_launch.append(f"--enable_each_rank_log={args.enable_each_rank_log}")
```
