### PR TITLE
[comm/ccl.py] Compatible with older pytorch versions

### DIFF
--- a/deepspeed/comm/ccl.py
+++ b/deepspeed/comm/ccl.py
@@ -170,7 +170,7 @@ class CCLBackend(TorchBackend):
             while True:
                 results.append(super(CCLBackend, self).get_global_rank(group, rank))
                 rank += 1
-        except ValueError:
+        except (ValueError, RuntimeError):
             pass
         if tuple(results) not in self.groups:
             self._new_group(results, group)


### PR DESCRIPTION
In latest pytorch, torch.distributed.distributed_c10d.get_global_rank would return ValueError if passed with wrong parameter.
A few versions ago, it would return RuntimeError.
To be able to run in all those situations, I modified comm/ccl.py to be compatible.