### PR TITLE
Pass base_dir to model files can be loaded for auto-tp/meta-tensor.

### DIFF
--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -301,11 +301,12 @@ def replace_transformer_layer(orig_layer_impl, model, checkpoint_dict, config, m
         checkpoint = checkpoint_dict["checkpoints"]
         pbar = tqdm.tqdm(total=len(checkpoint), desc=f"Loading {len(checkpoint)} checkpoint shards")
         for i in range(len(checkpoint)):
+            checkpoint_file = os.path.join(config.base_dir, checkpoint[i])
             replaced_module = replace_module(model=model,
                                              orig_class=orig_layer_impl,
                                              replace_fn=replace_fn,
                                              _replace_policy=config.injection_policy_tuple,
-                                             checkpoint=checkpoint[i])
+                                             checkpoint=checkpoint_file)
             pbar.update(1)
             gc.collect()
     else:


### PR DESCRIPTION
This PR will enable auto-tp and meta-tensor feature to work with all models including Llama2. 

Usage example with https://github.com/microsoft/DeepSpeedExamples/tree/master/inference/huggingface/text-generation 

Run Command:
```deepspeed --num_gpus=2 inference-test.py --model meta-llama/Llama-2-7b-hf --use_meta_tensor --checkpoint_path=/home/user/.cache/huggingface/hub/models--meta-llama--Llama-2-7b-hf/snapshots/6fdf2e60f86ff2481f2241aaee459f85b5b0bbb9/```