### PR TITLE
Added __HIP_PLATFORM_AMD__=1

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -486,6 +486,9 @@ class OpBuilder(ABC):
                 cxx_args.append("-DBF16_AVAILABLE")
                 nvcc_args.append("-DBF16_AVAILABLE")
 
+        if self.is_rocm_pytorch():
+            cxx_args.append("-D__HIP_PLATFORM_AMD__=1")
+
         op_module = load(name=self.name,
                          sources=self.strip_empty_entries(sources),
                          extra_include_paths=self.strip_empty_entries(extra_include_paths),


### PR DESCRIPTION
This PR is required in addition to https://github.com/microsoft/DeepSpeed/pull/4539 to define __HIP_PLATFORM_AMD__ on ROCm. 

This is required for DeepSpeed extensions build in those docker images with PyTorch built before https://github.com/pytorch/pytorch/pull/111975. 

cc: @jeffdaily @jithunnair-amd 