### PR TITLE
Allow multiple inference engines in single script

### DIFF
--- a/deepspeed/inference/engine.py
+++ b/deepspeed/inference/engine.py
@@ -28,6 +28,7 @@ from ..module_inject.auto_tp import AutoTP
 from ..module_inject.replace_policy import generic_policies
 from ..module_inject.auto_tp_model_utils import build_bloom_alibi_tensor, build_mpt_atten_bias_tensor, build_mpt_alibi_tensor
 from ..ops.transformer.inference.ds_attention import DeepSpeedSelfAttention
+from ..model_implementations.transformers.ds_transformer import DeepSpeedTransformerInference
 
 DS_INFERENCE_ENABLED = False
 from torch import nn
@@ -54,7 +55,7 @@ class InferenceEngine(Module):
         # Have to import here because inference_module is a global, but python
         # globals only work at the module level and will not be updated unless
         # we import it each time we init a new inference engine.
-        from ..model_implementations.transformers.ds_transformer import DeepSpeedTransformerInference, inference_module
+        from ..model_implementations.transformers.ds_transformer import inference_module
         if inference_module is not None:
             self.destroy()
 
@@ -186,7 +187,7 @@ class InferenceEngine(Module):
         # Have to import here because inference_module is a global, but python
         # globals only work at the module level and will not be updated unless
         # we import it each time we init a new inference engine.
-        from ..model_implementations.transformers.ds_transformer import DeepSpeedTransformerInference, inference_module
+        from ..model_implementations.transformers.ds_transformer import inference_module
         DeepSpeedTransformerInference.layer_id = 0
         DeepSpeedSelfAttention.num_layers = 0
         if inference_module is not None:

--- a/deepspeed/inference/engine.py
+++ b/deepspeed/inference/engine.py
@@ -182,7 +182,8 @@ class InferenceEngine(Module):
     def destroy(self):
         DeepSpeedTransformerInference.layer_id = 0
         DeepSpeedSelfAttention.num_layers = 0
-        inference_module.release_workspace()
+        if inference_module is not None:
+            inference_module.release_workspace()
 
     def profile_model_time(self, use_cuda_events=True):
         if not self.model_profile_enabled and not self._config.enable_cuda_graph:


### PR DESCRIPTION
The `InferenceEngine` relies on some global values and fails to clean up workspaces such that if we try to run multiple models via DeepSpeed-Inference in a single script (see example below), we get errors like this:
```bash
RuntimeError: The specified pointer resides on host memory and is not registered with any CUDA device.
```

This PR adds a `destroy()` method that will be automatically called on subsequent invocations of `deepspeed.init_inference()`.

example.py:
```python
import os
import torch
import deepspeed
from transformers import pipeline

local_rank = int(os.environ.get("LOCAL_RANK", 0))
world_size = int(os.environ.get("WORLD_SIZE", 1))

model1 = "bigscience/bloom-560m"
task1 = "text-generation"
pipe1 = pipeline(task1, model1, torch_dtype=torch.float16, device=local_rank)
pipe1.model = deepspeed.init_inference(
    pipe1.model,
    dtype=torch.float16,
    replace_with_kernel_inject=True,
    mp_size=world_size,
)
print(model1, pipe1("test one two"))

model2 = "gpt2"
task2 = "text-generation"
pipe2 = pipeline(task2, model2, torch_dtype=torch.float16, device=local_rank)
pipe2.model = deepspeed.init_inference(
    pipe2.model,
    dtype=torch.float16,
    replace_with_kernel_inject=True,
    mp_size=world_size,
)
print(model2, pipe2("test one two"))
```

Co-authored-by: Jeff Rasley <jeffra45@gmail.com>