### PR TITLE
Check inference input_id tokens length

### DIFF
--- a/deepspeed/inference/engine.py
+++ b/deepspeed/inference/engine.py
@@ -598,4 +598,12 @@ class InferenceEngine(Module):
             raise NotImplementedError("DeepSpeed does not support `num_beams` > 1, if this is important to you please "
                                       "add your request to: https://github.com/microsoft/DeepSpeed/issues/2506")
 
+        if ("input_ids" in kwargs) and (kwargs["input_ids"].dim() == 2):
+            for input_tensor in kwargs["input_ids"]:
+                tensor_length = input_tensor.shape[-1]
+                if tensor_length > self._config.max_out_tokens:
+                    raise RuntimeError(
+                        f"Input with size {tensor_length} exceeds maximum length of {self._config.max_out_tokens}. Please increase `max_tokens` in the DeepSpeed Inference Config."
+                    )
+
         return self.module.generate(*inputs, **kwargs)


### PR DESCRIPTION
When the inputs to the inference engine have a length greater than `max_tokens` we will run into segfaults, garbage output, and generally bad behavior. Adding a check to avoid this.