### PR TITLE
Fix UNET and VAE implementations for new diffusers version

### DIFF
--- a/deepspeed/model_implementations/diffusers/unet.py
+++ b/deepspeed/model_implementations/diffusers/unet.py
@@ -62,7 +62,13 @@ class DSUNet(CUDAGraph, torch.nn.Module):
 
         self.cuda_graph_created = True
 
-    def _forward(self, sample, timestamp, encoder_hidden_states, return_dict=True, cross_attention_kwargs=None, timestep_cond=None):
+    def _forward(self,
+                 sample,
+                 timestamp,
+                 encoder_hidden_states,
+                 return_dict=True,
+                 cross_attention_kwargs=None,
+                 timestep_cond=None):
         if cross_attention_kwargs:
             return self.unet(sample,
                              timestamp,

--- a/deepspeed/model_implementations/diffusers/unet.py
+++ b/deepspeed/model_implementations/diffusers/unet.py
@@ -62,7 +62,7 @@ class DSUNet(CUDAGraph, torch.nn.Module):
 
         self.cuda_graph_created = True
 
-    def _forward(self, sample, timestamp, encoder_hidden_states, return_dict=True, cross_attention_kwargs=None):
+    def _forward(self, sample, timestamp, encoder_hidden_states, return_dict=True, cross_attention_kwargs=None, timestep_cond=None):
         if cross_attention_kwargs:
             return self.unet(sample,
                              timestamp,

--- a/deepspeed/model_implementations/diffusers/vae.py
+++ b/deepspeed/model_implementations/diffusers/vae.py
@@ -30,7 +30,7 @@ class DSVAE(CUDAGraph, torch.nn.Module):
         self._decoder_cuda_graph.replay()
         return self.static_decoder_output
 
-    def _decode(self, x, return_dict=True):
+    def _decode(self, x, return_dict=True, generator=None):
         return self.vae.decode(x, return_dict=return_dict)
 
     def _create_cuda_graph_decoder(self, *inputs, **kwargs):


### PR DESCRIPTION
This PR updates the DepSpeed UNET and VAE implementations to support `diffusers>=0.23.0`.