### PR TITLE
DS-Chat BLOOM: Fix Attention mask

### DIFF
--- a/deepspeed/ops/transformer/inference/ds_attention.py
+++ b/deepspeed/ops/transformer/inference/ds_attention.py
@@ -247,6 +247,11 @@ class BloomSelfAttention(DeepSpeedSelfAttention):
 
         offset = dist.get_rank() * self.num_attention_heads_per_partition if dist.is_initialized() else 0
         target_dtype = torch.float16 if self.config.dtype == torch.int8 else self.config.dtype
+
+        # When using the hybrid engine with BLOOM, input_mask needs to be converted from torch.bool -> torch.int64
+        if input_mask.dtype == torch.bool:
+            input_mask = input_mask.long()
+
         attention_probs = self.softmax_func(attn_scores=attention_scores,
                                             attn_mask=((1 - input_mask).to(target_dtype) * minus_inf),
                                             alibi=alibi,


### PR DESCRIPTION
This PR fixes the input mask type in DS attention when the BLOOM model is used with the Hybrid Engine in DeepSpeed-Chat.

Thanks to @shenzhuo for the debug efforts in #3518.