### PR TITLE
TorchCheckpointEngine: torch.save using pickle protocol 4

### DIFF
--- a/deepspeed/runtime/checkpoint_engine/torch_checkpoint_engine.py
+++ b/deepspeed/runtime/checkpoint_engine/torch_checkpoint_engine.py
@@ -19,7 +19,7 @@ class TorchCheckpointEngine(CheckpointEngine):
 
     def save(self, state_dict, path: str):
         logger.info(f"[Torch] Saving {path}...")
-        torch.save(state_dict, path)
+        torch.save(state_dict, path, pickle_protocol=4)
         logger.info(f"[Torch] Saved {path}.")
         return None
 


### PR DESCRIPTION
to allow large tensor serialization > 4B.
Can reproduce this by running the attached files:
1. put both files in same directory.
2. change the .txt to .py
3. run from the directory `python test_large_tensor_save_cp.py`
4. expecting the following error message: `OverflowError: serializing a string larger than 4 GiB requires pickle protocol 4 or higher`

[deepspeed_vllm_config.json](https://github.com/microsoft/DeepSpeed/files/13786680/deepspeed_vllm_config.json)
[test_large_tensor_save_cp.txt](https://github.com/microsoft/DeepSpeed/files/13786681/test_large_tensor_save_cp.txt)

**Note:** It cannot be reproduced with CPU backend, could not check on GPU. for HPU (Intel Gaudi2) it does happen. I assume it is somehow related to backends that goes through the the below flow in pytorch:
https://github.com/pytorch/pytorch/blob/4bfaa6bc250f5ff5702703ea237f578a15bbe3b6/torch/_tensor.py#L247 
which converts the tensor into a numpy format. 