### PR TITLE
Revert "Fix for when prompt contains an odd num of apostrophes (#4660)"

### DIFF
--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -390,7 +390,7 @@ def main(args=None):
     args = parse_args(args)
 
     # For when argparse interprets remaining args as a single string
-    args.user_args = shlex.split(" ".join(list(map(lambda x: x if x.startswith("-") else f'"{x}"', args.user_args))))
+    args.user_args = shlex.split(" ".join(list(map(lambda x: x if x.startswith("-") else f"'{x}'", args.user_args))))
 
     if args.elastic_training:
         assert args.master_addr != "", "Master Addr is required when elastic training is enabled"


### PR DESCRIPTION
This reverts commit 00e7dc5e5116a5384647db917c3a1fa723bf4a5b from #4660.  

@oelayan7 - FYI, we've hit issues on the transformers CI tests that reverting this PR fixes.  

Fixes #4795.

