### PR TITLE
Remove optimizer step on initialization

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -1015,10 +1015,6 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             else:
                 self.fp32_partitioned_groups_flat[i].grad = gradient_buffer.narrow(0, 0, num_elements)
 
-            # Initialize the optimizer states with the flattened fp32 partition.
-            if not is_adagrad:
-                self._optimizer_step(i)
-
             if swappable_param_subgroup:
                 self._partitioned_params_swap_out(i)
 

--- a/deepspeed/utils/__init__.py
+++ b/deepspeed/utils/__init__.py
@@ -17,6 +17,6 @@ from .tensor_fragment import safe_set_full_fp32_param, safe_set_full_optimizer_s
 from .tensor_fragment import safe_get_local_fp32_param, safe_get_local_grad, safe_get_local_optimizer_state
 from .tensor_fragment import safe_set_local_fp32_param, safe_set_local_optimizer_state
 from .z3_leaf_module import set_z3_leaf_modules, unset_z3_leaf_modules, get_z3_leaf_modules, z3_leaf_module, z3_leaf_parameter
-from .mixed_precision_linkage import link_hp_params
+from .mixed_precision_linkage import link_hp_params, lazy_init_hp_params_optimizer_state
 from deepspeed.runtime.dataloader import RepeatingLoader
 from .numa import get_numactl_cmd

--- a/deepspeed/utils/tensor_fragment.py
+++ b/deepspeed/utils/tensor_fragment.py
@@ -21,11 +21,11 @@ class tensor_fragment:
     lp_fragment_address: fragment_address
     hp_fragment: torch.Tensor
     hp_fragment_address: fragment_address
-    optim_fragment: Dict
     gradient_dict: Dict
     offload_gradient_dict: Dict
     use_offload: bool
     param_group_index: int
+    optim_fragment: Dict = None
 
     def update_hp(self):
         self.hp_fragment.data.copy_(self.lp_fragment.data)
@@ -38,6 +38,13 @@ class tensor_fragment:
             return self.optim_fragment[key]
         else:
             raise ValueError(f'{key} not found in optimizer state fragment')
+
+    def set_optim_state_fragment(self, flat_hp_partition, optim_fragment):
+        self.optim_fragment = {
+            key: value.narrow(0, self.hp_fragment_address.start, self.hp_fragment_address.numel)
+            for key, value in optim_fragment.items()
+            if torch.is_tensor(value) and value.shape == flat_hp_partition.shape
+        }
 
     def get_hp_fragment_address(self):
         return self.hp_fragment_address
@@ -255,7 +262,7 @@ def safe_set_local_fp32_param(param, value):
 
 
 def get_hp_fragment_mapping(lp_param, lp_start, flat_hp_partition, gradient_dict, offload_gradient_dict, use_offload,
-                            param_group_index, partition_start, partition_size, optimizer_state_dict):
+                            param_group_index, partition_start, partition_size):
     lp_end = lp_param.numel() + lp_start
     hp_start = partition_start
     hp_end = partition_start + partition_size
@@ -268,11 +275,6 @@ def get_hp_fragment_mapping(lp_param, lp_start, flat_hp_partition, gradient_dict
     fragment_numel = fragment_end - fragment_start
     hp_frag_address = fragment_address(start=fragment_start - hp_start, numel=fragment_numel)
     hp_fragment_tensor = flat_hp_partition.narrow(0, hp_frag_address.start, hp_frag_address.numel)
-    optim_fragment = {
-        key: value.narrow(0, hp_frag_address.start, hp_frag_address.numel)
-        for key, value in optimizer_state_dict.items()
-        if torch.is_tensor(value) and value.shape == flat_hp_partition.shape
-    }
 
     lp_frag_address = fragment_address(start=fragment_start - lp_start, numel=fragment_numel)
     lp_fragment_tensor = lp_param.flatten().narrow(0, lp_frag_address.start, lp_frag_address.numel)
@@ -281,7 +283,6 @@ def get_hp_fragment_mapping(lp_param, lp_start, flat_hp_partition, gradient_dict
                            lp_fragment_address=lp_frag_address,
                            hp_fragment=hp_fragment_tensor,
                            hp_fragment_address=hp_frag_address,
-                           optim_fragment=optim_fragment,
                            gradient_dict=gradient_dict,
                            offload_gradient_dict=offload_gradient_dict,
                            use_offload=use_offload,

--- a/tests/unit/runtime/zero/test_zero_tensor_fragment.py
+++ b/tests/unit/runtime/zero/test_zero_tensor_fragment.py
@@ -24,33 +24,24 @@ FIRST_ORDER_KEY = 'exp_avg'
 SECOND_ORDER_KEY = 'exp_avg_sq'
 
 
-def validate_full_tensors(model):
+def validate_tensor(model, api_type, opt_states):
+    assert api_type in ["full", "local"]
     for _, lp in model.named_parameters():
-        hp = safe_get_full_fp32_param(lp)
-        exp_avg = safe_get_full_optimizer_state(lp, 'exp_avg')
-        exp_avg_sq = safe_get_full_optimizer_state(lp, 'exp_avg_sq')
-        hp_grad = safe_get_full_grad(lp)
-        param_list = [hp, hp_grad, exp_avg, exp_avg_sq]
+        param_list = []
+        if opt_states:
+            param_list.append(
+                safe_get_full_optimizer_state(lp, 'exp_avg') if api_type ==
+                "full" else safe_get_local_optimizer_state(lp, 'exp_avg'))
+            param_list.append(
+                safe_get_full_optimizer_state(lp, 'exp_avg_sq') if api_type ==
+                "full" else safe_get_local_optimizer_state(lp, 'exp_avg_sq'))
+        else:
+            param_list.append(safe_get_full_fp32_param(lp) if api_type == "full" else safe_get_local_fp32_param(lp))
+            param_list.append(safe_get_full_grad(lp) if api_type == "full" else safe_get_local_grad(lp))
         if lp.requires_grad:
             assert all([p is not None for p in param_list])
         else:
             assert all([p is None for p in param_list])
-
-
-def validate_local_tensors(model):
-    for _, lp in model.named_parameters():
-        hp = safe_get_local_fp32_param(lp)
-        exp_avg = safe_get_local_optimizer_state(lp, 'exp_avg')
-        exp_avg_sq = safe_get_local_optimizer_state(lp, 'exp_avg_sq')
-        hp_grad = safe_get_local_grad(lp)
-        param_list = [hp, hp_grad, exp_avg, exp_avg_sq]
-        if lp.requires_grad:
-            assert all([p is not None for p in param_list])
-        else:
-            assert all([p is None for p in param_list])
-
-
-validate_funcs_mapping = {"full": validate_full_tensors, "local": validate_local_tensors}
 
 
 class MyModel(torch.nn.Module):
@@ -71,12 +62,10 @@ class MyModel(torch.nn.Module):
         for l in self.linears:
             x = l(x)
             x = self.act(x)
-        loss = self.cel(x, y)
-        val = (x, loss)
-        return val
+        return self.cel(x, y)
 
 
-def run_fragmented_model(model, config_dict, hidden_dim, dtype, validate_func):
+def run_fragmented_model(model, config_dict, hidden_dim, dtype, validate_after_bwd, validate_after_step):
     model, _, _, _ = deepspeed.initialize(model=model, model_parameters=model.parameters(), config=config_dict)
     data_loader = random_dataloader(model=model,
                                     total_samples=10,
@@ -86,10 +75,10 @@ def run_fragmented_model(model, config_dict, hidden_dim, dtype, validate_func):
     dist.barrier()
     for n, batch in enumerate(data_loader):
         loss = model(batch[0], batch[1])
-        loss = loss[1]
         model.backward(loss)
-        validate_func(model)
+        validate_after_bwd(model)
         model.step()
+        validate_after_step(model)
 
     # Needed in ZeRO 3. Not doing so can give memory leak
     model.destroy()
@@ -147,9 +136,10 @@ class TestTensorFragmentGet(DistributedTest):
         else:
             model = MyModel(hidden_dim, frozen_weights)
 
-        validate_func = validate_funcs_mapping[api_type]
+        validate_after_bwd = lambda model: validate_tensor(model, api_type, opt_states=False)
+        validate_after_step = lambda model: validate_tensor(model, api_type, opt_states=True)
 
-        run_fragmented_model(model, config_dict, hidden_dim, torch.float16, validate_func)
+        run_fragmented_model(model, config_dict, hidden_dim, torch.float16, validate_after_bwd, validate_after_step)
 
     def test_bf16_fragments(self, frozen_weights):
         if frozen_weights:
@@ -178,7 +168,12 @@ class TestTensorFragmentGet(DistributedTest):
 
         hidden_dim = 128
         model = MyModel(hidden_dim, frozen_weights)
-        run_fragmented_model(model, config_dict, hidden_dim, torch.bfloat16, validate_full_tensors)
+
+        api_type = "full"
+        validate_after_bwd = lambda model: validate_tensor(model, api_type, opt_states=False)
+        validate_after_step = lambda model: validate_tensor(model, api_type, opt_states=True)
+
+        run_fragmented_model(model, config_dict, hidden_dim, torch.bfloat16, validate_after_bwd, validate_after_step)
 
 
 def create_random_values(model, key_list, group, use_cuda=True):
@@ -315,23 +310,21 @@ class TestTensorFragmentUpdate(DistributedTest):
         if zero_stage == 3:
             config_dict["zero_optimization"]["param_persistence_threshold"] = hidden_dim
             with deepspeed.zero.Init(config_dict_or_path=config_dict):
-                model = SimpleModel(hidden_dim, nlayers=4)
+                model = SimpleModel(hidden_dim)
         else:
-            model = SimpleModel(hidden_dim, nlayers=4)
+            model = SimpleModel(hidden_dim)
 
-        model, _, _, _ = deepspeed.initialize(model=model, model_parameters=model.parameters(), config=config_dict)
         world = dist.get_world_size()
         group = dist.new_group(ranks=list(range(world)))
 
         dist.barrier()
-        optim_keys = [WEIGHT_KEY, FIRST_ORDER_KEY, SECOND_ORDER_KEY]
-        helper_funcs = helper_funcs_mapping[api_type]
-        optim_state_values = helper_funcs["create_random_values"](model,
-                                                                  optim_keys,
-                                                                  group,
-                                                                  use_cuda=offload_device == OffloadDeviceEnum.none)
-        helper_funcs["set_param_values_with_dict"](model, optim_state_values)
-        helper_funcs["validate_param_values_with_dict"](model, optim_state_values)
 
-        # Needed in ZeRO 3. Not doing so can leak memory.
-        model.destroy()
+        def validate_func(model):
+            optim_keys = [WEIGHT_KEY, FIRST_ORDER_KEY, SECOND_ORDER_KEY]
+            helper_funcs = helper_funcs_mapping[api_type]
+            optim_state_values = helper_funcs["create_random_values"](
+                model, optim_keys, group, use_cuda=offload_device == OffloadDeviceEnum.none)
+            helper_funcs["set_param_values_with_dict"](model, optim_state_values)
+            helper_funcs["validate_param_values_with_dict"](model, optim_state_values)
+
+        run_fragmented_model(model, config_dict, hidden_dim, dtype, lambda _: None, validate_func)


### PR DESCRIPTION
All ZeRO 1/2/3 stages call the optimizer's `step()` on its initialization. This increments a counter in the optimizer and produces a different result in parameter update with the normal usage of PyTorch. This PR eliminates `step()` in the initialization and lazily configures some internal states (linking *hp_params*) after the first `step()` call.