### PR TITLE
fix RuntimeError: Error building extension 'ragged_device_ops'

### DIFF
--- a/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu
+++ b/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu
@@ -3,6 +3,7 @@
 
 // DeepSpeed Team
 
+#include <cassert>
 #include "blocked_kv_rotary.cuh"
 #include "conversion_utils.h"
 #include "ds_kernel_utils.h"


### PR DESCRIPTION
fix RuntimeError: Error building extension 'ragged_device_ops'

```
/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(261): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(261): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(261): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(261): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(262): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(262): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(262): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(262): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(263): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(263): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(263): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(263): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(264): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(264): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(264): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(264): error: identifier "assert" is undefined

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(265): error: identifier "assert" is undefined

....

/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu(362): error: identifier "assert" is undefined

60 errors detected in the compilation of "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.cu".
ninja: build stopped: subcommand failed.
Traceback (most recent call last):
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/torch/utils/cpp_extension.py", line 2103, in _run_ninja_build
    subprocess.run(
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['ninja', '-v']' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/root/.local/share/code-server/extensions/ms-python.python-2023.19.13031019/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 39, in <module>
    cli.main()
  File "/root/.local/share/code-server/extensions/ms-python.python-2023.19.13031019/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 430, in main
    run()
  File "/root/.local/share/code-server/extensions/ms-python.python-2023.19.13031019/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 284, in run_file
    runpy.run_path(target, run_name="__main__")
  File "/root/.local/share/code-server/extensions/ms-python.python-2023.19.13031019/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 321, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/root/.local/share/code-server/extensions/ms-python.python-2023.19.13031019/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 135, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/root/.local/share/code-server/extensions/ms-python.python-2023.19.13031019/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 124, in _run_code
    exec(code, run_globals)
  File "src/generate.py", line 484, in <module>
    main()
  File "src/generate.py", line 473, in main
    model, tokenizer, sampling_params = init_model(model_args, finetuning_args, generating_args, infer_args)
  File "src/generate.py", line 171, in init_model
    model = pipeline(model_name_or_path)
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/mii/api.py", line 156, in pipeline
    inference_engine = load_model(model_config)
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/mii/modeling/models.py", line 17, in load_model
    inference_engine = build_hf_engine(
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/engine_factory.py", line 126, in build_hf_engine
    return InferenceEngineV2(policy, engine_config)
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/engine_v2.py", line 83, in __init__
    self._model = self._policy.build_model(self._config, self._base_mp_group)
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/model_implementations/inference_policy_base.py", line 156, in build_model
    self.model = self.instantiate_model(engine_config, mp_group)
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/model_implementations/llama_v2/policy.py", line 17, in instantiate_model
    return Llama2InferenceModel(config=self._model_config, engine_config=engine_config, base_mp_group=mp_group)
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/model_implementations/inference_transformer_base.py", line 217, in __init__
    self.make_attn_layer()
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/model_implementations/inference_transformer_base.py", line 334, in make_attn_layer
    self.attn = heuristics.instantiate_attention(attn_config, self._engine_config)
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/modules/heuristics.py", line 53, in instantiate_attention
    return DSSelfAttentionRegistry.instantiate_config(config)
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/modules/module_registry.py", line 39, in instantiate_config
    return cls.registry[config_bundle.name](config_bundle.config, config_bundle.implementation_config)
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/modules/implementations/attention/dense_blocked_attention.py", line 100, in __init__
    self._kv_copy = BlockedRotaryEmbeddings(self._config.head_size, self._config.n_heads_q,
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/inference/v2/kernels/ragged_ops/linear_blocked_kv_rotary/blocked_kv_rotary.py", line 50, in __init__
    inf_module = RaggedOpsBuilder().load()
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/ops/op_builder/builder.py", line 478, in load
    return self.jit_load(verbose)
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/deepspeed/ops/op_builder/builder.py", line 522, in jit_load
    op_module = load(name=self.name,
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/torch/utils/cpp_extension.py", line 1308, in load
    return _jit_compile(
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/torch/utils/cpp_extension.py", line 1710, in _jit_compile
    _write_ninja_file_and_build_library(
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/torch/utils/cpp_extension.py", line 1823, in _write_ninja_file_and_build_library
    _run_ninja_build(
  File "/mnt/workspace/workgroup_share/pengcheng/envs/llama_factory/lib/python3.9/site-packages/torch/utils/cpp_extension.py", line 2119, in _run_ninja_build
    raise RuntimeError(message) from e
RuntimeError: Error building extension 'ragged_device_ops'
```