### PR TITLE
Disable CPU inference on PRs

### DIFF
--- a/.github/workflows/cpu-inference.yml
+++ b/.github/workflows/cpu-inference.yml
@@ -1,13 +1,7 @@
 name: cpu-inference
 
 on:
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'blogs/**'
   workflow_dispatch:
-  merge_group:
-    branches: [ master ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Currently paused in the GitHub UI, so this does not have an impact on the current changes.