### PR TITLE
MoE type hints

### DIFF
--- a/deepspeed/moe/experts.py
+++ b/deepspeed/moe/experts.py
@@ -3,33 +3,36 @@
 
 # DeepSpeed Team
 
-import torch
 import copy
+from typing import List, Optional
+
+import torch
+from torch import nn
 
 
-class Experts(torch.nn.Module):
+class Experts(nn.Module):
 
-    def __init__(self, expert, num_local_experts=1, expert_group_name=None):
+    def __init__(self, expert: nn.Module, num_local_experts: int = 1, expert_group_name: Optional[str] = None) -> None:
         super(Experts, self).__init__()
 
-        self.deepspeed_experts = torch.nn.ModuleList([copy.deepcopy(expert) for i in range(num_local_experts)])
+        self.deepspeed_experts = nn.ModuleList([copy.deepcopy(expert) for _ in range(num_local_experts)])
         self.num_local_experts = num_local_experts
 
         # TODO: revisit allreduce for moe.gate...
         for expert in self.deepspeed_experts:
             # TODO: Create param groups to handle expert + data case (e.g. param.group = moe_group)
-            for name, param in expert.named_parameters():
+            for param in expert.parameters():
                 param.allreduce = False
                 param.group_name = expert_group_name
 
-    def forward(self, inputs):
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
         chunks = inputs.chunk(self.num_local_experts, dim=1)
-        expert_outputs = []
+        expert_outputs: List[torch.Tensor] = []
+
         for chunk, expert in zip(chunks, self.deepspeed_experts):
             out = expert(chunk)
-            if type(out) is tuple:
+            if isinstance(out, tuple):
                 out = out[0]  # Ignore the bias term for now
             expert_outputs += [out]
 
-        expert_output = torch.cat(expert_outputs, dim=1)
-        return expert_output
+        return torch.cat(expert_outputs, dim=1)

--- a/deepspeed/moe/utils.py
+++ b/deepspeed/moe/utils.py
@@ -3,16 +3,19 @@
 
 # DeepSpeed Team
 
-from typing import List, Tuple, Dict
+from typing import Any, Dict, List, Set, Tuple, Union, cast
+
 import torch
+from torch import nn
+
 from .layer import MoE
 
 
-def has_moe_layers(m):
+def has_moe_layers(m: nn.Module) -> Tuple[bool, int]:
     has_moe = False
     num_experts = 0
 
-    for _, module in m.named_modules():
+    for module in m.modules():
         if isinstance(module, MoE):
             has_moe = True
             num_experts = module.num_experts
@@ -27,8 +30,10 @@ def is_moe_param(param: torch.Tensor) -> bool:
 
 
 def split_params_into_shared_and_expert_params(
-        params: List[torch.nn.Parameter]) -> Tuple[torch.nn.Parameter, torch.nn.Parameter]:
-    shared_params, expert_params = [], []
+        params: List[torch.nn.Parameter]) -> Tuple[List[torch.nn.Parameter], List[torch.nn.Parameter]]:
+    shared_params: List[nn.Parameter] = []
+    expert_params: List[nn.Parameter] = []
+
     for p in params:
         if is_moe_param(p):
             expert_params.append(p)
@@ -38,7 +43,7 @@ def split_params_into_shared_and_expert_params(
 
 
 def split_params_grads_into_shared_and_expert_params(
-        group: List[torch.nn.Parameter]) -> Tuple[torch.nn.Parameter, torch.nn.Parameter]:
+        group: List[torch.nn.Parameter]) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
     """Split grad of parameters into grads of non-expert params
     and grads of expert params. This is useful while computing
     grad-norms for clipping and overflow detection
@@ -48,11 +53,12 @@ def split_params_grads_into_shared_and_expert_params(
             The group of parameters to split
 
     Returns:
-        Tuple[List[torch.nn.Parameter], List[torch.nn.Parameter]]:
+        Tuple[List[torch.Tensor], List[torch.Tensor]]:
         list of gradients for non MoE params, list of gradients of MoE params
     """
-    expert_grads = []
-    shared_grads = []
+    expert_grads: List[torch.Tensor] = []
+    shared_grads: List[torch.Tensor] = []
+
     for p in group:
         if p.grad is not None:
             if is_moe_param(p):
@@ -62,16 +68,18 @@ def split_params_grads_into_shared_and_expert_params(
     return shared_grads, expert_grads
 
 
-def split_params_into_different_moe_groups_for_optimizer(param_groups: Tuple[Dict],
-                                                         max_group_size=178956971) -> Tuple[Dict]:
+def split_params_into_different_moe_groups_for_optimizer(param_groups: Union[Dict[str, Any], Tuple[Dict[str, Any],
+                                                                                                   ...],
+                                                                             List[Dict[str, Any]]],
+                                                         max_group_size: int = 178956971) -> List[Dict[str, Any]]:
     """Split parameters into different MoE groups for optimizer
 
     Args:
-        param_groups (Tuple[Dict]):
+        param_groups (Union[Dict[str, Any], Tuple[Dict[str, Any], ...], List[Dict[str, Any]]])
             The list of parameter groups to split
 
     Returns:
-        Tuple[Dict]:
+        List[Dict[str, Any]]:
         list of MoE/non-MoE groups for optimizer
     """
     if isinstance(param_groups, tuple):
@@ -82,45 +90,46 @@ def split_params_into_different_moe_groups_for_optimizer(param_groups: Tuple[Dic
         raise ValueError(f"Unknown param group type of {type(param_groups)}")
 
     # gather all data parallel group names
-    data_parallel_group_names = set()
+    data_parallel_group_names: Set[str] = set()
     for param_group in param_groups:
-        for param in param_group["params"]:
+        for param in cast(List[nn.Parameter], param_group["params"]):
             if is_moe_param(param):
                 data_parallel_group_names.add(param.group_name)
-    data_parallel_group_names = list(data_parallel_group_names)
-    group_moe = {}
+
     # Create the param MoE groups, leave param assign to next step
+    group_moe: Dict[str, Dict[str, Dict[str, Any]]] = {}
     for param_group in param_groups:
         group_moe[param_group['name']] = {}
         for key in data_parallel_group_names:
             group_moe[param_group['name']][key] = {}
             group_moe[param_group['name']][key]['name'] = key
             group_moe[param_group['name']][key]['moe'] = True
+
             for ori_key in param_group.keys():
                 if ori_key != 'name':
-                    if ori_key == 'params':
-                        group_moe[param_group['name']][key][ori_key] = []
-                    else:
-                        group_moe[param_group['name']][key][ori_key] = param_group[ori_key]
+                    group_moe[param_group['name']][key][ori_key] = ([]
+                                                                    if ori_key == 'params' else param_group[ori_key])
+
     # Assign param
     for param_group in param_groups:
-        new_params = []
-        for param in param_group['params']:
+        new_params: List[nn.Parameter] = []
+
+        for param in cast(List[nn.Parameter], param_group['params']):
             if is_moe_param(param):
                 group_moe[param_group['name']][param.group_name]['params'].append(param)
-                # param_group['params'].remove(param)
             else:
                 new_params.append(param)
         param_group['params'] = new_params
 
     # Flatten the moe groups
     if max_group_size is not None:
-        for k, v in group_moe.items():
-            for k1, v1 in v.items():
-                cur_group = []
-                all_groups = []
+        for moe_group in group_moe.values():
+            for param_group in moe_group.values():
+                cur_group: List[nn.Parameter] = []
+                all_groups: List[List[nn.Parameter]] = []
                 size_of_cur_group = 0
-                for param in v1['params']:
+
+                for param in cast(List[nn.Parameter], param_group['params']):
                     if size_of_cur_group + param.numel() <= max_group_size:
                         cur_group.append(param)
                         size_of_cur_group += param.numel()
@@ -128,18 +137,17 @@ def split_params_into_different_moe_groups_for_optimizer(param_groups: Tuple[Dic
                         all_groups.append(cur_group)
                         cur_group = [param]
                         size_of_cur_group = param.numel()
+
                 if cur_group:
                     all_groups.append(cur_group)
+
                 for group in all_groups:
-                    new_dict = {}
-                    for key, val in v1.items():
-                        if key != 'params':
-                            new_dict[key] = val
+                    new_dict = dict(param_group)
                     new_dict['params'] = group
                     param_groups.append(new_dict)
     else:
-        for k, v in group_moe.items():
-            for k1, v1 in v.items():
-                param_groups.append(v1)
+        for moe_group in group_moe.values():
+            for param_group in moe_group.values():
+                param_groups.append(param_group)
 
-    return tuple(param_groups)
+    return param_groups

--- a/docs/_tutorials/mixture-of-experts.md
+++ b/docs/_tutorials/mixture-of-experts.md
@@ -124,7 +124,6 @@ def create_moe_param_groups(model):
 The above param groups can then be fed to the ZeRO stage-2 optimizer as follows.
 
 ```python
-
 net = Net()
 
 parameters = create_moe_param_groups(net)


### PR DESCRIPTION
This PR fixes 5 pyright errors in `deepspeed`. My main goal is to fix the type signatures of `split_params_into_different_moe_groups_for_optimizer` since this affects my project's linting.

I made a few other improvements along the way:

* use more descriptive variable names (`param_group` instead of `v1`, `moe_group` instead of `v`)
* remove a few unused variables by choosing better-suited iterators like `dict.values()` instead of `dict.items()` or `nn.Module.parameters()` instead of `nn.Module.named_parameters()`
* fix incorrect function type signatures
* [use simple `dict()` shallow copy instead of of unnecessary for loop excluding a key is then immediately overwritten: ](https://github.com/microsoft/DeepSpeed/compare/master...ringohoffman:moe-type-hints?expand=1#diff-cec48b3c7def770ef2d14ac7398bfbdf0f209d2558645ffd47d0028988fa66a3L134-L138)
* [ternary to reduce duplicating long expression](https://github.com/microsoft/DeepSpeed/compare/master...ringohoffman:moe-type-hints?expand=1#diff-cec48b3c7def770ef2d14ac7398bfbdf0f209d2558645ffd47d0028988fa66a3L101-L104)
* `isinstance()` instead of `type(...) is ...`
* `typing.cast(List[nn.Parameter], param_group['params'])` as a general pattern for improved type hinting of its elements during iteration
