### PR TITLE
47% FastGen speedup for low workload - refactor allocator 

### DIFF
--- a/deepspeed/inference/v2/allocator.py
+++ b/deepspeed/inference/v2/allocator.py
@@ -10,8 +10,10 @@ import torch
 
 from deepspeed.accelerator import get_accelerator
 
+
 class Allocator:
     cache = defaultdict(dict)
+
     def empty_from(tensor: torch.Tensor, shape: Iterable[int]) -> torch.Tensor:
         try:
             return Allocator.cache[tensor][shape]
@@ -19,9 +21,10 @@ class Allocator:
             shape_size = reduce(lambda x, y: x * y, shape)
             if shape_size == 0:
                 raise ValueError("Cannot create empty tensor with size 0")
-            Allocator.cache[tensor][shape]=tensor.flatten()[:shape_size].view(shape)
+            Allocator.cache[tensor][shape] = tensor.flatten()[:shape_size].view(shape)
             return Allocator.cache[tensor][shape]
-        
+
+
 empty_from = Allocator.empty_from
 
 

--- a/deepspeed/inference/v2/allocator.py
+++ b/deepspeed/inference/v2/allocator.py
@@ -5,17 +5,24 @@
 
 from functools import reduce
 from typing import Iterable
-
+from collections import defaultdict
 import torch
 
 from deepspeed.accelerator import get_accelerator
 
-
-def empty_from(tensor: torch.Tensor, shape: Iterable[int]) -> torch.Tensor:
-    shape_size = reduce(lambda x, y: x * y, shape)
-    if shape_size == 0:
-        raise ValueError("Cannot create empty tensor with size 0")
-    return tensor.flatten()[:shape_size].view(shape)
+class Allocator:
+    cache = defaultdict(dict)
+    def empty_from(tensor: torch.Tensor, shape: Iterable[int]) -> torch.Tensor:
+        try:
+            return Allocator.cache[tensor][shape]
+        except KeyError:
+            shape_size = reduce(lambda x, y: x * y, shape)
+            if shape_size == 0:
+                raise ValueError("Cannot create empty tensor with size 0")
+            Allocator.cache[tensor][shape]=tensor.flatten()[:shape_size].view(shape)
+            return Allocator.cache[tensor][shape]
+        
+empty_from = Allocator.empty_from
 
 
 def on_device(method) -> torch.Tensor:


### PR DESCRIPTION
This PR refactor FastGen allocator and add caching for empty_from method

![image](https://github.com/microsoft/DeepSpeed/assets/46639297/16d1f736-358c-4224-b88f-a708eef8f3a4)

DS Master: Deployment: Mixtral-8x7B-v0.1-tp4-b768 Clients: 1, Prompt (mean): 500 tokens, Generation (mean): 1024 tokens, Query throughput: 0.075 queries/s, Token throughput (total): **163.130 tokens/s**, Query latency: 13.310 s, Token generation latency: 0.020 s/token, First token received: 0.055 s

This PR: Deployment: Mixtral-8x7B-v0.1-tp4-b768-allocator-rework Clients: 1, Prompt (mean): 500 tokens, Generation (mean): 1024 tokens, Query throughput: 0.095 queries/s, Token throughput (total): **240.386 tokens/s**, Query latency: 10.472 s, Token generation latency: 0.016 s/token, First token received: 0.056 s

