### PR TITLE
[docs] Add new autotp supported model in tutorial

### DIFF
--- a/docs/_tutorials/automatic-tensor-parallelism.md
+++ b/docs/_tutorials/automatic-tensor-parallelism.md
@@ -121,6 +121,7 @@ The following results were collected using V100 SXM2 32GB GPUs.
 The following model families have been successfully tested with automatic tensor parallelism. Other models may work but have not been tested yet.
 
 - albert
+- baichuan
 - bert
 - bigbird_pegasus
 - bloom
@@ -130,6 +131,7 @@ The following model families have been successfully tested with automatic tensor
 - electra
 - ernie
 - esm
+- falcon
 - glm
 - gpt-j
 - gpt-neo
@@ -137,6 +139,7 @@ The following model families have been successfully tested with automatic tensor
 - longt5
 - luke
 - llama
+- llama2
 - m2m_100
 - marian
 - mpt
@@ -147,10 +150,12 @@ The following model families have been successfully tested with automatic tensor
 - pegasus
 - perceiver
 - plbart
+- qwen
 - reformer
 - roberta
 - roformer
 - splinter
+- starcode
 - t5
 - xglm
 - xlm_roberta

--- a/docs/_tutorials/automatic-tensor-parallelism.md
+++ b/docs/_tutorials/automatic-tensor-parallelism.md
@@ -127,6 +127,7 @@ The following model families have been successfully tested with automatic tensor
 - bloom
 - camembert
 - codegen
+- codellama
 - deberta_v2
 - electra
 - ernie
@@ -142,6 +143,7 @@ The following model families have been successfully tested with automatic tensor
 - llama2
 - m2m_100
 - marian
+- mistral
 - mpt
 - mvp
 - nezha


### PR DESCRIPTION
This PR refresh the list of models supported by AutoTP.  Newly added models are:
- baichuan
- codellama
- falcon
- llama2
- mistral
- qwen
- starcode