### PR TITLE
Add HIP conversion file outputs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,10 @@ docs/code-docs/build
 ## Testing data
 # Saved checkpoints for testing
 tests/unit/saved_checkpoint/
+
+# Ignore HIP files created during AMD compilation
+*_hip.cpp
+*_hip.h
+*.hip
+*.cuh
+*hip_layers.h

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ docs/code-docs/build
 # Saved checkpoints for testing
 tests/unit/saved_checkpoint/
 
-# Ignore HIP files created during AMD compilation
+# HIP files created during AMD compilation
 *_hip.cpp
 *_hip.h
 *.hip


### PR DESCRIPTION
This PR adds the following HIP output files to `.gitignore`:
``` 
*_hip.cpp
*_hip.h
*.hip
*.cuh
*hip_layers.h
```