### PR TITLE
Fix SD workflow to work with latest diffusers version

### DIFF
--- a/deepspeed/module_inject/containers/vae.py
+++ b/deepspeed/module_inject/containers/vae.py
@@ -13,8 +13,8 @@ class VAEPolicy(DSPolicy):
         super().__init__()
         try:
             import diffusers
-            if hasattr(diffusers.models.vae, "AutoencoderKL"):
-                self._orig_layer_class = diffusers.models.vae.AutoencoderKL
+            if hasattr(diffusers.models.autoencoders.vae, "AutoencoderKL"):
+                self._orig_layer_class = diffusers.models.autoencoders.vae.AutoencoderKL
             else:
                 # Diffusers >= 0.12.0 changes location of AutoencoderKL
                 self._orig_layer_class = diffusers.models.autoencoder_kl.AutoencoderKL

--- a/deepspeed/module_inject/containers/vae.py
+++ b/deepspeed/module_inject/containers/vae.py
@@ -17,7 +17,7 @@ class VAEPolicy(DSPolicy):
                 self._orig_layer_class = diffusers.models.autoencoders.vae.AutoencoderKL
             else:
                 # Diffusers >= 0.12.0 changes location of AutoencoderKL
-                self._orig_layer_class = diffusers.models.autoencoder_kl.AutoencoderKL
+                self._orig_layer_class = diffusers.models.autoencoders.autoencoder_kl.AutoencoderKL
         except ImportError:
             self._orig_layer_class = None
 

--- a/requirements/requirements-sd.txt
+++ b/requirements/requirements-sd.txt
@@ -1,2 +1,2 @@
-diffusers
+diffusers>=0.25.0
 triton>=2.1.0


### PR DESCRIPTION
This PR fixes the Stable Diffusion workflow to work with the latest `diffusers` version (`0.25.0`).