### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: "master"
+    - id: setup-venv
+      uses: ./.github/workflows/setup-venv
     - name: Get release version from tag
       run: |
         echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
@@ -22,7 +24,7 @@ jobs:
         python release/check_release_version.py --release_version ${{ env.RELEASE_VERSION }}
     - name: Build DeepSpeed
       run: |
-        DS_BUILD_STRING=" " python setup.py sdist_wheel
+        DS_BUILD_STRING=" " python setup.py sdist
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
Was using `sdist_wheel` instead of `sdist` in the build command. Also adding the use of `setup-env` workflow so the environment is updated and consistent with the rest of our workflows.

@loadams 
@jeffra 