### PR TITLE
fix: check-license

### DIFF
--- a/scripts/check-license.py
+++ b/scripts/check-license.py
@@ -19,20 +19,24 @@ def err(s: str) -> None:
 
 
 COPYRIGHT = [
-    r"^\(\/\/\|#\) Copyright (c) Microsoft Corporation.$", r"^\(\/\/\|#\) SPDX-License-Identifier: Apache-2.0$",
-    r"^\(\/\/\|#\) DeepSpeed Team$"
+    (r"^# Copyright (c) Microsoft Corporation.$", r"^\/\/ Copyright (c) Microsoft Corporation.$"),
+    (r"^# SPDX-License-Identifier: Apache-2.0$", r"^\/\/ SPDX-License-Identifier: Apache-2.0$"),
+    (r"^# DeepSpeed Team$", r"^\/\/ DeepSpeed Team$"),
 ]
 
 success = True
 failures = []
 for f in sys.argv[1:]:
     for copyright_line in COPYRIGHT:
-        if not success:
-            break
-        res = subprocess.run(["git", "grep", "--quiet", "-e", copyright_line, f], capture_output=True)
+        cmd = ["git", "grep", "--quiet"]
+        for line in copyright_line:
+            cmd.extend(["-e", line])
+        cmd.append(f)
+        res = subprocess.run(cmd, capture_output=True)
         if res.returncode == 1:
             success = False
             failures.append(f)
+            break
         elif res.returncode == 2:
             err(f"Error invoking grep on {', '.join(sys.argv[1:])}:")
             err(res.stderr.decode("utf-8"))


### PR DESCRIPTION
git grep on apple is currently unable to parse the regex used in the license check.
I have changed the logic in the license check script such that it works on mac and linux.

On Mac, the git grep does not work, even though the grep works:
<img width="706" alt="image" src="https://github.com/microsoft/DeepSpeed/assets/56836461/26215f5d-3a88-442d-89d4-1e136a7af519">

While remoted to a machine running Ubuntu, the git grep works:
<img width="665" alt="image" src="https://github.com/microsoft/DeepSpeed/assets/56836461/891485e3-a81d-4d6d-adc1-c4cde3af0070">
