### PR TITLE
Fix for MII unit tests

### DIFF
--- a/.github/workflows/nv-mii.yml
+++ b/.github/workflows/nv-mii.yml
@@ -54,5 +54,5 @@ jobs:
           cd DeepSpeed-MII
           pip install .[dev]
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch
-          cd tests
+          cd tests/legacy
           pytest $PYTEST_OPTS --forked -m "deepspeed" ./


### PR DESCRIPTION
https://github.com/microsoft/DeepSpeed-MII/pull/262 Moved the legacy-MII unit tests to a subdirectory. Reflecting that change here.

@loadams 