### PR TITLE
Add more weight only quantization algorithms into DeepSpeed inference.

### DIFF
--- a/deepspeed/inference/config.py
+++ b/deepspeed/inference/config.py
@@ -97,9 +97,18 @@ class BaseQuantConfig(DeepSpeedConfigModel):
     q_groups: int = 1
 
 
+class WeightQuantAlgoEnum(str, Enum):
+    default = "default"
+    rtn = "rtn"
+    awq = "awq"
+    gptq = "gptq"
+    teq = "teq"
+
+
 class WeightQuantConfig(BaseQuantConfig):
     enabled = True
     quantized_initialization: Dict = {}
+    algo_type: WeightQuantAlgoEnum = WeightQuantAlgoEnum.default
     post_init_quant: Dict = {}
 
 


### PR DESCRIPTION
This PR is used to unify the interface of extending more weight only quantization algos for DeepSpeed inference.

At this PR, we plan to introduce "RTN"/"TEQ"/"AWQ"/"GPTQ" weight only quantization algos implemented in [Intel Neural Compressor](https://github.com/intel/neural-compressor) into DeepSpeed.

RTN: supports more models/architectures, including any Linear shape, enhanced by MSE-driven mechanism.
 
TEQ: supports more models/architectures, cross-architectures (CPU and GPU), and comparable with SOTA, supports layer-wise mixed-bits quantization, this algo is orthogonal with AWQ/GPTQ.

GPTQ: supports more models/architectures, being more productive with lexible calibration data types (fixed/unfixed length, tensor/tuple/dict)

AWQ: supports more models/architectures, including CPU device.

<table class="tg">
<thead>
  <tr>
    <th rowspan="2">Model name</th>
    <th rowspan="2">Configuration</th>
    <th colspan="2">Lambada_openai</th>
    <th rowspan="2">Accuracy Ratio<br>[INT8/FP32]</th>
  </tr>
  <tr>
    <th>Accuracy</th>
    <th>Perplexity</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td rowspan="2">meta-llama/Llama-2-70b-chat-hf</td>
    <td>FP32</td>
    <td>0.7543</td>
    <td>2.6181</td>
    <td>/</td>
  </tr>
  <tr>
    <td>RTN<br>W4G32Asym</td>
    <td>0.7518</td>
    <td>2.6496</td>
    <td>0.9967</td>
  </tr>
  <tr>
    <td rowspan="2">meta-llama/Llama-2-70b-hf</td>
    <td>FP32</td>
    <td>0.7964</td>
    <td>2.6612</td>
    <td>/</td>
  </tr>
  <tr>
    <td>RTN<br>W4G32Sym</td>
    <td>0.7941</td>
    <td>2.7243</td>
    <td>0.9971</td>
  </tr>
  <tr>
    <td rowspan="2">meta-llama/Llama-2-7b-chat-hf</td>
    <td>FP32</td>
    <td>0.7058</td>
    <td>3.2788</td>
    <td>/</td>
  </tr>
  <tr>
    <td>GPTQ<br>W4G32Asym</td>
    <td>0.7002</td>
    <td>3.4124</td>
    <td>0.9921</td>
  </tr>
  <tr>
    <td rowspan="2">EleutherAI/gpt-j-6b</td>
    <td>FP32</td>
    <td>0.6831</td>
    <td>4.1023</td>
    <td>/</td>
  </tr>
  <tr>
    <td>TEQ<br>W4G128Asym</td>
    <td>0.6713</td>
    <td>4.3064</td>
    <td>0.9827</td>
  </tr>
</tbody>
</table>

With such rich algos introduced, user can decide which one to be used for their production.