### PR TITLE
Update falcon fused type order

### DIFF
--- a/deepspeed/module_inject/fusedqkv_utils.py
+++ b/deepspeed/module_inject/fusedqkv_utils.py
@@ -39,10 +39,10 @@ def prepare_tp_fused_qkvw(module, src, mp_size, gpu_index):
         "MPTBlock": 'glmtype',
         "MptBlock": 'glmtype',
         "BaichuanLayer": 'glmtype',
-        "DecoderLayer": 'glmtype',
         "QWenBlock": 'qwentype',
         "FalconDecoderLayer": 'bloomtype',
         "GPTBigCodeBlock": 'bigcodetype',
+        "DecoderLayer": 'glmtype',
     }
 
     def _codegen_type_transpose(input, mp_size, codegen_mp_num=4):


### PR DESCRIPTION
The selection of fused type depends on the order of fused_type_dict.
If put “DecoderLayer” in front of “FalconDecoderLayer”, Falcon will still choose glmtype incorrectly, so need to put “DecoderLayer at” the last position of fused_type_dict.