### PR TITLE
Fix exception handling in get_all_ranks_from_group() function

### DIFF
--- a/deepspeed/comm/comm.py
+++ b/deepspeed/comm/comm.py
@@ -595,7 +595,7 @@ def get_all_ranks_from_group(group=None):
         while True:
             group_ranks.append(cdb.get_global_rank(group, rank))
             rank += 1
-    except RuntimeError:
+    except (RuntimeError, ValueError):
         pass
     return group_ranks
 


### PR DESCRIPTION
In the latest Pytorch nightly, the exception thrown from `torch.distributed.distributed_c10d.get_global_rank()` is changed from `RuntimeError` to `ValueError` so we need to update our try-catch in `deepspeed.comm`

Tested with torch version 2.3.0.dev20231221+cu121

Fixes: https://github.com/microsoft/DeepSpeed/issues/4853