### PR TITLE
add available memory check to accelerators

### DIFF
--- a/accelerator/abstract_accelerator.py
+++ b/accelerator/abstract_accelerator.py
@@ -147,6 +147,10 @@ class DeepSpeedAccelerator(ABC):
     def total_memory(self, device_index=None):
         ...
 
+    @abc.abstractmethod
+    def available_memory(self, device_index=None):
+        ...
+
     # Data types
     @abc.abstractmethod
     def is_bf16_supported(self):

--- a/accelerator/cpu_accelerator.py
+++ b/accelerator/cpu_accelerator.py
@@ -159,6 +159,9 @@ class CPU_Accelerator(DeepSpeedAccelerator):
     def total_memory(self, device_index=None):
         return psutil.virtual_memory().total
 
+    def available_memory(self, device_index=None):
+        return psutil.virtual_memory().available
+
     # Misc
     def amp(self):
         return torch.cpu.amp

--- a/accelerator/cuda_accelerator.py
+++ b/accelerator/cuda_accelerator.py
@@ -22,18 +22,21 @@ pynvml = None
 class CUDA_Accelerator(DeepSpeedAccelerator):
 
     def __init__(self):
-        global pynvml
         self._name = 'cuda'
         self._communication_backend_name = 'nccl'
         if pynvml is None:
-            try:
-                import pynvml
-            except ImportError:
-                pass
-            try:
-                pynvml.nvmlInit()
-            except pynvml.NVMLError:
-                pynvml = None
+            self._init_pynvml()
+
+    def _init_pynvml(self):
+        global pynvml
+        try:
+            import pynvml
+        except ImportError:
+            return
+        try:
+            pynvml.nvmlInit()
+        except pynvml.NVMLError:
+            return
 
     def is_synchronized_device(self):
         return False

--- a/accelerator/cuda_accelerator.py
+++ b/accelerator/cuda_accelerator.py
@@ -15,12 +15,22 @@ try:
 except ImportError:
     pass
 
+# Delay import pynvml to avoid import error when CUDA is not available
+pynvml = None
+
 
 class CUDA_Accelerator(DeepSpeedAccelerator):
 
     def __init__(self):
+        global pynvml
         self._name = 'cuda'
         self._communication_backend_name = 'nccl'
+        if pynvml is None:
+            try:
+                import pynvml
+                pynvml.nvmlInit()
+            except ImportError:
+                pass
 
     def is_synchronized_device(self):
         return False
@@ -135,6 +145,14 @@ class CUDA_Accelerator(DeepSpeedAccelerator):
 
     def total_memory(self, device_index=None):
         return torch.cuda.get_device_properties(device_index).total_memory
+
+    def available_memory(self, device_index=None):
+        if pynvml:
+            handle = pynvml.nvmlDeviceGetHandleByIndex(device_index)
+            info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            return info.free
+        else:
+            return self.total_memory(device_index) - self.memory_allocated(device_index)
 
     # Data types
     def is_bf16_supported(self):

--- a/accelerator/cuda_accelerator.py
+++ b/accelerator/cuda_accelerator.py
@@ -28,9 +28,12 @@ class CUDA_Accelerator(DeepSpeedAccelerator):
         if pynvml is None:
             try:
                 import pynvml
-                pynvml.nvmlInit()
             except ImportError:
                 pass
+            try:
+                pynvml.nvmlInit()
+            except pynvml.NVMLError:
+                pynvml = None
 
     def is_synchronized_device(self):
         return False

--- a/accelerator/cuda_accelerator.py
+++ b/accelerator/cuda_accelerator.py
@@ -30,13 +30,13 @@ class CUDA_Accelerator(DeepSpeedAccelerator):
     def _init_pynvml(self):
         global pynvml
         try:
-            import pynvml as tmp_pynvml
+            import pynvml
         except ImportError:
             return
         try:
-            tmp_pynvml.nvmlInit()
-            pynvml = tmp_pynvml
-        except tmp_pynvml.NVMLError:
+            pynvml.nvmlInit()
+        except pynvml.NVMLError:
+            pynvml = None
             return
 
     def is_synchronized_device(self):

--- a/accelerator/cuda_accelerator.py
+++ b/accelerator/cuda_accelerator.py
@@ -30,12 +30,13 @@ class CUDA_Accelerator(DeepSpeedAccelerator):
     def _init_pynvml(self):
         global pynvml
         try:
-            import pynvml
+            import pynvml as tmp_pynvml
         except ImportError:
             return
         try:
-            pynvml.nvmlInit()
-        except pynvml.NVMLError:
+            tmp_pynvml.nvmlInit()
+            pynvml = tmp_pynvml
+        except tmp_pynvml.NVMLError:
             return
 
     def is_synchronized_device(self):

--- a/accelerator/mps_accelerator.py
+++ b/accelerator/mps_accelerator.py
@@ -131,6 +131,9 @@ class MPS_Accelerator(DeepSpeedAccelerator):
     def total_memory(self, device_index=None):
         return
 
+    def available_memory(self, device_index=None):
+        return
+
     # Data types
     def is_bf16_supported(self):
         return False

--- a/accelerator/npu_accelerator.py
+++ b/accelerator/npu_accelerator.py
@@ -127,6 +127,9 @@ class NPU_Accelerator(DeepSpeedAccelerator):
     def total_memory(self, device_index=None):
         return torch.npu.get_device_properties(device_index).total_memory
 
+    def available_memory(self, device_index=None):
+        return self.total_memory(device_index) - self.memory_allocated(device_index)
+
     # Data types
     def is_bf16_supported(self):
         return torch.npu.is_bf16_supported()

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,5 +5,6 @@ packaging>=20.0
 psutil
 py-cpuinfo
 pydantic
+pynvml
 torch
 tqdm


### PR DESCRIPTION
There are many scenarios where we need to get an accurate estimate of the available memory on a device. Currently we rely on the torch memory allocator stats to give us this information, however there are several cases where memory may be allocated outside the view of torch. This means that `torch.cuda.get_device_properties(device_index).total_memory - torch.cuda.memory_allocated(device_index)` is not accurate. This is usually less of a problem on data center GPUs but quite common on consumer grade GPUs that are often shared between torch and the operating system.

This PR introduces `available_memory` to the abstract accelerator interface. On CUDA devices we can rely on [`pynvml`](https://pypi.org/project/pynvml/) to get the ground truth w.r.t. available memory.

This also introduces a hard dependency on `pynvml`. I have tested on non-GPU systems and this package seems to install successfully but fails at runtime at the `nvmlInit()` call. We fall back to using torch stats for memory in cases where pynvml is not functional.