### PR TITLE
Change PR/schedule triggers for CPU-inference

### DIFF
--- a/.github/workflows/cpu-inference.yml
+++ b/.github/workflows/cpu-inference.yml
@@ -5,9 +5,10 @@ on:
     paths:
       - '.github/workflows/cpu-inference.yml'
       - 'requirements/**'
-      - 'deepspeed/inference/**'
       - 'deepspeed/__init__.py'
+      - 'deepspeed/inference/**'
       - '!deepspeed/inference/v2/**' # exclude v2 dir
+      - 'tests/unit/inference/**'
       - 'tests/unit/inference/v2/**' # exclude v2 tests dir
   workflow_dispatch:
   merge_group:

--- a/.github/workflows/cpu-inference.yml
+++ b/.github/workflows/cpu-inference.yml
@@ -2,13 +2,15 @@ name: cpu-inference
 
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'blogs/**'
+    paths:
+      - '.github/workflows/cpu-inference.yml'
+      - 'requirements/**'
+      - 'deepspeed/inference/**'
   workflow_dispatch:
   merge_group:
     branches: [ master ]
-
+  schedule:
+        - cron: "0 0 * * 0"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cpu-inference.yml
+++ b/.github/workflows/cpu-inference.yml
@@ -6,6 +6,8 @@ on:
       - '.github/workflows/cpu-inference.yml'
       - 'requirements/**'
       - 'deepspeed/inference/**'
+      - 'deepspeed/__init__.py`
+      - '!deepspeed/inference/v2/**' # exclude v2 dir
   workflow_dispatch:
   merge_group:
     branches: [ master ]

--- a/.github/workflows/cpu-inference.yml
+++ b/.github/workflows/cpu-inference.yml
@@ -6,8 +6,9 @@ on:
       - '.github/workflows/cpu-inference.yml'
       - 'requirements/**'
       - 'deepspeed/inference/**'
-      - 'deepspeed/__init__.py`
+      - 'deepspeed/__init__.py'
       - '!deepspeed/inference/v2/**' # exclude v2 dir
+      - 'tests/unit/inference/v2/**' # exclude v2 tests dir
   workflow_dispatch:
   merge_group:
     branches: [ master ]

--- a/.github/workflows/cpu-inference.yml
+++ b/.github/workflows/cpu-inference.yml
@@ -9,7 +9,7 @@ on:
       - 'deepspeed/inference/**'
       - '!deepspeed/inference/v2/**' # exclude v2 dir
       - 'tests/unit/inference/**'
-      - 'tests/unit/inference/v2/**' # exclude v2 tests dir
+      - '!tests/unit/inference/v2/**' # exclude v2 tests dir
   workflow_dispatch:
   merge_group:
     branches: [ master ]

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -2,11 +2,13 @@ name: nv-inference
 
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'blogs/**'
-      - 'deepspeed/inference/v2/**'
-      - 'tests/unit/inference/v2/**'
+    paths:
+      - '.github/workflows/nv-inference.yml'
+      - 'requirements/**'
+      - 'deepspeed/inference/**'
+      - 'deepspeed/__init__.py'
+      - '!deepspeed/inference/v2/**' # exclude v2 dir
+      - '!tests/unit/inference/v2/**' # exclude v2 tests dir
   merge_group:
     branches: [ master ]
   schedule:

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -9,7 +9,7 @@ on:
       - 'deepspeed/inference/**'
       - '!deepspeed/inference/v2/**' # exclude v2 dir
       - 'tests/unit/inference/**'
-      - 'tests/unit/inference/v2/**' # exclude v2 tests dir
+      - '!tests/unit/inference/v2/**' # exclude v2 tests dir
   merge_group:
     branches: [ master ]
   schedule:

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -5,10 +5,11 @@ on:
     paths:
       - '.github/workflows/nv-inference.yml'
       - 'requirements/**'
-      - 'deepspeed/inference/**'
       - 'deepspeed/__init__.py'
+      - 'deepspeed/inference/**'
       - '!deepspeed/inference/v2/**' # exclude v2 dir
-      - '!tests/unit/inference/v2/**' # exclude v2 tests dir
+      - 'tests/unit/inference/**'
+      - 'tests/unit/inference/v2/**' # exclude v2 tests dir
   merge_group:
     branches: [ master ]
   schedule:


### PR DESCRIPTION
Update triggers for cpu-inference and nv-inference.

- cpu-inference changes: set CI to be weekly, added triggers to run when deepspeed/inference folders are modified.
- nv-inference: updated triggers to be similar to cpu-inference.