### PR TITLE
Update cpu_inference checkout action

### DIFF
--- a/.github/workflows/cpu-inference.yml
+++ b/.github/workflows/cpu-inference.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - id: setup-venv
         uses: ./.github/workflows/setup-venv


### PR DESCRIPTION
For some reason this was the only action that wasn't updated to use `actions/checkout@v3`.  I see no reason why it couldn't, so this updates it to be in line.

Warning:
```
[unit-tests](https://github.com/microsoft/DeepSpeed/actions/runs/6356521056/job/17266306307)
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```