### PR TITLE
Add backwards compatibility w/ older versions of diffusers (<0.25.0)

### DIFF
--- a/deepspeed/module_inject/containers/vae.py
+++ b/deepspeed/module_inject/containers/vae.py
@@ -14,16 +14,16 @@ class VAEPolicy(DSPolicy):
         try:
             import diffusers
             if hasattr(diffusers.models, "autoencoders"):
-                # Diffusers >= 0.25.0 changes location to 'autoencoders' directory
-                if hasattr(diffusers.models.autoencoders.vae, "AutoencoderKL"):
-                    self._orig_layer_class = diffusers.models.autoencoders.vae.AutoencoderKL
-                else:
-                    self._orig_layer_class = diffusers.models.autoencoders.autoencoder_kl.AutoencoderKL
+                # Diffusers >= 0.25.0
+                # Changes location to 'autoencoders' directory
+                self._orig_layer_class = diffusers.models.autoencoders.autoencoder_kl.AutoencoderKL
             else:
                 if hasattr(diffusers.models.vae, "AutoencoderKL"):
+                    # Diffusers < 0.12.0
                     self._orig_layer_class = diffusers.models.vae.AutoencoderKL
                 else:
-                    # Diffusers >= 0.12.0 changes location of AutoencoderKL
+                    # Diffusers >= 0.12.0 & < 0.25.0
+                    # Changes location of AutoencoderKL
                     self._orig_layer_class = diffusers.models.autoencoder_kl.AutoencoderKL
         except ImportError:
             self._orig_layer_class = None

--- a/deepspeed/module_inject/containers/vae.py
+++ b/deepspeed/module_inject/containers/vae.py
@@ -13,11 +13,18 @@ class VAEPolicy(DSPolicy):
         super().__init__()
         try:
             import diffusers
-            if hasattr(diffusers.models.autoencoders.vae, "AutoencoderKL"):
-                self._orig_layer_class = diffusers.models.autoencoders.vae.AutoencoderKL
+            if hasattr(diffusers.models, "autoencoders"):
+                # Diffusers >= 0.25.0 changes location to 'autoencoders' directory
+                if hasattr(diffusers.models.autoencoders.vae, "AutoencoderKL"):
+                    self._orig_layer_class = diffusers.models.autoencoders.vae.AutoencoderKL
+                else:
+                    self._orig_layer_class = diffusers.models.autoencoders.autoencoder_kl.AutoencoderKL
             else:
-                # Diffusers >= 0.12.0 changes location of AutoencoderKL
-                self._orig_layer_class = diffusers.models.autoencoders.autoencoder_kl.AutoencoderKL
+                if hasattr(diffusers.models.vae, "AutoencoderKL"):
+                    self._orig_layer_class = diffusers.models.vae.AutoencoderKL
+                else:
+                    # Diffusers >= 0.12.0 changes location of AutoencoderKL
+                    self._orig_layer_class = diffusers.models.autoencoder_kl.AutoencoderKL
         except ImportError:
             self._orig_layer_class = None
 

--- a/deepspeed/module_inject/containers/vae.py
+++ b/deepspeed/module_inject/containers/vae.py
@@ -17,14 +17,13 @@ class VAEPolicy(DSPolicy):
                 # Diffusers >= 0.25.0
                 # Changes location to 'autoencoders' directory
                 self._orig_layer_class = diffusers.models.autoencoders.autoencoder_kl.AutoencoderKL
+            elif hasattr(diffusers.models.vae, "AutoencoderKL"):
+                # Diffusers < 0.12.0
+                self._orig_layer_class = diffusers.models.vae.AutoencoderKL
             else:
-                if hasattr(diffusers.models.vae, "AutoencoderKL"):
-                    # Diffusers < 0.12.0
-                    self._orig_layer_class = diffusers.models.vae.AutoencoderKL
-                else:
-                    # Diffusers >= 0.12.0 & < 0.25.0
-                    # Changes location of AutoencoderKL
-                    self._orig_layer_class = diffusers.models.autoencoder_kl.AutoencoderKL
+                # Diffusers >= 0.12.0 & < 0.25.0
+                # Changes location of AutoencoderKL
+                self._orig_layer_class = diffusers.models.autoencoder_kl.AutoencoderKL
         except ImportError:
             self._orig_layer_class = None
 


### PR DESCRIPTION
This PR adds backwards compatibility for older versions of `diffusers` (`<0.25.0`) by updating the `vae` container import logic to account for changes between the various versions.