### PR TITLE
Fix DS Stable Diffusion for latest diffusers version

### DIFF
--- a/deepspeed/model_implementations/diffusers/unet.py
+++ b/deepspeed/model_implementations/diffusers/unet.py
@@ -68,7 +68,8 @@ class DSUNet(CUDAGraph, torch.nn.Module):
                  encoder_hidden_states,
                  return_dict=True,
                  cross_attention_kwargs=None,
-                 timestep_cond=None):
+                 timestep_cond=None,
+                 added_cond_kwargs=None):
         if cross_attention_kwargs:
             return self.unet(sample,
                              timestamp,


### PR DESCRIPTION
This PR fixes the DeepSpeed `UNet` forward function to work with the latest `diffusers` version.

Manual `nv-sd` workflow run:
https://github.com/microsoft/DeepSpeed/actions/runs/7092016979

Fixes #4760 