### PR TITLE
Enable workflow dispatch on all workflows

### DIFF
--- a/.github/workflows/amd-mi200.yml
+++ b/.github/workflows/amd-mi200.yml
@@ -1,9 +1,9 @@
 name: amd-mi200
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cpu-inference.yml
+++ b/.github/workflows/cpu-inference.yml
@@ -1,6 +1,7 @@
 name: cpu-inference
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - '.github/workflows/cpu-inference.yml'
@@ -10,7 +11,6 @@ on:
       - '!deepspeed/inference/v2/**' # exclude v2 dir
       - 'tests/unit/inference/**'
       - '!tests/unit/inference/v2/**' # exclude v2 tests dir
-  workflow_dispatch:
   merge_group:
     branches: [ master ]
   schedule:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,6 +1,7 @@
 name: Formatting
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       '**'

--- a/.github/workflows/nv-accelerate-v100.yml
+++ b/.github/workflows/nv-accelerate-v100.yml
@@ -1,6 +1,7 @@
 name: nv-accelerate-v100
 
 on:
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/nv-h100.yml
+++ b/.github/workflows/nv-h100.yml
@@ -1,9 +1,9 @@
 name: nv-h100
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -1,6 +1,7 @@
 name: nv-inference
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - '.github/workflows/nv-inference.yml'

--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -1,6 +1,7 @@
 name: nv-lightning-v100
 
 on:
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/nv-megatron.yml
+++ b/.github/workflows/nv-megatron.yml
@@ -1,6 +1,7 @@
 name: nv-megatron
 
 on:
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/nv-mii.yml
+++ b/.github/workflows/nv-mii.yml
@@ -1,6 +1,7 @@
 name: nv-mii
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - '.github/workflows/nv-mii.yml'

--- a/.github/workflows/nv-pre-compile-ops.yml
+++ b/.github/workflows/nv-pre-compile-ops.yml
@@ -1,6 +1,7 @@
 name: nv-pre-compile-ops
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       '**'

--- a/.github/workflows/nv-sd.yml
+++ b/.github/workflows/nv-sd.yml
@@ -1,9 +1,9 @@
 name: nv-sd
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * 0"
-  workflow_dispatch:
   pull_request:
     paths:
       - "deepspeed/ops/transformer/inference/diffusers_**"

--- a/.github/workflows/nv-torch-latest-cpu.yml
+++ b/.github/workflows/nv-torch-latest-cpu.yml
@@ -1,6 +1,7 @@
 name: nv-torch-latest-cpu
 
 on:
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -1,6 +1,7 @@
 name: nv-torch-latest-v100
 
 on:
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -1,6 +1,7 @@
 name: nv-torch-nightly-v100
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/nv-torch110-p40.yml
+++ b/.github/workflows/nv-torch110-p40.yml
@@ -1,9 +1,9 @@
 name: nv-torch110-p40
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/nv-torch110-v100.yml
+++ b/.github/workflows/nv-torch110-v100.yml
@@ -1,9 +1,9 @@
 name: nv-torch110-v100
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,6 +1,7 @@
 name: python
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       '**'


### PR DESCRIPTION
Enable `workflow_dispatch:` on all workflows where we did not have it previously. This allows us to run the workflows on branches without creating a PR or without needing to merge to master to see the results of CI/scheduled builds.