### PR TITLE
Optimize preprocess for ragged batching

### DIFF
--- a/deepspeed/inference/v2/ragged/ragged_wrapper.py
+++ b/deepspeed/inference/v2/ragged/ragged_wrapper.py
@@ -113,12 +113,23 @@ class RaggedBatchWrapper:
         # Default behavior should be no padding
         self._is_padded = False
 
+        self._current_tokens = 0
+        self._current_sequences = 0
+        self._batch_tokens = []
+        self._inflight_seq_descriptors_shadow_buf = []
+        self._kv_blocks_ptr_buf = []
+        self._token_to_seq_storage_shadow_buf = []
+
     def clear(self) -> None:
         """
         Clear the ragged batch. This will reset the number of tokens and sequences to 0.
         """
-        self._batch_metadata_storage_shadow[0] = 0
-        self._batch_metadata_storage_shadow[1] = 0
+        self._current_tokens = 0
+        self._current_sequences = 0
+        self._batch_tokens = []
+        self._inflight_seq_descriptors_shadow_buf = []
+        self._kv_blocks_ptr_buf = []
+        self._token_to_seq_storage_shadow_buf = []
 
     def insert_sequence(self, seq_descriptor: DSSequenceDescriptor, tokens: torch.Tensor, do_checks=True) -> None:
         """
@@ -140,18 +151,18 @@ class RaggedBatchWrapper:
         if do_checks and self.current_tokens + seq_tokens > self._config.max_ragged_batch_size:
             raise RuntimeError(f"Ragged batch is full due to capacity limit: {self._config.max_ragged_batch_size})")
 
-        self._input_ids_shadow[self.current_tokens:self.current_tokens + seq_tokens].copy_(tokens)
-        self._token_to_seq_storage_shadow[self.current_tokens:self.current_tokens + seq_tokens].fill_(
-            self.current_sequences)
+        self._batch_tokens.append(tokens)
+        self._inflight_seq_descriptors_shadow_buf.append(self.current_tokens)
+        self._inflight_seq_descriptors_shadow_buf.append(seq_tokens)
+        self._inflight_seq_descriptors_shadow_buf.append(seq_descriptor.seen_tokens)
+        self._inflight_seq_descriptors_shadow_buf.append(0)  # alignment
 
-        self._inflight_seq_descriptors_shadow[self.current_sequences][0] = self.current_tokens
-        self._inflight_seq_descriptors_shadow[self.current_sequences][1] = seq_tokens
-        self._inflight_seq_descriptors_shadow[self.current_sequences][2] = seq_descriptor.seen_tokens
+        self._token_to_seq_storage_shadow_buf.extend([self.current_sequences] * seq_tokens)
 
-        self._kv_ptrs_shadow[self.current_sequences] = seq_descriptor.kv_blocks_ptr
+        self._kv_blocks_ptr_buf.append(seq_descriptor.kv_blocks_ptr)
 
-        self._batch_metadata_storage_shadow[0] += seq_tokens
-        self._batch_metadata_storage_shadow[1] += 1
+        self._current_tokens += seq_tokens
+        self._current_sequences += 1
 
     @property
     def tensor_toks(self) -> torch.Tensor:
@@ -170,6 +181,14 @@ class RaggedBatchWrapper:
         Completes construction of the ragged batch by flushing the host buffers to the device.
         """
         cur_toks = self.current_tokens
+
+        self._inflight_seq_descriptors_shadow.flatten()[:len(self._inflight_seq_descriptors_shadow_buf)].copy_(
+            torch.tensor(self._inflight_seq_descriptors_shadow_buf))
+        self._input_ids_shadow[:self.current_tokens].copy_(torch.cat(self._batch_tokens, dim=0))
+        self._token_to_seq_storage_shadow[:len(self._token_to_seq_storage_shadow_buf)].copy_(
+            torch.tensor(self._token_to_seq_storage_shadow_buf))
+        self._kv_ptrs_shadow[:len(self._kv_blocks_ptr_buf)].copy_(torch.tensor(self._kv_blocks_ptr_buf))
+        self._batch_metadata_storage_shadow.copy_(torch.tensor([cur_toks, self.current_sequences]))
 
         if padding:
             padded_toks = to_padded(cur_toks)
@@ -256,7 +275,7 @@ class RaggedBatchWrapper:
         The number of tokens in the in-flight ragged batch. This will not trigger
         synchronization with the device.
         """
-        return self._batch_metadata_storage_shadow[0].item()
+        return self._current_tokens
 
     @property
     def current_sequences(self) -> int:
@@ -264,4 +283,4 @@ class RaggedBatchWrapper:
         The number of sequences in the in-flight ragged batch. This will not trigger
         synchronization with the device.
         """
-        return self._batch_metadata_storage_shadow[1].item()
+        return self._current_sequences

--- a/tests/unit/inference/test_inference.py
+++ b/tests/unit/inference/test_inference.py
@@ -3,25 +3,33 @@
 
 # DeepSpeed Team
 
+import pytest
+
+import itertools
+import pickle
 import os
 import time
-import pickle
-import torch
-import pytest
-import itertools
+
+from dataclasses import dataclass
+from typing import List
+
 import deepspeed
-from deepspeed.git_version_info import torch_info
-from unit.common import DistributedTest
+import torch
+
+from huggingface_hub import HfApi
 from packaging import version as pkg_version
-from deepspeed.ops.op_builder import OpBuilder
+from torch import nn
 from transformers import pipeline, AutoTokenizer
 from transformers.models.t5.modeling_t5 import T5Block
 from transformers.models.roberta.modeling_roberta import RobertaLayer
-from huggingface_hub import HfApi
-from deepspeed.model_implementations import DeepSpeedTransformerInference
-from torch import nn
+
 from deepspeed.accelerator import get_accelerator
+from deepspeed.git_version_info import torch_info
+from deepspeed.model_implementations import DeepSpeedTransformerInference
 from deepspeed.ops.op_builder import InferenceBuilder
+from deepspeed.ops.op_builder import OpBuilder
+
+from unit.common import DistributedTest
 
 rocm_version = OpBuilder.installed_rocm_version()
 if rocm_version != (0, 0):
@@ -65,14 +73,46 @@ _test_tasks = [
     "text2text-generation", "summarization", "translation"
 ]
 
+
+@dataclass
+class ModelInfo:
+    modelId: str
+    pipeline_tag: str
+    tags: List[str]
+
+
+def _hf_model_list() -> List[ModelInfo]:
+    """ Caches HF model list to avoid repeated API calls """
+
+    cache_dir = os.getenv("TRANSFORMERS_CACHE", "~/.cache/huggingface")
+    cache_file_path = os.path.join(cache_dir, "DS_model_cache.pkl")
+    cache_expiration_seconds = 60 * 60 * 24  # 1 day
+
+    # Load or initialize the cache
+    model_data = {"cache_time": 0, "model_list": []}
+    if os.path.isfile(cache_file_path):
+        with open(cache_file_path, 'rb') as f:
+            model_data = pickle.load(f)
+
+    current_time = time.time()
+
+    # Update the cache if it has expired
+    if (model_data["cache_time"] + cache_expiration_seconds) < current_time:
+        api = HfApi()
+        model_data["model_list"] = [
+            ModelInfo(modelId=m.modelId, pipeline_tag=m.pipeline_tag, tags=m.tags) for m in api.list_models()
+        ]
+        model_data["cache_time"] = current_time
+
+        # Save the updated cache
+        with open(cache_file_path, 'wb') as f:
+            pickle.dump(model_data, f)
+
+    return model_data["model_list"]
+
+
 # Get a list of all models and mapping from task to supported models
-try:
-    with open("hf_models.pkl", "rb") as fp:
-        _hf_models = pickle.load(fp)
-except FileNotFoundError:
-    _hf_models = list(HfApi().list_models())
-    with open("hf_models.pkl", "wb") as fp:
-        pickle.dump(_hf_models, fp)
+_hf_models = _hf_model_list()
 _hf_model_names = [m.modelId for m in _hf_models]
 _hf_task_to_models = {task: [m.modelId for m in _hf_models if m.pipeline_tag == task] for task in _test_tasks}
 


### PR DESCRIPTION
This PR improves efficiency of preprocessing for ragged batching.

It is not efficient to iterate substituting values to tensor slices or copy/fill calls for small numbers of values. This PR records the values in python lists or primitives and copy them at once.