### PR TITLE
Fix for nightly torch CI

### DIFF
--- a/deepspeed/runtime/zero/mics.py
+++ b/deepspeed/runtime/zero/mics.py
@@ -42,8 +42,9 @@ class MiCS_AllGatherCoalescedHandle(AllGatherCoalescedHandle):
         """
         # let the current stream to op
         try:
+            print("HANDLE", self.allgather_handle)
             instrument_w_nvtx(self.allgather_handle.wait)()
-        except RuntimeError as e:
+        except (ValueError, RuntimeError) as e:
             log_dist(
                 f"WARNING: Runtime Error while waiting the collective all-gather, possibly due to the _IllegalWork",
                 ranks=[0])


### PR DESCRIPTION
As noted in #4792, the coalesced allgather with MiCS enabled can sometimes trigger an `_IllegalWorker` error. The latest version of torch changes this from a `RuntimeError` to `ValueError`. Updating the try...except block to catch this.

Nightly workflow: https://github.com/microsoft/DeepSpeed/actions/runs/7718830548/job/21040895738