### PR TITLE
Fix Zero3 contiguous grads, reduce scatter false  accuracy issue

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -1105,7 +1105,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         if not get_accelerator().is_synchronized_device():
             self.reduce_and_partition_stream.wait_stream(get_accelerator().default_stream())
 
-        if self.contiguous_gradients and self.elements_in_ipg_bucket + param.grad.numel() < self.reduce_bucket_size:
+        if self.contiguous_gradients and self.elements_in_ipg_bucket + param.grad.numel() <= self.reduce_bucket_size:
             # move the gradient to a contiguous buffer
             with get_accelerator().stream(self.reduce_and_partition_stream):
                 # move the parameter's gradient to the contiguous flat buffer


### PR DESCRIPTION
it is a corner case met when running Zero3 on flan-t5 HF model. Where HF auto bucket size becomes exactly the same size if hidden_size^2 This is the exact size of some of the params. due to the bug the params are not being reduced during backward.