### PR TITLE
BF16 optimizer: Improve device utilization via instant grad update

### DIFF
--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -168,10 +168,10 @@ def get_bfloat16_enabled(param_dict):
     return False
 
 
-def get_bfloat16_accumulate_grads_via_hooks(param_dict):
+def get_bfloat16_immediate_grad_update(param_dict):
     for key in [BFLOAT16, BFLOAT16_OLD]:
         if key in param_dict.keys():
-            return get_scalar_param(param_dict[key], BFLOAT16_GRAD_ACC_VIA_HOOKS, BFLOAT16_GRAD_ACC_VIA_HOOKS_DEFAULT)
+            return get_scalar_param(param_dict[key], BFLOAT16_IMMEDIATE_GRAD_UPDATE, BFLOAT16_IMMEDIATE_GRAD_UPDATE_DEFAULT)
     return False
 
 
@@ -820,7 +820,7 @@ class DeepSpeedConfig(object):
         self.fp16_enabled = get_fp16_enabled(param_dict)
         self.fp16_auto_cast = get_fp16_auto_cast(param_dict)
         self.bfloat16_enabled = get_bfloat16_enabled(param_dict)
-        self.bfloat16_accumulate_grads_via_hooks = get_bfloat16_accumulate_grads_via_hooks(param_dict)
+        self.bfloat16_immediate_grad_update = get_bfloat16_immediate_grad_update(param_dict)
         assert not (self.fp16_enabled
                     and self.bfloat16_enabled), 'bfloat16 and fp16 modes cannot be simultaneously enabled'
         self.fp16_master_weights_and_gradients = get_fp16_master_weights_and_grads_enabled(param_dict)

--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -168,6 +168,13 @@ def get_bfloat16_enabled(param_dict):
     return False
 
 
+def get_bfloat16_accumulate_grads_via_hooks(param_dict):
+    for key in [BFLOAT16, BFLOAT16_OLD]:
+        if key in param_dict.keys():
+            return get_scalar_param(param_dict[key], BFLOAT16_GRAD_ACC_VIA_HOOKS, BFLOAT16_GRAD_ACC_VIA_HOOKS_DEFAULT)
+    return False
+
+
 def get_fp16_master_weights_and_grads_enabled(param_dict):
     if get_fp16_enabled(param_dict):
         return get_scalar_param(param_dict[FP16], FP16_MASTER_WEIGHTS_AND_GRADS, FP16_MASTER_WEIGHTS_AND_GRADS_DEFAULT)
@@ -813,6 +820,7 @@ class DeepSpeedConfig(object):
         self.fp16_enabled = get_fp16_enabled(param_dict)
         self.fp16_auto_cast = get_fp16_auto_cast(param_dict)
         self.bfloat16_enabled = get_bfloat16_enabled(param_dict)
+        self.bfloat16_accumulate_grads_via_hooks = get_bfloat16_accumulate_grads_via_hooks(param_dict)
         assert not (self.fp16_enabled
                     and self.bfloat16_enabled), 'bfloat16 and fp16 modes cannot be simultaneously enabled'
         self.fp16_master_weights_and_gradients = get_fp16_master_weights_and_grads_enabled(param_dict)

--- a/deepspeed/runtime/constants.py
+++ b/deepspeed/runtime/constants.py
@@ -126,6 +126,10 @@ BFLOAT16_OLD = "bfloat16"  # keeping for backwards compatibility
 BFLOAT16_ENABLED = "enabled"
 BFLOAT16_ENABLED_DEFAULT = False
 
+# BFLOAT16 optimizer gradient accumulation via hooks
+BFLOAT16_GRAD_ACC_VIA_HOOKS = "accumulate_grads_via_hooks"
+BFLOAT16_GRAD_ACC_VIA_HOOKS_DEFAULT = False
+
 #########################################
 # FP16 support
 #########################################

--- a/deepspeed/runtime/constants.py
+++ b/deepspeed/runtime/constants.py
@@ -126,9 +126,9 @@ BFLOAT16_OLD = "bfloat16"  # keeping for backwards compatibility
 BFLOAT16_ENABLED = "enabled"
 BFLOAT16_ENABLED_DEFAULT = False
 
-# BFLOAT16 optimizer gradient accumulation via hooks
-BFLOAT16_GRAD_ACC_VIA_HOOKS = "accumulate_grads_via_hooks"
-BFLOAT16_GRAD_ACC_VIA_HOOKS_DEFAULT = False
+# BFLOAT16 optimizer immediate gradient update via hooks
+BFLOAT16_IMMEDIATE_GRAD_UPDATE = "immediate_grad_update"
+BFLOAT16_IMMEDIATE_GRAD_UPDATE_DEFAULT = False
 
 #########################################
 # FP16 support

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1451,7 +1451,8 @@ class DeepSpeedEngine(Module):
                                    allgather_bucket_size=self.zero_allgather_bucket_size(),
                                    dp_process_group=self.seq_data_parallel_group,
                                    timers=timers,
-                                   grad_acc_dtype=self.get_data_types()[1])
+                                   grad_acc_dtype=self.get_data_types()[1],
+                                   accumulate_grads_via_hooks=self._config.bfloat16_accumulate_grads_via_hooks)
 
         return optimizer
 

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1452,7 +1452,7 @@ class DeepSpeedEngine(Module):
                                    dp_process_group=self.seq_data_parallel_group,
                                    timers=timers,
                                    grad_acc_dtype=self.get_data_types()[1],
-                                   accumulate_grads_via_hooks=self._config.bfloat16_accumulate_grads_via_hooks)
+                                   immediate_grad_update=self._config.bfloat16_immediate_grad_update)
 
         return optimizer
 

--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -781,7 +781,8 @@ class PipelineEngine(DeepSpeedEngine):
 
         if self.using_bf16_optimizer and not self.is_last_stage():
             # manually call because we don't call optimizer.backward()
-            self.optimizer.update_hp_grads(clear_lp_grads=False)
+            if not self._config.bfloat16_accumulate_grads_via_hooks:
+                self.optimizer.update_hp_grads(clear_lp_grads=False)
 
         # Free up the memory from the output of forward()
         self.pipe_buffers['output_tensors'][buffer_id] = None

--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -781,7 +781,7 @@ class PipelineEngine(DeepSpeedEngine):
 
         if self.using_bf16_optimizer and not self.is_last_stage():
             # manually call because we don't call optimizer.backward()
-            if not self._config.bfloat16_accumulate_grads_via_hooks:
+            if not self._config.bfloat16_immediate_grad_update:
                 self.optimizer.update_hp_grads(clear_lp_grads=False)
 
         # Free up the memory from the output of forward()


### PR DESCRIPTION
Enabled gradient accumulation in bf16 optimizer which updates fp32 gradients once the gradient is available.

This improves device utilization on some back-ends, by parallelizing the underlying workload across hardware engines.

To enable the feature (disabled by default), use a new config flag "accumulate_grads_via_hooks" under "bf16" section in Deepspeed config.json (default is false).
  Example:
  "bf16": {
    "enabled": true,
    "accumulate_grads_via_hooks": true
   }