### PR TITLE
Fix wrong documentation of `ignore_unused_parameters`

### DIFF
--- a/deepspeed/runtime/zero/config.py
+++ b/deepspeed/runtime/zero/config.py
@@ -236,7 +236,7 @@ class DeepSpeedZeroConfig(DeepSpeedConfigModel):
     Unused parameters in modules may be unexpected in static networks, but
     could be normal in dynamic networks. This controls whether or not training
     should terminate with an error message when unused parameters are detected.
-    This is set to ``False`` by default, which means unused parameters are
+    This is set to ``True`` by default, which means unused parameters are
     ignored and training continues. Now is just used in stage 2.
     """
 


### PR DESCRIPTION
The documentation says:

> `ignore_unused_parameters: bool = True`
> ...
> This is set to `False` **(which should be `True`)** by default, which means unused parameters are ignored and training continues.

Hence the inconsistency.