### PR TITLE
Update torch version for nv-torch-latest-cpu

### DIFF
--- a/.github/workflows/nv-torch-latest-cpu.yml
+++ b/.github/workflows/nv-torch-latest-cpu.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install pytorch
         run: |
-          pip install torch==1.12.0+cpu torchvision==0.13.0+cpu torchaudio==0.12.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install torch==2.1.2+cpu torchvision==0.16.2+cpu --extra-index-url https://download.pytorch.org/whl/cpu
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
@@ -46,5 +46,5 @@ jobs:
         run: |
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch
           cd tests
-          TRANSFORMERS_CACHE=/tmp/transformers_cache/ pytest $PYTEST_OPTS -n 4 unit/ --torch_ver="1.12"
-          TRANSFORMERS_CACHE=/tmp/transformers_cache/ pytest $PYTEST_OPTS -m 'sequential' unit/ --torch_ver="1.12"
+          TRANSFORMERS_CACHE=/tmp/transformers_cache/ pytest $PYTEST_OPTS -n 4 unit/ --torch_ver="2.1"
+          TRANSFORMERS_CACHE=/tmp/transformers_cache/ pytest $PYTEST_OPTS -m 'sequential' unit/ --torch_ver="2.1"


### PR DESCRIPTION
Given the name of this test, we should be running a newer version of torch than we were, this updates to a newer version.

Total test coverage remains the same:
```
torch 1.12
========== 151 passed, 891 skipped, 20 warnings in 126.58s (0:02:06) ===========
========= 4 passed, 61 skipped, 5342 deselected, 2 warnings in 48.66s ==========

torch 2.1
========== 151 passed, 880 skipped, 20 warnings in 157.64s (0:02:37) ===========
========= 4 passed, 62 skipped, 5330 deselected, 2 warnings in 55.73s ==========
```