### PR TITLE
Fix bug where ZeRO2 never uses the reduce method.

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1461,7 +1461,6 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     ######################Reduction Related Methods##############################
     def allreduce_bucket(self, bucket, rank=None, log=None, divide=True, process_group=None):
-        rank = None
         tensor = self.flatten(bucket)
 
         process_group = self.dp_process_group if process_group is None else process_group


### PR DESCRIPTION
On this PR https://github.com/microsoft/DeepSpeed/pull/4695, the gradient synchronization operation is moved to the `allreduce_bucket` method, but on this method, rank is set to None, and it will never use the reduce method even if `use_multi_rank_bucket_allreduce` is set to False.