### PR TITLE
Fix min torch version

### DIFF
--- a/tests/unit/inference/quantization/test_int4_quantization.py
+++ b/tests/unit/inference/quantization/test_int4_quantization.py
@@ -20,8 +20,8 @@ from typing import Dict
 
 device = get_accelerator().device_name() if get_accelerator().is_available() else 'cpu'
 
-if not required_torch_version(min_version=1.10):
-    pytest.skip("torch.Tensor.bitwise_left_shift in INT4 quantizer needs torch 1.10 or above.",
+if not required_torch_version(min_version=1.11):
+    pytest.skip("torch.Tensor.bitwise_left_shift in INT4 quantizer needs torch 1.11 or above.",
                 allow_module_level=True)
 
 


### PR DESCRIPTION
`tensor.view()` usage requires [torch-1.11]([Enable all dtype combinations in `torch.Tensor.view(dtype)` (#66493) · pytorch/pytorch@0420545 (github.com)](https://github.com/pytorch/pytorch/commit/0420545639503e293783db7d9f8b6fa80446ca00))

Fixes #4341, #4330 