### PR TITLE
fix falcon-40b accuracy issue

### DIFF
--- a/deepspeed/module_inject/fusedqkv_utils.py
+++ b/deepspeed/module_inject/fusedqkv_utils.py
@@ -38,6 +38,7 @@ def prepare_tp_fused_qkvw(module_str, src, mp_size, gpu_index):
         "MptBlock": 'glmtype',
         "BaichuanLayer": 'glmtype',
         "DecoderLayer": 'glmtype',
+        "FalconDecoderLayer": 'bloomtype',
     }
 
     def _codegen_type_transpose(input, mp_size, codegen_mp_num=4):


### PR DESCRIPTION
This [PR](https://github.com/microsoft/DeepSpeed/pull/4721) added the "DecoderLayer":glmtype. It will cause the Falcon model to choose "glmtype" fused_qkv_type. Falcon model (including Falcondecoderlayer) needs to choose 'bloomtype' explicitly.