### PR TITLE
[CCLBackend] Using parallel memcpy for inference_all_reduce

### DIFF
--- a/csrc/cpu/comm/ccl.cpp
+++ b/csrc/cpu/comm/ccl.cpp
@@ -70,7 +70,7 @@ void shared_close(SharedData* data)
 // SHM based allreduce helper functions
 // buffer that holds shm name
 #define NAME_BUF_SIZE 1000
-#define MAX_BUF_SIZE 1048576
+#define MAX_BUF_SIZE 1048576*16
 #define SHM_BUFFER_NAME "deepspeed_allreduce_buffer"
 SharedData allreduce_buffer;
 struct allreduce_workspace {


### PR DESCRIPTION
This PR introduce a parallel version of memcpy and use it in inference_all_reduce.   This allows memcpy fully utilize host memory bandwidth and improve performance.   For some typical message size, this PR improve their performance as follows: (Tested on 2 socket 4th Gen Xeon Scalable system)
32KB: 26us -->23us
128KB: 59us --> 29us
512KB: 210us --> 40us

Besides, we improved handling of large message size.  Now a fixed size shared memory can support any message size.  This would help first token of a long input sequence.

