### PR TITLE
Fix torch import causing release build failure

### DIFF
--- a/op_builder/async_io.py
+++ b/op_builder/async_io.py
@@ -5,7 +5,6 @@
 
 import distutils.spawn
 import subprocess
-import torch
 
 from .builder import OpBuilder
 
@@ -36,6 +35,7 @@ class AsyncIOBuilder(OpBuilder):
         # -O0 for improved debugging, since performance is bound by I/O
         CPU_ARCH = self.cpu_arch()
         SIMD_WIDTH = self.simd_width()
+        import torch  # Keep this import here to avoid errors when building DeepSpeed wheel without torch installed
         TORCH_MAJOR, TORCH_MINOR = map(int, torch.__version__.split('.')[0:2])
         if TORCH_MAJOR >= 2 and TORCH_MINOR >= 1:
             CPP_STD = '-std=c++17'


### PR DESCRIPTION
The torch import added in #4452 causes an `ImportError` when trying to build a release for DeepSpeed in environments without torch:
```bash
Traceback (most recent call last):
  File "setup.py", line 37, in <module>
    from op_builder import get_default_compute_capabilities, OpBuilder
  File "/home/runner/work/DeepSpeed/DeepSpeed/op_builder/__init__.py", line 48, in <module>
    module = importlib.import_module(f".{module_name}", package=op_builder_dir)
  File "/usr/lib/python3.8/importlib/__init__.py", line [12](https://github.com/microsoft/DeepSpeed/actions/runs/6436848308/job/17481015251#step:6:13)7, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/home/runner/work/DeepSpeed/DeepSpeed/op_builder/async_io.py", line 8, in <module>
    import torch
ModuleNotFoundError: No module named 'torch'
```

@jeffra
@loadams 