### PR TITLE
fix for tests using torch<2.1

### DIFF
--- a/tests/unit/alexnet_model.py
+++ b/tests/unit/alexnet_model.py
@@ -10,7 +10,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 import deepspeed
 import deepspeed.comm as dist
-import deepspeed.runtime.utils as ds_utils, required_torch_version
+import deepspeed.runtime.utils as ds_utils
+from deepspeed.runtime.utils import required_torch_version
 from deepspeed.accelerator import get_accelerator
 from deepspeed.runtime.pipe.module import PipelineModule, LayerSpec
 


### PR DESCRIPTION
Our torch 1.10 tests have been failling since the merge of #4569. This added a `device_type` kwarg to the `torch.random.fork_rng` call. But this is not compatible with older versions of torch. Added in https://github.com/pytorch/pytorch/pull/98069

Fixes #4644, #4503