### PR TITLE
Enhance query APIs for text generation

### DIFF
--- a/deepspeed/inference/v2/engine_v2.py
+++ b/deepspeed/inference/v2/engine_v2.py
@@ -104,7 +104,7 @@ class InferenceEngineV2:
         ranks = list(range(self._config.tensor_parallel.tp_size))
         return dist.new_group(ranks=ranks)
 
-    def put(self, batch_uids: Iterable[int], batch_tokens: Iterable[torch.Tensor], skip_check=False) -> torch.Tensor:
+    def put(self, batch_uids: Iterable[int], batch_tokens: Iterable[torch.Tensor], do_checks=True) -> torch.Tensor:
         """
         Put a ragged batch onto the inference engine. This will perform one forward and return
         a Tensor of the shape [len(batch_uids), *output_shape]. Logits for the non-final tokens
@@ -129,7 +129,7 @@ class InferenceEngineV2:
             host_seq_desc.pre_forward(tokens.numel())
 
             # We can disable checks since we already validated schedulability.
-            self._batch.insert_sequence(host_seq_desc, tokens, do_checks=False)
+            self._batch.insert_sequence(host_seq_desc, tokens, do_checks=do_checks)
 
         # Send all metadata to the device
         self._batch.finalize()

--- a/deepspeed/inference/v2/engine_v2.py
+++ b/deepspeed/inference/v2/engine_v2.py
@@ -115,7 +115,7 @@ class InferenceEngineV2:
             batch_tokens: Iterable of token tensors for the batch on the host
         """
 
-        if not skip_check:
+        if do_checks:
             token_lens = [len(tokens) for tokens in batch_tokens]
             schedule_check = self.can_schedule(batch_uids, token_lens)
             if schedule_check != SchedulingResult.Success:

--- a/deepspeed/inference/v2/engine_v2.py
+++ b/deepspeed/inference/v2/engine_v2.py
@@ -225,6 +225,15 @@ class InferenceEngineV2:
 
         return SchedulingResult.Success
 
+    def get_remaining_block_capacity(self, uid: int) -> int:
+        """
+        Get the remaining capacity of the last block already allocated.
+        """
+        seq_desc = self._state_manager.get_sequence(uid)
+        if seq_desc is None:
+            return 0
+        return self._model.get_remaining_block_capacity(seq_desc)
+
     def flush(self, uid: int) -> None:
         """
         Remove all state associated with a sequence from the inference engine.

--- a/deepspeed/inference/v2/model_implementations/inference_model_base.py
+++ b/deepspeed/inference/v2/model_implementations/inference_model_base.py
@@ -200,6 +200,10 @@ class DSInferenceModelBase(torch.nn.Module, ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def get_remaining_block_capacity(self, sequence: DSSequenceDescriptor) -> int:
+        raise NotImplementedError()
+
+    @abstractmethod
     def maybe_allocate_kv(self, sequence: DSSequenceDescriptor, n_new_tokens: int) -> None:
         """
         Given a sequence and the number of new tokens in the sequence, determine

--- a/deepspeed/inference/v2/model_implementations/inference_transformer_base.py
+++ b/deepspeed/inference/v2/model_implementations/inference_transformer_base.py
@@ -334,7 +334,7 @@ class DSTransformerModelBase(DSInferenceModelBase):
         self.attn = heuristics.instantiate_attention(attn_config, self._engine_config)
 
     def get_kv_requirements(self, sequence: DSSequenceDescriptor, max_new_tokens: int,
-                            max_new_blocks: int) -> Tuple[int, torch.Tensor]:
+                            max_new_blocks: int) -> Tuple[int, int]:
         """
         See ``DSInferenceModelBase.get_kv_requirements`` for documentation.
 
@@ -351,7 +351,7 @@ class DSTransformerModelBase(DSInferenceModelBase):
         token_capacity = (max_new_blocks +
                           sequence.cur_allocated_blocks) * self.attn.kv_block_size - sequence.seen_tokens
 
-        return token_capacity, torch.tensor([max_new_blocks])
+        return token_capacity, max_new_blocks
 
     def get_remaining_block_capacity(self, sequence: DSSequenceDescriptor) -> int:
         return sequence.seen_tokens % self.attn.kv_block_size
@@ -363,7 +363,8 @@ class DSTransformerModelBase(DSInferenceModelBase):
         This method assumes an autoregressive dense attention pattern. Override this method
         if this does not match the model's attention pattern.
         """
-        _, n_needed_blocks = self.get_kv_requirements(sequence, n_new_tokens, self.state_manager.free_blocks)
+        free_block = self.state_manager.free_blocks[0]
+        _, n_needed_blocks = self.get_kv_requirements(sequence, n_new_tokens, free_block)
 
         if n_needed_blocks > 0:
             new_blocks = self.state_manager.allocate_blocks(n_needed_blocks)

--- a/deepspeed/inference/v2/model_implementations/inference_transformer_base.py
+++ b/deepspeed/inference/v2/model_implementations/inference_transformer_base.py
@@ -353,6 +353,9 @@ class DSTransformerModelBase(DSInferenceModelBase):
 
         return token_capacity, torch.tensor([max_new_blocks])
 
+    def get_remaining_block_capacity(self, sequence: DSSequenceDescriptor) -> int:
+        return sequence.seen_tokens % self.attn.kv_block_size
+
     def maybe_allocate_kv(self, sequence: DSSequenceDescriptor, n_new_tokens: int) -> None:
         """
         See ``DSInferenceModelBase.maybe_allocate_kv`` for documentation.

--- a/deepspeed/inference/v2/ragged/kv_cache.py
+++ b/deepspeed/inference/v2/ragged/kv_cache.py
@@ -140,9 +140,6 @@ class BlockedKVCache:
 
         self._caches = tuple(caches)
         self._allocators = tuple(allocators)
-        self._free_blocks = torch.empty(len(self._allocators), dtype=torch.int32, device="cpu")
-        for i, allocator in enumerate(self._allocators):
-            self._free_blocks[i] = allocator.free_blocks
 
     def reserve(self, num_blocks: int, cache_group: int = 0) -> torch.Tensor:
         """
@@ -201,9 +198,7 @@ class BlockedKVCache:
         """
         Return the number of free blocks in each cache
         """
-        for i, allocator in enumerate(self._allocators):
-            self._free_blocks[i] = allocator.free_blocks
-        return self._free_blocks
+        return [allocator.free_blocks for allocator in self._allocators]
 
     @property
     def num_caches(self) -> int:

--- a/deepspeed/inference/v2/ragged/sequence_descriptor.py
+++ b/deepspeed/inference/v2/ragged/sequence_descriptor.py
@@ -168,7 +168,9 @@ class DSSequenceDescriptor(BaseSequenceDescriptor):
         Arguments:
             cache_group (int): The cache group to query.
         """
-        return self._blocks_per_allocation_group[cache_group].sum()
+        if len(self._blocks_per_allocation_group) == 1:
+            return self._blocks_per_allocation_group[0].item()
+        return self._blocks_per_allocation_group[cache_group].sum().item()
 
     def kv_cache_ids(self, cache_group: int = 0, on_device: bool = False) -> torch.Tensor:
         """


### PR DESCRIPTION
This PR was authored to improve efficiency using DeepSpeed-FastGen.
DeepSpeed-FastGen queries states of KV cache very frequently. Thus, this PR adds an API for the query and improves the efficiency of some query APIs.
This PR also allows skipping the schedulability check in case it is already checked.