### PR TITLE
ckpt: add open and close methods to checkpoint engine

### DIFF
--- a/deepspeed/runtime/checkpoint_engine/checkpoint_engine.py
+++ b/deepspeed/runtime/checkpoint_engine/checkpoint_engine.py
@@ -22,9 +22,15 @@ class CheckpointEngine(object):
     def save(self, state_dict, path: str):
         pass
 
+    def commit(self, tag):
+        # to tell checkpoint services if all files are readys.
+        pass
+
+    def open(self, load_dir=None, tag=None):
+        pass
+
     def load(self, path: str, map_location=None):
         pass
 
-    def commit(self, tag):
-        # to tell checkpoint services if all files are readys.
+    def close(self, tag):
         pass

--- a/deepspeed/runtime/checkpoint_engine/torch_checkpoint_engine.py
+++ b/deepspeed/runtime/checkpoint_engine/torch_checkpoint_engine.py
@@ -3,6 +3,8 @@
 
 # DeepSpeed Team
 
+import os
+
 import torch
 from deepspeed.utils import logger, log_dist
 from deepspeed.runtime.checkpoint_engine.checkpoint_engine import \
@@ -11,8 +13,9 @@ from deepspeed.runtime.checkpoint_engine.checkpoint_engine import \
 
 class TorchCheckpointEngine(CheckpointEngine):
 
-    def __init__(self, config_params=None):
+    def __init__(self, config_params=None, rank=0):
         super().__init__(config_params)
+        self.rank = rank
 
     def create(self, tag):
         log_dist(f"[Torch] Checkpoint {tag} is about to be saved!", ranks=[0])
@@ -23,12 +26,29 @@ class TorchCheckpointEngine(CheckpointEngine):
         logger.info(f"[Torch] Saved {path}.")
         return None
 
+    def commit(self, tag):
+        # record tag of most recent checkpoint in 'latest' file
+        if self.rank == 0:
+            with open(os.path.join(save_dir, 'latest'), 'w') as fd:
+                fd.write(tag)
+
+        logger.info(f"[Torch] Checkpoint {tag} is ready now!")
+        return True
+
+    def open(self, load_dir=None, tag=None):
+        # read tag from latest file if not given an actual name
+        if tag in ['latest', 'latest_universal']:
+            latest_path = os.path.join(load_dir, tag)
+            if os.path.isfile(latest_path):
+                with open(latest_path, "r") as fd:
+                    tag = fd.read().strip()
+                    return tag
+            else:
+                return None
+        return tag
+
     def load(self, path: str, map_location=None):
         logger.info(f"[Torch] Loading checkpoint from {path}...")
         partition = torch.load(path, map_location=map_location)
         logger.info(f"[Torch] Loaded checkpoint from {path}.")
         return partition
-
-    def commit(self, tag):
-        logger.info(f"[Torch] Checkpoint {tag} is ready now!")
-        return True


### PR DESCRIPTION
Replaces https://github.com/microsoft/DeepSpeed/pull/3009 (too many merge conflicts while trying to refresh)

For consideration, this adds ``open()`` and ``close()`` calls to the ``CheckpointEngine`` to serve as start and end markers during a restart.  Similar to how ``create()`` and ``commit()`` define the start and end markers when writing a checkpoint, these new calls are useful for checkpoint engines while reading a checkpoint.

The ``open()`` function can be used by the checkpoint engine to find and prepare a checkpoint for loading.  The caller may specify a directory in ``load_dir`` and a checkpoint name in ``tag``.  If ``tag == None`` or ``"latest"``, the checkpoint engine loads the most recent checkpoint that it can find.  Otherwise, the checkpoint engine attempts to load the checkpoint named in ``tag``.  ``open()`` returns the ``tag`` value of the checkpoint that it actually loaded, or ``None`` if it fails to find a checkpoint.

The ``close()`` call can be used to free any resources that were allocated by the checkpoint engine during ``open()``.

All ``load()`` calls that read checkpoint files should be placed between ``open()`` and ``close()`` bookends.

Implementation details and TODOs:
- This moves the processing for the ``latest`` file to ``TorchCheckpointEngine``.  It is written during ``commit()`` and read during ``open()``.  For now, ``save_latest`` is a member variable of the class that is hard coded to be ``True``.  To make this dynamic, this could either be a config parameter or an option passed to ``create()``.  So that only rank 0 creates the ``latest`` file, I pass the rank of each process in the ``TorchCheckpointEngine`` constructor.  If it's acceptable to use ``dist`` within the checkpoint engine, we could alternatively get the rank directly.
- I took an educated guess at updating Nebula to use ``open()`` and ``close()``, but it's not possible for me to test the code.  The main change is that the search logic that locates the checkpoint has been moved from ``load()`` to ``open()``.  In particular, one should review my changes to ``tag_flag``.
- As an extension, the ``load_dir`` parameter that is passed to ``open()`` could be made optional, in which case, one could use the current working directory, or ``load_dir`` could be passed as a parameter to the checkpoint engine constructor.  Similar changes could be made for ``save_dir``.  I'm guessing that in most cases, these directory paths do not change during a run.