### PR TITLE
DS-Inference Quantization refresh: Fix several issues and add more features

### DIFF
--- a/csrc/transformer/inference/csrc/dequantize.cu
+++ b/csrc/transformer/inference/csrc/dequantize.cu
@@ -241,15 +241,15 @@ void launch_dequantize_4bits(T* output,
         output, input, qscale, hidden_dim, hidden_dim, thd_cnt);
 }
 
-#define INSTANTIATE_DEQUANTIZE_NO_MERGE(T) \
+#define INSTANTIATE_DEQUANTIZE_4BIT(T) \
     template void launch_dequantize_4bits<T>(    \
         T*, const int8_t*, const float*, unsigned, unsigned, unsigned, cudaStream_t);
 
-INSTANTIATE_DEQUANTIZE_NO_MERGE(float);
+INSTANTIATE_DEQUANTIZE_4BIT(float);
 #ifdef BF16_AVAILABLE
-INSTANTIATE_DEQUANTIZE_NO_MERGE(__nv_bfloat16);
+INSTANTIATE_DEQUANTIZE_4BIT(__nv_bfloat16);
 #endif
-INSTANTIATE_DEQUANTIZE_NO_MERGE(__half);
+INSTANTIATE_DEQUANTIZE_4BIT(__half);
 
 
 
@@ -341,15 +341,15 @@ void launch_dequantize_2bits(T* output,
         output, input, qscale, hidden_dim, hidden_dim, thd_cnt);
 }
 
-#define INSTANTIATE_DEQUANTIZE_NO_MERGE(T) \
+#define INSTANTIATE_DEQUANTIZE_2BIT(T) \
     template void launch_dequantize_2bits<T>(    \
         T*, const int8_t*, const float*, unsigned, unsigned, unsigned, cudaStream_t);
 
-INSTANTIATE_DEQUANTIZE_NO_MERGE(float);
+INSTANTIATE_DEQUANTIZE_2BIT(float);
 #ifdef BF16_AVAILABLE
-INSTANTIATE_DEQUANTIZE_NO_MERGE(__nv_bfloat16);
+INSTANTIATE_DEQUANTIZE_2BIT(__nv_bfloat16);
 #endif
-INSTANTIATE_DEQUANTIZE_NO_MERGE(__half);
+INSTANTIATE_DEQUANTIZE_2BIT(__half);
 
 
 __global__ void dequantize_kernel_10bits(float* output,
@@ -420,12 +420,12 @@ void launch_dequantize_10bits(T* output,
         output, input, qscale, hidden_dim, hidden_dim, thd_cnt);
 }
 
-#define INSTANTIATE_DEQUANTIZE_NO_MERGE(T) \
+#define INSTANTIATE_DEQUANTIZE_10BIT(T) \
     template void launch_dequantize_10bits<T>(    \
         T*, const int16_t*, const float*, unsigned, unsigned, unsigned, cudaStream_t);
 
-INSTANTIATE_DEQUANTIZE_NO_MERGE(float);
+INSTANTIATE_DEQUANTIZE_10BIT(float);
 #ifdef BF16_AVAILABLE
-INSTANTIATE_DEQUANTIZE_NO_MERGE(__nv_bfloat16);
+INSTANTIATE_DEQUANTIZE_10BIT(__nv_bfloat16);
 #endif
-INSTANTIATE_DEQUANTIZE_NO_MERGE(__half);
+INSTANTIATE_DEQUANTIZE_10BIT(__half);

--- a/csrc/transformer/inference/csrc/dequantize.cu
+++ b/csrc/transformer/inference/csrc/dequantize.cu
@@ -81,7 +81,6 @@ __global__ void dequantize_kernel(float* output,
                                   int cnt)
 {
 }
-
 template <typename T>
 __global__ void dequantize_kernel(T* output,
                                   const int8_t* input,
@@ -130,21 +129,300 @@ void launch_dequantize(T* output,
 {
     unsigned threads = 1024;
     hidden_dim /= 4;
-    unsigned hid_cnt = threads / hidden_dim;
     unsigned thd_cnt = (hidden_dim - 1) / threads + 1;
-    hid_cnt = hid_cnt > 0 ? hid_cnt : 1;
 
-    unsigned blocks = (output_size + hid_cnt * groups - 1) / (hid_cnt * groups);
+    assert(output_size % groups == 0);
+    unsigned blocks = output_size / groups;
+
     dim3 block_dims(threads);
     dim3 grid_dims(groups, blocks);
 
     dequantize_kernel<<<grid_dims, block_dims, 0, stream>>>(
-        output, input, qscale, hidden_dim, hid_cnt * hidden_dim, thd_cnt);
+        output, input, qscale, hidden_dim, hidden_dim, thd_cnt);
 }
 
 #define INSTANTIATE_DEQUANTIZE_NO_MERGE(T) \
     template void launch_dequantize<T>(    \
         T*, const int8_t*, const float*, unsigned, unsigned, unsigned, cudaStream_t);
+
+INSTANTIATE_DEQUANTIZE_NO_MERGE(float);
+#ifdef BF16_AVAILABLE
+INSTANTIATE_DEQUANTIZE_NO_MERGE(__nv_bfloat16);
+#endif
+INSTANTIATE_DEQUANTIZE_NO_MERGE(__half);
+
+struct q4_data{
+    int8_t a: 4, b:4; // two 4-bit data
+};
+
+__global__ void dequantize_kernel_4bits(float* output,
+                                  const int8_t* input,
+                                  const float* qscale,
+                                  int hidden_dim,
+                                  unsigned merge_hidden,
+                                  int cnt)
+{
+}
+template <typename T>
+__global__ void dequantize_kernel_4bits(T* output,
+                                  const int8_t* input,
+                                  const float* qscale,
+                                  unsigned hidden_dim,
+                                  unsigned merge_hidden,
+                                  int cnt)
+{
+    unsigned bid = blockIdx.x * gridDim.y + blockIdx.y;
+    unsigned tid = threadIdx.x;
+
+    float local_scale = qscale[blockIdx.x];
+
+    const float* input_cast = reinterpret_cast<const float*>(input);
+    float4* output_cast = reinterpret_cast<float4*>(output);
+
+    input_cast += bid * merge_hidden;
+    output_cast += bid * merge_hidden;
+
+    for (int c = 0; c < cnt; c++) 
+    {
+        if (tid < merge_hidden) {
+            float q = input_cast[tid];
+            int8_t* q_int4 = (int8_t*)&q;
+
+            float4 q_f;
+            T* q_h = (T*)&q_f;
+            q4_data q4[4];
+
+            q4[0].a = (q_int4[0] & 0xf);
+            q4[0].b = ((q_int4[0] & 0xf0) >> 4);
+            q_h[0] = conversion::to<T>(local_scale * (float)q4[0].a);
+            q_h[1] = conversion::to<T>(local_scale * (float)q4[0].b);
+
+            q4[1].a = (q_int4[1] & 0xf);
+            q4[1].b = ((q_int4[1] & 0xf0) >> 4);
+            q_h[2] = conversion::to<T>(local_scale * (float)q4[1].a);
+            q_h[3] = conversion::to<T>(local_scale * (float)q4[1].b);
+
+            q4[2].a = (q_int4[2] & 0xf);
+            q4[2].b = ((q_int4[2] & 0xf0) >> 4);
+            q_h[4] = conversion::to<T>(local_scale * (float)q4[2].a);
+            q_h[5] = conversion::to<T>(local_scale * (float)q4[2].b);
+
+            q4[3].a = (q_int4[3] & 0xf);
+            q4[3].b = ((q_int4[3] & 0xf0) >> 4);
+            q_h[6] = conversion::to<T>(local_scale * (float)q4[3].a);
+            q_h[7] = conversion::to<T>(local_scale * (float)q4[3].b);
+            
+            output_cast[tid] = q_f;
+            tid += blockDim.x;
+        }
+    }
+}
+
+template <typename T>
+void launch_dequantize_4bits(T* output,
+                       const int8_t* input,
+                       const float* qscale,
+                       unsigned output_size,
+                       unsigned hidden_dim,
+                       unsigned groups,
+                       cudaStream_t stream)
+{
+    unsigned threads = 1024;
+    hidden_dim /= 8;
+    unsigned thd_cnt = (hidden_dim - 1) / threads + 1;
+
+    assert(output_size % groups == 0);
+    unsigned blocks = output_size / groups;
+
+    dim3 block_dims(thd_cnt == 1 ? hidden_dim : threads);
+    dim3 grid_dims(groups, blocks);
+
+    dequantize_kernel_4bits<<<grid_dims, block_dims, 0, stream>>>(
+        output, input, qscale, hidden_dim, hidden_dim, thd_cnt);
+}
+
+#define INSTANTIATE_DEQUANTIZE_NO_MERGE(T) \
+    template void launch_dequantize_4bits<T>(    \
+        T*, const int8_t*, const float*, unsigned, unsigned, unsigned, cudaStream_t);
+
+INSTANTIATE_DEQUANTIZE_NO_MERGE(float);
+#ifdef BF16_AVAILABLE
+INSTANTIATE_DEQUANTIZE_NO_MERGE(__nv_bfloat16);
+#endif
+INSTANTIATE_DEQUANTIZE_NO_MERGE(__half);
+
+
+
+struct q2_data{
+    int8_t a: 2, b: 2, c: 2, d: 2; // four 2-bit data
+};
+
+__global__ void dequantize_kernel_2bits(float* output,
+                                  const int8_t* input,
+                                  const float* qscale,
+                                  int hidden_dim,
+                                  unsigned merge_hidden,
+                                  int cnt)
+{
+}
+template <typename T>
+__global__ void dequantize_kernel_2bits(T* output,
+                                  const int8_t* input,
+                                  const float* qscale,
+                                  unsigned hidden_dim,
+                                  unsigned merge_hidden,
+                                  int cnt)
+{
+    unsigned bid = blockIdx.x * gridDim.y + blockIdx.y;
+    unsigned tid = threadIdx.x;
+
+    float local_scale = qscale[blockIdx.x];
+
+    const int16_t* input_cast = reinterpret_cast<const int16_t*>(input);
+
+    float2* output_cast = reinterpret_cast<float2*>(output);
+
+    input += bid * merge_hidden;
+    output_cast += bid * merge_hidden;
+
+    for (int c = 0; c < cnt; c++) {
+        if (tid < merge_hidden) {
+            int16_t q = input[tid];
+            int8_t* q_int2 = (int8_t*)&q;
+
+            float2 q_f;
+            T* q_h = (T*)&q_f;
+            q2_data q2[2];
+
+            q2[0].a = (q_int2[0] & 0x3);
+            q2[0].b = ((q_int2[0] & 0xC) >> 2);
+            q2[0].c = ((q_int2[0] & 0x30) >> 4);
+            q2[0].d = ((q_int2[0] & 0xC0) >> 6);
+            q_h[0] = conversion::to<T>(local_scale * (float)q2[0].a);
+            q_h[1] = conversion::to<T>(local_scale * (float)q2[0].b);
+            q_h[2] = conversion::to<T>(local_scale * (float)q2[0].c);
+            q_h[3] = conversion::to<T>(local_scale * (float)q2[0].d);
+
+            q2[1].a = (q_int2[1] & 0x3);
+            q2[1].b = ((q_int2[1] & 0xC) >> 2);
+            q2[1].c = ((q_int2[1] & 0x30) >> 4);
+            q2[1].d = ((q_int2[1] & 0xC0) >> 6);
+            q_h[4] = conversion::to<T>(local_scale * (float)q2[1].a);
+            q_h[5] = conversion::to<T>(local_scale * (float)q2[1].b);
+            q_h[6] = conversion::to<T>(local_scale * (float)q2[1].c);
+            q_h[7] = conversion::to<T>(local_scale * (float)q2[1].d);
+
+            output_cast[tid] = q_f;
+            tid += blockDim.x;
+        }
+    }
+}
+
+template <typename T>
+void launch_dequantize_2bits(T* output,
+                       const int8_t* input,
+                       const float* qscale,
+                       unsigned output_size,
+                       unsigned hidden_dim,
+                       unsigned groups,
+                       cudaStream_t stream)
+{
+    unsigned threads = 1024;
+    hidden_dim /= 8;
+    unsigned thd_cnt = (hidden_dim - 1) / threads + 1;
+
+    assert(output_size % groups == 0);
+    unsigned blocks = output_size / groups;
+
+    dim3 block_dims(threads);
+    dim3 grid_dims(groups, blocks);
+
+    dequantize_kernel_2bits<<<grid_dims, block_dims, 0, stream>>>(
+        output, input, qscale, hidden_dim, hidden_dim, thd_cnt);
+}
+
+#define INSTANTIATE_DEQUANTIZE_NO_MERGE(T) \
+    template void launch_dequantize_2bits<T>(    \
+        T*, const int8_t*, const float*, unsigned, unsigned, unsigned, cudaStream_t);
+
+INSTANTIATE_DEQUANTIZE_NO_MERGE(float);
+#ifdef BF16_AVAILABLE
+INSTANTIATE_DEQUANTIZE_NO_MERGE(__nv_bfloat16);
+#endif
+INSTANTIATE_DEQUANTIZE_NO_MERGE(__half);
+
+
+__global__ void dequantize_kernel_10bits(float* output,
+                                  const int16_t* input,
+                                  const float* qscale,
+                                  int hidden_dim,
+                                  unsigned merge_hidden,
+                                  int cnt)
+{
+}
+template <typename T>
+__global__ void dequantize_kernel_10bits(T* output,
+                                  const int16_t* input,
+                                  const float* qscale,
+                                  unsigned hidden_dim,
+                                  unsigned merge_hidden,
+                                  int cnt)
+{
+    unsigned bid = blockIdx.x * gridDim.y + blockIdx.y;
+    unsigned tid = threadIdx.x;
+
+    float local_scale = qscale[blockIdx.x];
+
+    const float2* input_cast = reinterpret_cast<const float2*>(input);
+    float2* output_cast = reinterpret_cast<float2*>(output);
+
+    input_cast += bid * merge_hidden;
+    output_cast += bid * merge_hidden;
+
+    for (int c = 0; c < cnt; c++) {
+        if (tid < merge_hidden) {
+            float2 q = input_cast[tid];
+            int16_t* q_int10 = (int16_t*)&q;
+
+            float2 q_f;
+            T* q_h = (T*)&q_f;
+
+            q_h[0] = conversion::to<T>(local_scale * (float)q_int10[0]);
+            q_h[1] = conversion::to<T>(local_scale * (float)q_int10[1]);
+            q_h[2] = conversion::to<T>(local_scale * (float)q_int10[2]);
+            q_h[3] = conversion::to<T>(local_scale * (float)q_int10[3]);
+            output_cast[tid] = q_f;
+            tid += blockDim.x;
+        }
+    }
+}
+
+template <typename T>
+void launch_dequantize_10bits(T* output,
+                       const int16_t* input,
+                       const float* qscale,
+                       unsigned output_size,
+                       unsigned hidden_dim,
+                       unsigned groups,
+                       cudaStream_t stream)
+{
+    unsigned threads = 1024;
+    hidden_dim /= 4;
+    unsigned thd_cnt = (hidden_dim - 1) / threads + 1;
+
+    assert(output_size % groups == 0);
+    unsigned blocks = output_size / groups;
+
+    dim3 block_dims(threads);
+    dim3 grid_dims(groups, blocks);
+
+    dequantize_kernel_10bits<<<grid_dims, block_dims, 0, stream>>>(
+        output, input, qscale, hidden_dim, hidden_dim, thd_cnt);
+}
+
+#define INSTANTIATE_DEQUANTIZE_NO_MERGE(T) \
+    template void launch_dequantize_10bits<T>(    \
+        T*, const int16_t*, const float*, unsigned, unsigned, unsigned, cudaStream_t);
 
 INSTANTIATE_DEQUANTIZE_NO_MERGE(float);
 #ifdef BF16_AVAILABLE

--- a/csrc/transformer/inference/includes/inference_cuda_layers.h
+++ b/csrc/transformer/inference/includes/inference_cuda_layers.h
@@ -141,6 +141,32 @@ void launch_dequantize(T* output,
                        cudaStream_t stream);
 
 template <typename T>
+void launch_dequantize_2bits(T* output,
+                       const int8_t* input,
+                       const float* qscale,
+                       unsigned output_size,
+                       unsigned hidden_dim,
+                       unsigned groups,
+                       cudaStream_t stream);
+
+template <typename T>
+void launch_dequantize_4bits(T* output,
+                       const int8_t* input,
+                       const float* qscale,
+                       unsigned output_size,
+                       unsigned hidden_dim,
+                       unsigned groups,
+                       cudaStream_t stream);
+
+template <typename T>
+void launch_dequantize_10bits(T* output,
+                       const int16_t* input,
+                       const float* qscale,
+                       unsigned output_size,
+                       unsigned hidden_dim,
+                       unsigned groups,
+                       cudaStream_t stream);
+template <typename T>
 void launch_dequantize(T* output,
                        const int8_t* input,
                        const float* qscale,

--- a/deepspeed/inference/config.py
+++ b/deepspeed/inference/config.py
@@ -92,31 +92,34 @@ class QuantTypeEnum(str, Enum):
 
 
 class BaseQuantConfig(DeepSpeedConfigModel):
-    enabled = True
-    num_bits = 8
+    enabled: bool = False
+    num_bits: int = 8
     q_type: QuantTypeEnum = QuantTypeEnum.sym
     q_groups: int = 1
+    layers: list = []
 
 
 class WeightQuantConfig(BaseQuantConfig):
-    enabled = True
+    enabled = False
     quantized_initialization: Dict = {}
     post_init_quant: Dict = {}
 
 
 class ActivationQuantConfig(BaseQuantConfig):
-    enabled = True
+    enabled = False
 
 
 class QKVQuantConfig(DeepSpeedConfigModel):
-    enabled = True
+    enabled = False
 
 
 class QuantizationConfig(DeepSpeedConfigModel):
-    enabled: bool = True
+    enabled: bool = False
     activation: ActivationQuantConfig = ActivationQuantConfig()
-    weight: WeightQuantConfig = WeightQuantConfig()
-    qkv: QKVQuantConfig = QKVQuantConfig()
+    qkv: WeightQuantConfig = WeightQuantConfig()
+    attn_out: WeightQuantConfig = WeightQuantConfig()
+    mlp1: WeightQuantConfig = WeightQuantConfig()
+    mlp2: WeightQuantConfig = WeightQuantConfig()
 
 
 # todo: brainstorm on how to do ckpt loading for DS inference

--- a/deepspeed/model_implementations/transformers/ds_llama2.py
+++ b/deepspeed/model_implementations/transformers/ds_llama2.py
@@ -80,4 +80,6 @@ class DeepSpeedLlama2Inference(DeepSpeedTransformerInference):
             output = self.mlp(attention_output, input, inp_norm, self.attention.attn_ob)
 
             output = output.to(input_type)
+        #print(f'{self.config.layer_id}: {output.norm()}, {output.shape}')
+        #exit()
         return output

--- a/deepspeed/module_inject/auto_tp.py
+++ b/deepspeed/module_inject/auto_tp.py
@@ -53,7 +53,8 @@ class ReplaceWithTensorSlicing:
         if (len(src_shape) == 2 and len(dst_shape) == 2):
             if src_shape[outer_dim] == dst_shape[self.out_dim]:
                 try:
-                    dst = dst.reshape(-1).data.copy_(src.data.reshape(-1)).reshape(src.shape)
+                    dst = src
+                    #dst = dst.reshape(-1).data.copy_(src.data.reshape(-1)).reshape(src.shape)
                 except:
                     print(dst.shape, src.shape)
                     exit()
@@ -94,8 +95,9 @@ class ReplaceWithTensorSlicing:
         dst_shape = dst.shape
         if (len(src_shape) == 2 and len(dst_shape) == 2):
 
-            if src_shape[inner_dim] == dst_shape[self.in_dim] and src_shape[outer_dim] == dst_shape[self.out_dim]:
-                dst = dst.reshape(-1).data.copy_(src.data.reshape(-1)).reshape(src.shape)
+            if True: #src_shape[inner_dim] == dst_shape[self.in_dim] and src_shape[outer_dim] == dst_shape[self.out_dim]:
+                dst = src
+                #dst = dst.reshape(-1).data.copy_(src.data.reshape(-1)).reshape(src.shape)
             else:
                 if src_shape[inner_dim] != dst_shape[self.in_dim]:
                     self.merge_assert(src_shape[inner_dim], dst_shape[self.in_dim])

--- a/deepspeed/module_inject/containers/features/hybrid_engine.py
+++ b/deepspeed/module_inject/containers/features/hybrid_engine.py
@@ -84,18 +84,7 @@ class HybridEngineContainer(ABC):
         the called methods to handle partitioned weights (i.e. if qkv is split, override
         the `attention_qkv_mp` method). If the model component is not split, it should
         be safe to use the default implementation.
-        """
-        
-        # Apply weight quantization
-        # TODO(cmikeh2): Re-enable this once verified
-        self.apply_weight_quantization()
-        
-        #self.qkvw = self.transpose_impl(self.qkvw.data)
-        #self._h4h_w = self.transpose_impl(self._h4h_w.data)
-        self._4hh_w = self.transpose_impl(self._4hh_w.data)
-        #print(self._4hh_w.shape)
-        #self.dense_w = self.transpose_impl(self.dense_w.data)
-
+        """        
         # Setup the new Attention module
         self.attention_qkv_mp(mp_replace, reversed_dim=reversed_dim)
         self.attention_o_mp(mp_replace, reversed_dim=reversed_dim)

--- a/deepspeed/module_inject/containers/features/hybrid_engine.py
+++ b/deepspeed/module_inject/containers/features/hybrid_engine.py
@@ -85,17 +85,24 @@ class HybridEngineContainer(ABC):
         the `attention_qkv_mp` method). If the model component is not split, it should
         be safe to use the default implementation.
         """
+        
+        # Apply weight quantization
+        # TODO(cmikeh2): Re-enable this once verified
+        self.apply_weight_quantization()
+        
+        #self.qkvw = self.transpose_impl(self.qkvw.data)
+        #self._h4h_w = self.transpose_impl(self._h4h_w.data)
+        self._4hh_w = self.transpose_impl(self._4hh_w.data)
+        #print(self._4hh_w.shape)
+        #self.dense_w = self.transpose_impl(self.dense_w.data)
+
         # Setup the new Attention module
         self.attention_qkv_mp(mp_replace, reversed_dim=reversed_dim)
         self.attention_o_mp(mp_replace, reversed_dim=reversed_dim)
 
         # Setup the new MLP module
         self.mlp_inter_mp(mp_replace, reversed_dim=reversed_dim)
-        self.mlp_output_mp(mp_replace, reversed_dim=reversed_dim)
-
-        # Apply weight quantization
-        # TODO(cmikeh2): Re-enable this once verified
-        #self.apply_weight_quantization()
+        self.mlp_output_mp(mp_replace, reversed_dim=False)
 
     def _release_params(self, param_pairs: List[Tuple[torch.Tensor, torch.Tensor]]):
         """

--- a/deepspeed/module_inject/containers/features/split_qkv.py
+++ b/deepspeed/module_inject/containers/features/split_qkv.py
@@ -46,7 +46,7 @@ class HybridSplitQKVContainer(HybridEngineContainer):
                     dst[:self.qw.shape[0] // mp_replace.mp_size], src, int8=reversed_dim,
                     allocate_tensor=reversed_dim) if src is not None else None
         else:
-            super().attention_qkv_mp(mp_replace)
+            super().attention_qkv_mp(mp_replace, reversed_dim=reversed_dim)
 
     def release_qkv(self):
         super().release_qkv()

--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -47,13 +47,59 @@ class GroupQuantizer:
         self.q_int8 = q_int8
 
         self.num_groups = num_groups
+        
+    def q8(self, inputs, shape):
+        return inputs.reshape(shape).to(torch.int8).contiguous()
 
-    def quantize(self, inputs, qkv=True, count=1, parallel_dim=0):
+    def q4(self, inputs, shape):
+        inputs = inputs.reshape(-1, 2).to(torch.int8)
+        inputs_q = (inputs[:, 1] << 4 | (inputs[:, 0] & 0x0f))
+
+        return inputs_q.reshape(shape[0], shape[-1] // 2).contiguous()
+
+    def q2(self, inputs, shape):
+        inputs = inputs.reshape(-1, 4).to(torch.int8)
+        inputs_q = (inputs[:, 3] << 6 | ((inputs[:, 2] << 4) & 0x3f) | 
+                    ((inputs[:, 1] << 2) & 0x0f) | (inputs[:, 0] & 0x03))
+        
+        return inputs_q.reshape(shape[0], shape[-1] // 4).contiguous()
+
+    def q10(self, inputs, shape):
+        return inputs.reshape(shape).to(torch.int16).contiguous()
+        inputs = inputs.reshape(-1, 8).int()
+        inputs_q1 = (inputs[:, 1] << 16 | (inputs[:, 0] & 0xffff)).unsqueeze(-1)
+        inputs_q2 = (inputs[:, 3] << 16 | (inputs[:, 2] & 0xffff)).unsqueeze(-1)
+        inputs_q3 = (inputs[:, 5] << 16 | (inputs[:, 4] & 0xffff)).unsqueeze(-1)
+        inputs_q4 = (inputs[:, 7] << 16 | (inputs[:, 6] & 0xffff)).unsqueeze(-1)
+
+        return torch.cat((inputs_q1,
+                          inputs_q2,
+                          inputs_q3,
+                          inputs_q4), dim=-1).reshape(shape[0], shape[-1] // 2).to(torch.int32).contiguous()
+
+    def pack_with_n_bit_q(self, input_flat, shape, num_bits):
+        if num_bits == 8:
+            inputs_q = self.q8(input_flat, shape)
+        elif num_bits == 4:
+            #inputs_q = self.q8(input_flat, shape)
+            inputs_q = self.q4(input_flat, shape)
+        elif num_bits == 2:
+            #inputs_q = self.q8(input_flat, shape)
+            inputs_q = self.q2(input_flat, shape)
+        elif num_bits == 10:
+            inputs_q = self.q8(input_flat, shape)
+            #inputs_q = self.q4(input_flat, shape)
+        else:
+            print(f'please feel free to add the (de)quantization implementation for {num_bits}-quantization')
+            raise NotImplementedError
+        return inputs_q
+
+    def quantize(self, inputs, qkv=True, count=1, parallel_dim=0, num_bits=8):
         if not self.q_int8 or not qkv:
             inputs = torch.nn.Parameter(inputs, requires_grad=False)
             inputs.scale = torch.empty(1)
             return inputs
-        q_range = 2**self.num_bits
+        q_range = 2**num_bits #self.num_bits
         num_groups = self.num_groups if self.num_groups > 0 else inputs.shape[0] // self.group_size
         inputs = inputs.to(get_accelerator().current_device_name())
         input_flat = inputs.reshape(num_groups, -1).contiguous()
@@ -61,7 +107,7 @@ class GroupQuantizer:
         input_max = torch.max(input_flat, dim=1, keepdim=True)[0].float()
         scale = torch.max(input_min.abs(), input_max.abs()) * 2.0 / (q_range)
         input_flat = (input_flat / scale).round().clamp(-q_range // 2, q_range // 2 - 1)
-        inputs_q = input_flat.reshape(inputs.shape).to(torch.int8).contiguous()
+        inputs_q = self.pack_with_n_bit_q(input_flat, inputs.shape, num_bits)
         out = torch.nn.Parameter(inputs_q, requires_grad=False)
         inputs_split = inputs.split(inputs.shape[parallel_dim] // 2, dim=parallel_dim)
         input_flat = [inputs_split[i].reshape(num_groups, -1).contiguous() for i in range(2)]
@@ -69,7 +115,6 @@ class GroupQuantizer:
         input_max = [torch.max(input_flat[i], dim=1, keepdim=True)[0].float() for i in range(2)]
         scale1 = [(torch.max(input_min[i].abs(), input_max[i].abs()) * 2.0 / (q_range)).squeeze().unsqueeze(0)
                   for i in range(2)]
-
         out.scale = torch.cat([scale.squeeze().unsqueeze(0), scale1[0], scale1[1]], dim=0).reshape(num_groups,
                                                                                                    -1).contiguous()
         return out
@@ -246,10 +291,11 @@ def replace_transformer_layer(orig_layer_impl, model, checkpoint_dict, config, m
         _container.create_module()
 
         # 8. transpose the weights and bias if needed
-        _container.transpose()
+        if not quantize:
+            _container.transpose()
 
         # 9. deal with tensor parallelism.
-        _container.apply_tensor_parallelism(mp_replace)
+        _container.apply_tensor_parallelism(mp_replace, reversed_dim=quantize)
 
         # 10. copy the tensors from the model-specific container to the new module
         _container.copy_data_to_new_module()

--- a/deepspeed/ops/transformer/inference/config.py
+++ b/deepspeed/ops/transformer/inference/config.py
@@ -79,7 +79,8 @@ class DeepSpeedInferenceConfig(TransformerConfig):
                  transposed_mode=False,
                  use_triton=False,
                  triton_autotune=False,
-                 num_kv=-1):
+                 num_kv=-1,
+                 weight_quantization=None):
         super(DeepSpeedInferenceConfig,
               self).__init__(hidden_size, (intermediate_size if intermediate_size > 0 else 4 * hidden_size), heads,
                              num_hidden_layers)
@@ -114,6 +115,7 @@ class DeepSpeedInferenceConfig(TransformerConfig):
         self.use_triton = use_triton
         self.triton_autotune = triton_autotune
         self.num_kv = num_kv
+        self.weight_quantization= weight_quantization
 
     @classmethod
     def from_dict(cls, json_object):

--- a/deepspeed/ops/transformer/inference/op_binding/mlp_gemm.py
+++ b/deepspeed/ops/transformer/inference/op_binding/mlp_gemm.py
@@ -66,6 +66,7 @@ class MLPGemmOp(BaseOp):
                 bias: Optional[torch.Tensor] = None,
                 gamma: Optional[torch.Tensor] = None,
                 beta: Optional[torch.Tensor] = None):
+        q_int8 = self.config.dtype == torch.int8
         if self.config.norm_type == NormType.LayerNorm:
             output, residual_add = self.mlp_gemm_func(
                 input,
@@ -81,7 +82,10 @@ class MLPGemmOp(BaseOp):
                 self.config.mlp_after_attn,
                 weight_interm.scale if hasattr(weight_interm, 'scale') else torch.empty(1),  # type: ignore
                 weight_out.scale if hasattr(weight_out, 'scale') else torch.empty(1),  # type: ignore
-                self.config.dtype == torch.int8,
+                q_int8 and self.config.weight_quantization.mlp1.enabled,
+                self.config.weight_quantization.mlp1.num_bits,
+                q_int8 and self.config.weight_quantization.mlp2.enabled,
+                self.config.weight_quantization.mlp2.num_bits,
                 self.config.mlp_act_func_type,
                 self.config.transposed_mode)
         else:
@@ -94,7 +98,10 @@ class MLPGemmOp(BaseOp):
                 self.config.epsilon,
                 weight_interm.scale if hasattr(weight_interm, 'scale') else torch.empty(1),  # type: ignore
                 weight_out.scale if hasattr(weight_out, 'scale') else torch.empty(1),  # type: ignore
-                self.config.dtype == torch.int8,
+                q_int8 and self.config.weight_quantization.mlp1.enabled,
+                self.config.weight_quantization.mlp1.num_bits,
+                q_int8 and self.config.weight_quantization.mlp2.enabled,
+                self.config.weight_quantization.mlp2.num_bits,
                 self.config.mlp_act_func_type,
                 self.config.transposed_mode)
         return output, residual_add

--- a/deepspeed/ops/transformer/inference/op_binding/qkv_gemm.py
+++ b/deepspeed/ops/transformer/inference/op_binding/qkv_gemm.py
@@ -77,12 +77,10 @@ class QKVGemmOp(BaseOp):
         bias = bias if add_bias else torch.empty(1)  # type: ignore
         q_scale = weight.scale if hasattr(weight, 'scale') else torch.empty(1)  # type: ignore
         q_int8 = self.config.dtype == torch.int8
-
         if self.config.norm_type == NormType.LayerNorm:
             output, norm = self.qkv_gemm_func(input, weight, q_scale, bias, gamma, beta, self.config.epsilon, add_bias,
                                               q_int8, self.config.transposed_mode)
         else:
             output, norm = self.qkv_gemm_func(input, weight, q_scale, gamma, self.config.epsilon, q_int8,
                                               self.config.transposed_mode)
-
         return output, norm

--- a/deepspeed/ops/transformer/inference/op_binding/qkv_gemm.py
+++ b/deepspeed/ops/transformer/inference/op_binding/qkv_gemm.py
@@ -78,9 +78,13 @@ class QKVGemmOp(BaseOp):
         q_scale = weight.scale if hasattr(weight, 'scale') else torch.empty(1)  # type: ignore
         q_int8 = self.config.dtype == torch.int8
         if self.config.norm_type == NormType.LayerNorm:
-            output, norm = self.qkv_gemm_func(input, weight, q_scale, bias, gamma, beta, self.config.epsilon, add_bias,
-                                              q_int8, self.config.transposed_mode)
+            output, norm = self.qkv_gemm_func(input, weight, q_scale, bias, gamma, beta, self.config.epsilon, add_bias, 
+                            self.config.weight_quantization.qkv.enabled and q_int8, 
+                            self.config.weight_quantization.qkv.num_bits,
+                            self.config.transposed_mode)
         else:
-            output, norm = self.qkv_gemm_func(input, weight, q_scale, gamma, self.config.epsilon, q_int8,
-                                              self.config.transposed_mode)
+            output, norm = self.qkv_gemm_func(input, weight, q_scale, gamma, self.config.epsilon, 
+                            self.config.weight_quantization.qkv.enabled and q_int8, 
+                            self.config.weight_quantization.qkv.num_bits,
+                            self.config.transposed_mode)
         return output, norm

--- a/deepspeed/ops/transformer/inference/op_binding/softmax_context.py
+++ b/deepspeed/ops/transformer/inference/op_binding/softmax_context.py
@@ -23,7 +23,7 @@ class SoftmaxContextOp(BaseOp):
         except AttributeError:
             self.softmax_context_func = self.softmax_context_fallback
 
-    def softmax_context_fallback(self, query_key_value, attn_mask, rotary_dim, rotate_half, roteate_every_two, heads,
+    def softmax_context_fallback(self, query_key_value, attn_mask, rotary_dim, rotate_half, roteate_every_two, heads, num_kv,
                                  norm_factor, triangular_masking, local_attention, window_size, no_masking, layer_id,
                                  num_layers, alibi):
         raise NotImplementedError

--- a/deepspeed/ops/transformer/inference/op_binding/vector_matmul.py
+++ b/deepspeed/ops/transformer/inference/op_binding/vector_matmul.py
@@ -42,7 +42,13 @@ class VectorMatMulOp(BaseOp):
     def forward(self, input: torch.Tensor, weight: torch.Tensor, async_op: bool = False):
         q_scale = weight.scale if hasattr(weight, 'scale') else torch.empty(1)
         q_int8 = self.config.dtype == torch.int8
-        output = self.vector_matmul_func(input, weight, async_op, q_scale, q_int8, self.config.transposed_mode)
+        output = self.vector_matmul_func(input, 
+                weight, 
+                async_op, 
+                q_scale, 
+                q_int8 and self.config.weight_quantization.attn_out.enabled, 
+                self.config.weight_quantization.attn_out.num_bits,
+                self.config.transposed_mode)
         return output
 
     @staticmethod


### PR DESCRIPTION
This PR adds quantization support for 2, 4, and 8 bits which can be configured as a quantization config when injecting the inference kernels using `deepspeed.init_inference`. Here is an example of quantization config that I used for Llama-2-70B model in order to run this model on  1 GPU:
```

            weight_quantization = {
                "quant":{
                    "enabled": True,
                    "qkv": {
                        "enabled": True,
                        "num_bits": 4
                    },
                    "attn_out": {
                        "enabled": True,
                        "num_bits": 4
                    },
                    "mlp1": {
                        "enabled": True,
                        "num_bits": 4
                    },
                }
            }
            deepspeed.init_inference(model, 
                                    replace_with_kernel_inject=True, 
                                    dtype=torch.int8, 
                                    return_tuple=False, 
                                    mp_size=torch.distributed.get_world_size(),
                                    **weight_quantization,
                                    )
```
The output of the generation for a batch of 4 prompts looks coherent enough, however, it requires some quantitative evaluation using the lm-eval harness.
```
Loading extension module transformer_inference...                                                                                                                                                                             
Time to load transformer_inference op: 34.768511056900024 seconds                                                                                                                                                             
[2023-09-16 23:07:01,451] [INFO] [logging.py:96:log_dist] [Rank -1] DeepSpeed-Inference config: {'layer_id': 0, 'hidden_size': 8192, 'intermediate_size': 28672, 'heads': 64, 'num_hidden_layers': -1, 'dtype': torch.int8, 'p
re_layer_norm': True, 'norm_type': <NormType.RMSNorm: 3>, 'local_rank': -1, 'stochastic_mode': False, 'epsilon': 1e-05, 'mp_size': 1, 'scale_attention': True, 'triangular_masking': True, 'local_attention': False, 'window_s
ize': 1, 'rotary_dim': 128, 'rotate_half': False, 'rotate_every_two': True, 'return_tuple': False, 'mlp_after_attn': True, 'mlp_act_func_type': <ActivationFuncType.GATED_SILU: 4>, 'specialized_mode': False, 'training_mp_si
ze': 1, 'bigscience_bloom': False, 'max_out_tokens': 256, 'min_out_tokens': 1, 'scale_attn_by_inverse_layer_idx': False, 'enable_qkv_quantization': False, 'use_mup': False, 'return_single_tuple': False, 'set_empty_params':
 False, 'transposed_mode': False, 'use_triton': False, 'triton_autotune': False, 'num_kv': 8, 'weight_quantization': QuantizationConfig(enabled=True, activation=ActivationQuantConfig(enabled=False, num_bits=8, q_type='symm
etric', q_groups=1, layers=[]), qkv=WeightQuantConfig(enabled=True, num_bits=4, q_type='symmetric', q_groups=1, layers=[], quantized_initialization={}, post_init_quant={}), attn_out=WeightQuantConfig(enabled=True, num_bits
=4, q_type='symmetric', q_groups=1, layers=[], quantized_initialization={}, post_init_quant={}), mlp1=WeightQuantConfig(enabled=True, num_bits=4, q_type='symmetric', q_groups=1, layers=[], quantized_initialization={}, post
_init_quant={}), mlp2=WeightQuantConfig(enabled=False, num_bits=8, q_type='symmetric', q_groups=1, layers=[], quantized_initialization={}, post_init_quant={}))}                                                              
Using /home/aiscuser/.cache/torch_extensions/py38_cu117 as PyTorch extensions root...                                                                                                                                         
No modifications detected for re-loaded extension module transformer_inference, skipping build step...                                                                                                                        
Loading extension module transformer_inference...                                                                                                                                                                             
Time to load transformer_inference op: 6.755484342575073 seconds                                                                                                                                                              
----- Running DS-Inference with 7.294-bit quantization -----                                                                                                                                                                  
^@Loaded in 465.69 seconds                                                                                                                                                                                                    
------------------------------------------------------                                                                                                                                                                        
Free memory : 14.222534 (GigaBytes)                                                                                                                                                                                           
Total memory: 79.169678 (GigaBytes)                                                                                                                                                                                           
Requested memory: 5.375000 (GigaBytes)                                                                                                                                                                                        
Setting maximum total tokens (input + output) to 256                                                                                                                                                                          
WorkSpace: 0x7fa044000000                                                                                                                                                                                                     
------------------------------------------------------                                                                                                                                                                        
I believe the meaning of life is                                                                                                                                                                                              
> to strive to reach a balance between productivity and comfort. Productivity is what allows us to work and produce, without productivity there is no movement and no comfort. It's what is needed to pay the bills and provid
e for ourselves. Comfort is the luxury that productivity provides for us; comfort is how we rest our minds and bodies in order to continue to work hard and pay our bills. For a balance to exist between these two, they need
 to be the same, or at least as close to each other as possible. When comfort is too great productivity lacks, and when productivity is                     
==================================
                                               
Simply put, the theory of relativity states that 
> 1) space and time are two aspects of a single thing called space-time, 2) the speed of light is the same for all observers, and 3) there is no difference between observers in a uniform s
tate of motion.       
The theory of relativity is a theory of physics that was developed by Albert Einstein. It is based on the idea that space and time are relative concepts, and that the laws of physics are t
he same in all reference frames. The theory of relativity is divided into two parts: special relativity and general relativity.
Special relativity is concerned with the behavior of objects in
                                               
==================================
                                               
A brief message congratulating the team on the launch:
                                                                                              
        Hi everyone,                                                                          
         
        I just 
> wanted to take a moment to congratulate the team on the launch of the new app.  I know it was a lot of work, but I think we're all very happy with the results.  I also wanted to thank yo
u for all of your hard work and dedication.  Without your help, this project would not have been possible.
         
        Congratulations again, and here's to many more successful launches!
         
        Best,
        -Jeff                                                                                                              
==================================          

Translate English to French:                           
                                                       
        sea otter => loutre de mer                     
        peppermint => menthe poivrée                   
        plush girafe => girafe peluche                 
        cheese =>                                      
> fromage                                              
        black jeans => jeans noir                      
        bassinette => bassinette                       
        buggy => landau                                
        rice cake => biscuit au riz                    
        bug spray => produits anti-moustique           
        terry towel => serviette en terry              
        deluxe tent => tente de luxe                   
        web browser => navigateur web                  
        playset => jeu                                 
        play tent => tente de jeu                      
        light up toy => jouet qui s'allume             
        drying rack => grille de séchage               


==================================

You can give this a try using [this fork of llama](https://github.com/RezaYazdaniAminabadi/llama/tree/add-ds-inference). I also added some script here in order to help with running this model using different number of GPUs and with enabling the quantization.
