### PR TITLE
[NPU] Fix npu offload bug

### DIFF
--- a/csrc/includes/cpu_adagrad.h
+++ b/csrc/includes/cpu_adagrad.h
@@ -194,7 +194,7 @@ void Adagrad_Optimizer::Step_AVX(size_t* rounded_size,
 #elif defined(__ENABLE_CANN__)
         if (dev_params) {
             size_t memcpy_size = copy_size * sizeof(_doubled_buffer[_buf_index][0]);
-            if (half_precision) memoryCopySize /= 2;
+            if (half_precision) memcpy_size /= 2;
             aclrtMemcpy(dev_params + t,
                         memcpy_size,
                         _doubled_buffer[_buf_index],
@@ -202,6 +202,7 @@ void Adagrad_Optimizer::Step_AVX(size_t* rounded_size,
                         aclrtMemcpyKind::ACL_MEMCPY_HOST_TO_DEVICE);
 
             _buf_index = !_buf_index;
+        }
 #endif
     }
     *rounded_size = new_rounded_size;

--- a/csrc/includes/cpu_adam.h
+++ b/csrc/includes/cpu_adam.h
@@ -215,8 +215,7 @@ void Adam_Optimizer::Step_AVX(size_t* rounded_size,
 #if defined(__ENABLE_CUDA__)
         if ((t / TILE) >= 2) { cudaStreamSynchronize(_streams[_buf_index]); }
 #elif defined(__ENABLE_CANN__)
-        if ((t / TILE) >= 2) { aclrtSynchronizeStream((_streams[_buf_index].stream());
-        }
+        if ((t / TILE) >= 2) { aclrtSynchronizeStream(_streams[_buf_index].stream()); }
 #endif
 #pragma omp parallel for
         for (size_t i = t; i < offset; i += SIMD_WIDTH * span) {
@@ -274,7 +273,7 @@ void Adam_Optimizer::Step_AVX(size_t* rounded_size,
 #elif defined(__ENABLE_CANN__)
         if (dev_params) {
             size_t memcpy_size = copy_size * sizeof(_doubled_buffer[_buf_index][0]);
-            if (half_precision) memoryCopySize /= 2;
+            if (half_precision) memcpy_size /= 2;
             aclrtMemcpy(dev_params + t,
                         memcpy_size,
                         _doubled_buffer[_buf_index],
@@ -282,6 +281,7 @@ void Adam_Optimizer::Step_AVX(size_t* rounded_size,
                         aclrtMemcpyKind::ACL_MEMCPY_HOST_TO_DEVICE);
 
             _buf_index = !_buf_index;
+        }
 #endif
     }
     *rounded_size = new_rounded_size;

--- a/csrc/includes/cpu_lion.h
+++ b/csrc/includes/cpu_lion.h
@@ -223,7 +223,7 @@ void Lion_Optimizer::Step_AVX(size_t* rounded_size,
 #elif defined(__ENABLE_CANN__)
         if (dev_params) {
             size_t memcpy_size = copy_size * sizeof(_doubled_buffer[_buf_index][0]);
-            if (half_precision) memoryCopySize /= 2;
+            if (half_precision) memcpy_size /= 2;
             aclrtMemcpy(dev_params + t,
                         memcpy_size,
                         _doubled_buffer[_buf_index],
@@ -231,6 +231,7 @@ void Lion_Optimizer::Step_AVX(size_t* rounded_size,
                         aclrtMemcpyKind::ACL_MEMCPY_HOST_TO_DEVICE);
 
             _buf_index = !_buf_index;
+        }
 #endif
     }
     *rounded_size = new_rounded_size;


### PR DESCRIPTION
There are some syntax errors in the NPU offload. 

There may be no AVX instruction set on our server due to environment variables, as a result, this problem is not verified in our tests.

Sorry for the inconvenience and we will be more cautious in the next PRs.