### PR TITLE
Make batch size documentation clearer

### DIFF
--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -6,7 +6,7 @@ toc_label: "Contents"
 
 ### Batch Size Related Parameters
 
-**Note:** <i>**train_batch_size**</i> must be equal to  <i>**train_micro_batch_size_per_gpu**</i> * <i>**gradient_accumulation**</i> * number of GPUs. For simplicity, you can choose to only specify two of the three parameters, the last one will be inferred automatically by DeepSpeed.
+**Note:** <i>**train_batch_size**</i> must be equal to  <i>**train_micro_batch_size_per_gpu**</i> * <i>**gradient_accumulation_steps**</i> * number of GPUs. For simplicity, you can choose to only specify two of the three parameters, the last one will be inferred automatically by DeepSpeed.
 {: .notice--warning}
 
 <i>**train_batch_size**</i>: [integer]


### PR DESCRIPTION
The config variable for accumulation steps is ```gradient_accumulation_steps``` but the docs explaining batch size related parameters state it as ```gradient_accumulation``` in the note at the top. This could lead to misconfiguration if someone uses this note as their reference for configuration, and it makes the docs less clear to read because it is not necessarily obvious that ```gradient_accumulation``` actually refers to ```gradient_accumulation_steps```.