### PR TITLE
Update nv-transformers workflow to use cu11.6

### DIFF
--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: [self-hosted, nvidia, cu111, v100]
+    runs-on: [self-hosted, nvidia, cu116, v100]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- Update nv-transformers to use cuda 11.6.  This also has the side effect of running on a runner using Ubuntu 20.04 which will be needed for new async_io features.