### PR TITLE
Fix transformers test skipping all tests.

### DIFF
--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pytorch
         run: |
           # use the same pytorch version as transformers CI
-          pip install -U --cache-dir $TORCH_CACHE torch==2.1.0+cu118 --index-url https://download.pytorch.org/whl/cu118
+          pip install torch==2.0.1+cu118 --index-url https://download.pytorch.org/whl/cu118
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/.github/workflows/nv-transformers-v100.yml
+++ b/.github/workflows/nv-transformers-v100.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pytorch
         run: |
           # use the same pytorch version as transformers CI
-          pip install -U --cache-dir $TORCH_CACHE torch==2.0.1+cu118 --index-url https://download.pytorch.org/whl/cu118
+          pip install -U --cache-dir $TORCH_CACHE torch==2.1.0+cu118 --index-url https://download.pytorch.org/whl/cu118
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,5 +5,5 @@ packaging>=20.0
 psutil
 py-cpuinfo
 pydantic
-torch
+torch==2.0.1
 tqdm


### PR DESCRIPTION
Around the release of torch 2.1, something changed that began skipping all of the tests that should have been running in nv-transformers.

Sample passing build before: https://github.com/microsoft/DeepSpeed/actions/runs/6399875223/job/17372640478#step:8:1486
Sample passing build after (skips all tests): https://github.com/microsoft/DeepSpeed/actions/runs/6476276918/job/17584733821#step:8:1355