### PR TITLE
[minor] Improve logging for multiprocesses

### DIFF
--- a/deepspeed/launcher/launch.py
+++ b/deepspeed/launcher/launch.py
@@ -249,7 +249,8 @@ def main():
                 process = subprocess.Popen(cmd, env=current_env, stdout=log_fd, stderr=log_fd)
             else:
                 process = subprocess.Popen(cmd, env=current_env)
-
+            # logs the command from processes
+            logger.info(f"process {process.pid} spawned with command: {cmd}")
             processes.append(process)
     else:
         from ..elasticity import DSElasticAgent

--- a/deepspeed/utils/groups.py
+++ b/deepspeed/utils/groups.py
@@ -508,7 +508,7 @@ def _create_zero_param_parallel_group(group_size):
 
         Example - ZP + D parallel
         world_size = 16
-        zero_hpz_partition_size = 2 # number of ranks with with replicated params (dual partitioning)
+        zero_hpz_partition_size = 2 # number of ranks with replicated params (dual partitioning)
         zero_param_intra_parallel_group = [0, 1], [2,3], [4,5], [6,7], [8,9] - segmented (subgroup) with rep partition
         data_parallel_group = [0,1,...,15] - all reduce is on ZeRO model
     """

--- a/deepspeed/utils/logging.py
+++ b/deepspeed/utils/logging.py
@@ -34,7 +34,7 @@ class LoggerFactory:
         if name is None:
             raise ValueError("name for logger cannot be None")
 
-        formatter = logging.Formatter("[%(asctime)s] [%(levelname)s] "
+        formatter = logging.Formatter("[PID %(process)d] [%(asctime)s] [%(levelname)s] "
                                       "[%(filename)s:%(lineno)d:%(funcName)s] %(message)s")
 
         logger_ = logging.getLogger(name)

--- a/deepspeed/utils/logging.py
+++ b/deepspeed/utils/logging.py
@@ -34,7 +34,7 @@ class LoggerFactory:
         if name is None:
             raise ValueError("name for logger cannot be None")
 
-        formatter = logging.Formatter("[PID %(process)d] [%(asctime)s] [%(levelname)s] "
+        formatter = logging.Formatter("[%(asctime)s] [%(levelname)s] "
                                       "[%(filename)s:%(lineno)d:%(funcName)s] %(message)s")
 
         logger_ = logging.getLogger(name)


### PR DESCRIPTION
**Why?**
1. When the launcher starts multi-processes, there is no logs to show what cmd each process is running
2. A small typo

**What?**
add logs to reflect what each process is doing

**Testing**

![image](https://github.com/microsoft/DeepSpeed/assets/24364830/2d74c852-244b-4439-b558-76b0bb73906a)

