### PR TITLE
InfV2 - remove generation config requirement

### DIFF
--- a/.github/workflows/nv-a6000.yml
+++ b/.github/workflows/nv-a6000.yml
@@ -60,7 +60,10 @@ jobs:
           python -m pytest --color=yes --durations=0 --verbose -rF -m 'inference_v2_ops' unit/ --torch_ver="2.0" --cuda_ver="12"
       - name: MII unit tests
         run: |
-          BRANCH="${{ github.event.inputs.mii_branch }}"
+          BRANCH="main"
+          if [[ ! -z "${{ github.event.inputs.mii_branch }}" ]]; then
+              BRANCH="${{ github.event.inputs.mii_branch }}"
+          fi
           echo "Cloning DeepSpeed-MII branch: $BRANCH"
           git clone -b $BRANCH --depth=1 https://github.com/microsoft/DeepSpeed-MII.git
           cd DeepSpeed-MII

--- a/deepspeed/inference/v2/checkpoint/huggingface_engine.py
+++ b/deepspeed/inference/v2/checkpoint/huggingface_engine.py
@@ -22,13 +22,13 @@ class HuggingFaceCheckpointEngine(CheckpointEngineBase):
         self.model_name_or_path = model_name_or_path
         self.auth_token = auth_token
         self.model_config = AutoConfig.from_pretrained(self.model_name_or_path)
-        self.generation_config = GenerationConfig.from_pretrained(self.model_name_or_path)
         # Define this property here so we can use it in the model implementation
         if not hasattr(self.model_config, "max_seq_length"):
-            self.model_config.max_seq_length = self.model_config.max_position_embeddings
-        else:
-            self.model_config.max_seq_length = self.generation_config.max_length
-
+            if hasattr(self.model_config, "max_position_embeddings"):
+                self.model_config.max_seq_length = self.model_config.max_position_embeddings
+            else:
+                generation_config = GenerationConfig.from_pretrained(self.model_name_or_path)
+                self.model_config.max_seq_length = generation_config.max_length
         self._local_checkpoint_dir = None
         self._all_ckpt_paths = self._fetch_checkpoint_files()
 


### PR DESCRIPTION
Fix for https://github.com/microsoft/DeepSpeed-MII/issues/287

Some HF models do not have a generation config. We should only try to load it if the `max_seq_length` is not present in the model config.

Also fix bug introduced in #4936 