### PR TITLE
Switch hasattr check from compile to compiler

### DIFF
--- a/deepspeed/runtime/compiler.py
+++ b/deepspeed/runtime/compiler.py
@@ -13,7 +13,7 @@ COMPILE_CONFIG = "compile"
 
 
 def is_compile_supported():
-    return hasattr(torch, "compile")
+    return hasattr(torch, "compiler")
 
 
 def disable(func):


### PR DESCRIPTION
torch.compile introduced in torch 2.0 but torch.compiler was introduced in torch 2.1, this fixes issues for those building with torch 2.0 like the A6000 builds.

```
>>> torch.__version__
'2.1.0+cu121'
>>> hasattr(torch, "compile")
True
>>> hasattr(torch, "compiler")
True

>>> torch.__version__
'2.0.0+cu117'
>>> hasattr(torch, "compile")
True
>>> hasattr(torch, "compiler")
False
```