### PR TITLE
fix for DS_ENV issue

### DIFF
--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -552,10 +552,7 @@ def main(args=None):
                     runner.add_export(var, env[var])
 
         for environ_path in DEEPSPEED_ENVIRONMENT_PATHS:
-            environ_file = DEEPSPEED_ENVIRONMENT_NAME
-            # handle if users to enter path for `DS_ENV_FILE`
-            if not os.path.isfile(environ_file):
-                environ_file = os.path.join(environ_path, DEEPSPEED_ENVIRONMENT_NAME)
+            environ_file = os.path.join(environ_path, DEEPSPEED_ENVIRONMENT_NAME)
             if os.path.isfile(environ_file):
                 logger.info(f"deepspeed_env file = {environ_file}")
                 with open(environ_file, 'r') as fd:


### PR DESCRIPTION
When there exist two `.deepspeed_env` files (e.g., at `~/.deepspeed_env` and `./.deepspeed_env`), only the local version will be read and used. The behavior changed with the support of `$DS_ENV` (https://github.com/microsoft/DeepSpeed/pull/4006). This PR allows multuple `.deepspeed_env` files from all the `DEEPSPEED_ENVIRONMENT_PATHS` paths to be read and used when launching.