### PR TITLE
launcher_helper: enable fds passing

### DIFF
--- a/deepspeed/launcher/launcher_helper.py
+++ b/deepspeed/launcher/launcher_helper.py
@@ -100,7 +100,7 @@ def main(args=None):
 
     logger.info(f"launcher_helper cmd = {' '.join(cmd)}")
 
-    result = subprocess.Popen(cmd, env=env)
+    result = subprocess.Popen(cmd, env=env, close_fds=False)
     result.wait()
 
 


### PR DESCRIPTION
This PR is to enable file descriptor passing in launcher helper, otherwise sometimes it would trigger pmi init failed.