### PR TITLE
[feat] Add Aim monitor

### DIFF
--- a/blogs/deepspeed-chat/ds-chat-release-8-31/README.md
+++ b/blogs/deepspeed-chat/ds-chat-release-8-31/README.md
@@ -304,7 +304,7 @@ To gain better insight into DeepSpeed-Chat training, new [instrumentation featur
 
 
 ### TensorBoard
-TensorBoard logging can be enabled in each of the three training steps, with some slight nuances in Step 3. To start, for each training step, the `enable_tensorboard` argument can be used to enable a TensorBoard monitor at the Runtime Engine level ([see documentation](https://www.deepspeed.ai/docs/config-json/#monitoring-module-tensorboard-wandb-csv)) and is reflected in the corresponding model training configuration:
+TensorBoard logging can be enabled in each of the three training steps, with some slight nuances in Step 3. To start, for each training step, the `enable_tensorboard` argument can be used to enable a TensorBoard monitor at the Runtime Engine level ([see documentation](https://www.deepspeed.ai/docs/config-json/#monitoring-module-aim-tensorboard-wandb-csv)) and is reflected in the corresponding model training configuration:
 ```python
 "tensorboard": {
     "enabled": enable_tensorboard,

--- a/deepspeed/monitor/aim.py
+++ b/deepspeed/monitor/aim.py
@@ -1,0 +1,63 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from .utils import check_aim_availability
+from .monitor import Monitor
+
+import deepspeed.comm as dist
+
+
+class AimMonitor(Monitor):
+    def __init__(self, aim_config):
+        super().__init__(aim_config)
+        check_aim_availability()
+
+        from aim import Run
+
+        self.Run = Run
+
+        self.enabled = aim_config.enabled
+        self.repo = aim_config.repo
+        self.experiment_name = aim_config.experiment_name
+        self.log_system_params = aim_config.log_system_params
+        self.run_name = aim_config.run_name
+        self.run_hash = aim_config.run_hash
+        self.run = None
+
+        if self.enabled and dist.get_rank() == 0:
+            self.experiment()
+            for key in aim_config:
+                self.experiment.set(('hparams', key), aim_config.key, strict=False)
+
+    def write_events(self, event_list):
+        if self.enabled and dist.get_rank() == 0:
+            for event in event_list:
+                label = event[0]
+                value = event[1]
+                step = event[2]
+                self.experiment.track(value, name=label, step=step)
+
+    @property
+    def experiment(self):
+        if self.run is None:
+            if self.run_hash:
+                self.run = self.Run(
+                    self.run_hash,
+                    repo=self._repo_path,
+                    system_tracking_interval=self._system_tracking_interval,
+                    capture_terminal_logs=self._capture_terminal_logs,
+                )
+                if self.run_name is not None:
+                    self.run.name = self.run_name
+            else:
+                self.run = self.Run(
+                    repo=self._repo_path,
+                    experiment=self._experiment_name,
+                    system_tracking_interval=self._system_tracking_interval,
+                    log_system_params=self._log_system_params,
+                    capture_terminal_logs=self._capture_terminal_logs,
+                )
+                self.run_hash = self.run.hash
+        return self.run

--- a/deepspeed/monitor/config.py
+++ b/deepspeed/monitor/config.py
@@ -8,8 +8,30 @@ from deepspeed.runtime.config_utils import DeepSpeedConfigModel
 
 
 def get_monitor_config(param_dict):
-    monitor_dict = {key: param_dict.get(key, {}) for key in ("tensorboard", "wandb", "csv_monitor")}
+    monitor_dict = {key: param_dict.get(key, {}) for key in ("aim", "tensorboard", "wandb", "csv_monitor")}
     return DeepSpeedMonitorConfig(**monitor_dict)
+
+
+class AimConfig(DeepSpeedConfigModel):
+    """Sets parameters for aim monitor."""
+
+    enabled: bool = False
+    """ Whether logging to aim is enabled. Requires `aim` package is installed. """
+
+    repo: str = None
+    """ Path or the url of the repo. """
+
+    experiment_name: str = None
+    """ Name for the experiment. """
+
+    log_system_params: bool = True
+    """ Wether or not log system parameters. """
+
+    run_name: str = None
+    """ Aim run name, for reusing the specified run. """
+
+    run_hash: str = None
+    """ Aim run hash, for reusing the specified run. """
 
 
 class TensorBoardConfig(DeepSpeedConfigModel):
@@ -63,6 +85,9 @@ class CSVConfig(DeepSpeedConfigModel):
 class DeepSpeedMonitorConfig(DeepSpeedConfigModel):
     """Sets parameters for various monitoring methods."""
 
+    aim: AimConfig = {}
+    """ Aim monitor, requires `aim` package is installed. """
+
     tensorboard: TensorBoardConfig = {}
     """ TensorBoard monitor, requires `tensorboard` package is installed. """
 
@@ -74,6 +99,6 @@ class DeepSpeedMonitorConfig(DeepSpeedConfigModel):
 
     @root_validator
     def check_enabled(cls, values):
-        values["enabled"] = values.get("tensorboard").enabled or values.get("wandb").enabled or values.get(
+        values["enabled"] = values.get("aim").enabled or values.get("tensorboard").enabled or values.get("wandb").enabled or values.get(
             "csv_monitor").enabled
         return values

--- a/deepspeed/monitor/utils.py
+++ b/deepspeed/monitor/utils.py
@@ -3,6 +3,15 @@
 
 # DeepSpeed Team
 
+def check_aim_availability():
+    try:
+        import aim  # noqa: F401 # type: ignore
+    except ImportError:
+        print(
+            'If you want to use aim logging, please `pip install aim`'
+        )
+        raise
+
 
 def check_tb_availability():
     try:

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -41,7 +41,7 @@ lnav:
       - title: 'Flops Profiler'
         url: /docs/config-json/#flops-profiler
       - title: 'Monitoring'
-        url: /docs/config-json/#monitoring-module-tensorboard-wandb-csv
+        url: /docs/config-json/#monitoring-module-aim-tensorboard-wandb-csv
       - title: 'Communication Logging'
         url: /docs/config-json/#communication-logging
       - title: 'Model Compression'

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -1139,7 +1139,10 @@ DeepSpeed Data Efficiency Library includes two techniques: curriculum learning a
 | ---------------------------------------------------------------------------------------------------------------------------- | ------- |
 | List of which step to change difficulty level. One of the `schedule_config` when the `fixed_discrete` schedule_type is used. | N/A     |
 
-### Monitoring Module (TensorBoard, WandB, CSV)
+### Monitoring Module (Aim, TensorBoard, WandB, CSV)
+
+**Note:** Logging to Aim requires that the `aim` package is installed (read more in the [Aim documentation](https://aimstack.readthedocs.io/en/latest/)).
+{: .notice--warning}
 
 **Note:** Deepspeed logs to TensorBoard through PyTorch. Logging to TensorBoard requires that the `tensorboard` package is installed (read more in the [PyTorch documentation](https://pytorch.org/docs/1.8.0/tensorboard.html)).
 {: .notice--warning}
@@ -1147,7 +1150,7 @@ DeepSpeed Data Efficiency Library includes two techniques: curriculum learning a
 {: .notice--warning}
 
 
-Deepspeed's Monitor module can log training details into a [Tensorboard](https://www.tensorflow.org/tensorboard)-compatible file, to [WandB](https://wandb.ai/site), or to simple CSV files. Below is an overview of what DeepSpeed will log automatically.
+Deepspeed's Monitor module can log training details into a [Aim](https://aimstack.readthedocs.io/en/latest/), [Tensorboard](https://www.tensorflow.org/tensorboard)-compatible file, to [WandB](https://wandb.ai/site), or to simple CSV files. Below is an overview of what DeepSpeed will log automatically.
 
 | Field | Description                                                                                                                                                                                                                                                                                               |Conditions |
 | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
@@ -1160,6 +1163,33 @@ Deepspeed's Monitor module can log training details into a [Tensorboard](https:/
 | `Train/Samples/elapsed_time_ms_backward_inner`   | The backward time that does not include the gradient reduction time. Only in cases where the gradient reduction is not overlapped, if it is overlapped then the inner time should be about the same as the entire backward time. | `flops_profiler.enabled` or `wall_clock_breakdown`.  |
 | `Train/Samples/elapsed_time_ms_backward_allreduce`   | The global duration of the allreduce operation. | `flops_profiler.enabled` or `wall_clock_breakdown`.  |
 | `Train/Samples/elapsed_time_ms_step`   | The optimizer step time | `flops_profiler.enabled` or `wall_clock_breakdown`.  |
+
+
+
+<i>**aim**</i>: [dictionary]
+
+| Fields | Value                                                                                                                                                                                                                                                                                                        |Default |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| enabled   | Whether logging to [Aim](https://aimstack.readthedocs.io/en/latest/) is enabled. | `false` |
+| repo | Path or the url of the Aim repo. If None, the output path is set under the current directory.     | `None` |
+| experiment_name  | Name for the experiment. | `None` |
+| log_system_params  | Wether or not log system parameters. | `true` |
+| run_name  | Aim run name, for reusing the specified run. | `None` |
+| run_hash  | Aim run hash, for reusing the specified run. | `None` |
+
+
+Example of <i>**aim**</i> configuration:
+
+```json
+"aim": {
+    "enabled": True,
+    "repo": "./",
+    "experiment_name": "test_experiment",
+    "log_system_params": False
+}
+```
+
+
 
 <i>**tensorboard**</i>: [dictionary]
 

--- a/docs/_pages/training.md
+++ b/docs/_pages/training.md
@@ -513,10 +513,16 @@ The flops profiler can also be used as a standalone package. Please refer to the
 
 ### Monitor
 
-The DeepSpeed Monitor logs live training metrics to one or more monitoring backends, including PyTorch's [TensorBoard](https://pytorch.org/docs/1.8.0/tensorboard.html), [WandB](https://docs.wandb.ai/quickstart), or simply to CSV files. The Monitor can be configured with one or more backends in the `deepspeed_config` file as follows:
+The DeepSpeed Monitor logs live training metrics to one or more monitoring backends, including [Aim](https://aimstack.readthedocs.io/en/latest/), PyTorch's [TensorBoard](https://pytorch.org/docs/1.8.0/tensorboard.html), [WandB](https://docs.wandb.ai/quickstart), or simply to CSV files. The Monitor can be configured with one or more backends in the `deepspeed_config` file as follows:
 
 ```json
 {
+  "aim": {
+    "enabled": true,
+    "repo": "./",
+    "experiment_name": "test_experiment",
+    "log_system_params": false
+  }
   "tensorboard": {
     "enabled": true,
     "output_path": "output/ds_logs/",

--- a/docs/_tutorials/monitor.md
+++ b/docs/_tutorials/monitor.md
@@ -11,7 +11,12 @@ In this tutorial, we introduce the DeepSpeed Monitor and provide examples of its
 
 ## Overview
 
-Monitoring model and system metrics during training is vital to ensure hardware resources are fully utilized. The DeepSpeed Monitor enables live logging of metrics through one or more monitoring backends such as PyTorch's [TensorBoard](https://pytorch.org/docs/1.8.0/tensorboard.html), [WandB](https://docs.wandb.ai/quickstart), and simple CSV files.
+Monitoring model and system metrics during training is vital to ensure hardware resources are fully utilized. The DeepSpeed Monitor enables live logging of metrics through one or more monitoring backends such as [Aim](https://aimstack.readthedocs.io/en/latest/), PyTorch's [TensorBoard](https://pytorch.org/docs/1.8.0/tensorboard.html), [WandB](https://docs.wandb.ai/quickstart), and simple CSV files.
+
+Below is a live monitoring view for Aim:
+
+<!-- TODO add the aim_monitor.PNG file  -->
+![Aim Example Output](/assets/images/aim_monitor.PNG){: .align-center}
 
 Below is a live monitoring view for TensorBoard:
 
@@ -23,17 +28,23 @@ Below is a live monitoring view for WandB:
 
 ## Usage
 
-The DeepSpeed Monitor is configured within the deepspeed [configuration file](/docs/config-json/#monitoring-module-tensorboard-wandb-csv). DeepSpeed will automatically monitor key training metrics, including those tracked with the `wall_clock_breakdown` configuration option. In addition, users can log their own custom events and metrics.
+The DeepSpeed Monitor is configured within the deepspeed [configuration file](/docs/config-json/#monitoring-module-aim-tensorboard-wandb-csv). DeepSpeed will automatically monitor key training metrics, including those tracked with the `wall_clock_breakdown` configuration option. In addition, users can log their own custom events and metrics.
 
   - [Automatic Monitoring](#automatic-monitoring)
   - [Custom Monitoring](#custom-monitoring)
 
 ### Automatic Monitoring
 
-When using DeepSpeed for model training, the Monitor can be configured in the DeepSpeed [configuration file](/docs/config-json/#monitoring-module-tensorboard-wandb-csv). No explicit API calls are needed to use the Monitor. The Monitor can be enabled by adding the following field to DeepSpeed's configuration json file. Refer to [Monitoring](/docs/config-json/#monitoring-module-tensorboard-wandb-csv) for details.
+When using DeepSpeed for model training, the Monitor can be configured in the DeepSpeed [configuration file](/docs/config-json/#monitoring-module-aim-tensorboard-wandb-csv). No explicit API calls are needed to use the Monitor. The Monitor can be enabled by adding the following field to DeepSpeed's configuration json file. Refer to [Monitoring](/docs/config-json/#monitoring-module-aim-tensorboard-wandb-csv) for details.
 
 ```json
 {
+  "aim": {
+    "enabled": true,
+    "repo": "./",
+    "experiment_name": "test_experiment",
+    "log_system_params": false
+  }
   "tensorboard": {
     "enabled": true,
     "output_path": "output/ds_logs/",
@@ -60,7 +71,7 @@ DeepSpeed will automatically log to all available and enabled monitoring backend
 In addition to automatic monitoring, users can log their own custom metrics in client scripts. Currently, there are two ways to initialize Monitor objects:
 
 1. (Recommended) - Create a `MonitorMaster(ds_config.monitor_config)` object, which automatically initializes all monitor backends present in the DeepSpeed configuration
-2. Create a specific `TensorBoardMonitor(ds_config.monitor_config)`, `WandbMonitor(ds_config.monitor_config)`, `csvMonitor(ds_config.monitor_config)` object which will only initialize a specific monitor backend present in the DeepSpeed configuration
+2. Create a specific `AimMonitor(ds_config.monitor_config)` `TensorBoardMonitor(ds_config.monitor_config)`, `WandbMonitor(ds_config.monitor_config)`, `csvMonitor(ds_config.monitor_config)` object which will only initialize a specific monitor backend present in the DeepSpeed configuration
 
 
 The steps to create a custom monitor are as follows:

--- a/docs/code-docs/source/monitor.rst
+++ b/docs/code-docs/source/monitor.rst
@@ -2,7 +2,7 @@ Monitoring
 ==========
 
 Deepspeed’s Monitor module can log training details into a
-Tensorboard-compatible file, to WandB, or to simple CSV files. Below is an
+Aim, Tensorboard-compatible file, to WandB, or to simple CSV files. Below is an
 overview of what DeepSpeed will log automatically.
 
 .. csv-table:: Automatically Logged Data
@@ -18,6 +18,11 @@ overview of what DeepSpeed will log automatically.
     `Train/Samples/elapsed_time_ms_backward_inner`,The backward time that does not include the gradient reduction time. Only in cases where the gradient reduction is not overlapped, if it is overlapped then the inner time should be about the same as the entire backward time.,`flops_profiler.enabled` or `wall_clock_breakdown`.
     `Train/Samples/elapsed_time_ms_backward_allreduce`,The global duration of the allreduce operation.,`flops_profiler.enabled` or `wall_clock_breakdown`.
     `Train/Samples/elapsed_time_ms_step`,The optimizer step time,`flops_profiler.enabled` or `wall_clock_breakdown`.
+
+Aim
+-----------
+.. _AimConfig:
+.. autopydantic_model:: deepspeed.monitor.config.AimConfig
 
 TensorBoard
 -----------

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -17,4 +17,5 @@ sphinx-rtd-theme
 tensorboard
 torchvision
 transformers>=4.32.1
+aim
 wandb

--- a/tests/unit/monitor/test_monitor.py
+++ b/tests/unit/monitor/test_monitor.py
@@ -3,6 +3,7 @@
 
 # DeepSpeed Team
 
+from deepspeed.monitor.aim import AimMonitor
 from deepspeed.monitor.tensorboard import TensorBoardMonitor
 from deepspeed.monitor.wandb import WandbMonitor
 from deepspeed.monitor.csv_monitor import csvMonitor
@@ -10,6 +11,39 @@ from deepspeed.monitor.config import DeepSpeedMonitorConfig
 
 from unit.common import DistributedTest
 from deepspeed.runtime.config import DeepSpeedConfig
+
+
+
+class TestAim(DistributedTest):
+    world_size = 2
+
+    def test_aim(self):
+        config_dict = {
+            "train_batch_size": 2,
+            "aim": {
+                "enabled": True,
+                "repo": "./",
+                "experiment_name": "test_experiment",
+                "log_system_params": False
+            }
+        }
+        ds_config = DeepSpeedConfig(config_dict)
+        aim_monitor = AimMonitor(ds_config.monitor_config.aim)
+
+        assert aim_monitor.enabled == True
+        assert aim_monitor.repo == "./"
+        assert aim_monitor.experiment_name == "test_experiment"
+        assert aim_monitor.log_system_params == False
+
+    def test_empty_aim(self):
+        config_dict = {"train_batch_size": 2, "aim": {}}
+        ds_config = DeepSpeedConfig(config_dict)
+        aim_monitor = AimMonitor(ds_config.monitor_config.aim)
+        defaults = DeepSpeedMonitorConfig().aim
+        assert aim_monitor.enabled == defaults.enabled
+        assert aim_monitor.repo == defaults.repo
+        assert aim_monitor.experiment_name == defaults.experiment_name
+        assert aim_monitor.log_system_params == defaults.log_system_params
 
 
 class TestTensorBoard(DistributedTest):


### PR DESCRIPTION
Introducing AimMonitor, a new wrapper for [Aim](https://github.com/aimhubio/aim)  that helps track experiment metadata and events. This pull request includes:

- [x] AimMonitor creation
- [x] Documentation update
- [ ] Testing

These changes enhance experiment monitoring, making it more transparent and user-friendly.