### PR TITLE
Prevent infinite recursion when DS_ACCELERATOR is set to cuda

### DIFF
--- a/accelerator/real_accelerator.py
+++ b/accelerator/real_accelerator.py
@@ -98,7 +98,7 @@ def get_accelerator():
             except ImportError as e:
                 raise ValueError(
                     f"HPU_Accelerator requires habana_frameworks.torch.hpu, which is not installed on this system.")
-        elif is_current_accelerator_supported():
+        elif accelerator_name not in SUPPORTED_ACCELERATOR_LIST:
             raise ValueError(f'DS_ACCELERATOR must be one of {SUPPORTED_ACCELERATOR_LIST}. '
                              f'Value "{accelerator_name}" is not supported')
         ds_set_method = "override"


### PR DESCRIPTION
When DS_ACCELERATOR is overriden to CUDA, `get_accelerator` attempts to check if `is_current_accelerator_supported`. But since that calls `get_accelerator` again and `ds_accelerator` has not been initialized, DeepSpeed runs into infinite recursion.

```
    elif is_current_accelerator_supported():
  File "/usr/local/lib/python3.8/dist-packages/deepspeed/accelerator/real_accelerator.py", line 48, in is_current_accelerator_supported
    return get_accelerator().device_name() in SUPPORTED_ACCELERATOR_LIST
  File "/usr/local/lib/python3.8/dist-packages/deepspeed/accelerator/real_accelerator.py", line 101, in get_accelerator
    elif is_current_accelerator_supported():
  File "/usr/local/lib/python3.8/dist-packages/deepspeed/accelerator/real_accelerator.py", line 48, in is_current_accelerator_supported
    return get_accelerator().device_name() in SUPPORTED_ACCELERATOR_LIST
  File "/usr/local/lib/python3.8/dist-packages/deepspeed/accelerator/real_accelerator.py", line 101, in get_accelerator
    elif is_current_accelerator_supported():
  File "/usr/local/lib/python3.8/dist-packages/deepspeed/accelerator/real_accelerator.py", line 48, in is_current_accelerator_supported
    return get_accelerator().device_name() in SUPPORTED_ACCELERATOR_LIST
  File "/usr/local/lib/python3.8/dist-packages/deepspeed/accelerator/real_accelerator.py", line 101, in get_accelerator
    elif is_current_accelerator_supported():
  File "/usr/local/lib/python3.8/dist-packages/deepspeed/accelerator/real_accelerator.py", line 48, in is_current_accelerator_supported
    return get_accelerator().device_name() in SUPPORTED_ACCELERATOR_LIST
  File "/usr/local/lib/python3.8/dist-packages/deepspeed/accelerator/real_accelerator.py", line 59, in get_accelerator
    if "DS_ACCELERATOR" in os.environ.keys():
  File "/usr/lib/python3.8/_collections_abc.py", line 717, in __contains__
    return key in self._mapping
  File "/usr/lib/python3.8/_collections_abc.py", line 666, in __contains__
    self[key]
  File "/usr/lib/python3.8/os.py", line 672, in __getitem__
    value = self._data[self.encodekey(key)]
RecursionError: maximum recursion depth exceeded
```

This change fixes that by comparing the accelerator directly with the supported list of accelerators.