### PR TITLE
Add HIP device abstraction, update Triton skip logic

### DIFF
--- a/accelerator/hip_accelerator.py
+++ b/accelerator/hip_accelerator.py
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from .cuda_accelerator import CUDA_Accelerator
+# During setup stage torch may not be installed, pass on no torch will
+# allow op builder related API to be executed.
+try:
+    import torch.cuda
+except ImportError:
+    pass
+
+# Delay import pynvml to avoid import error when CUDA is not available
+pynvml = None
+
+
+class HIP_Accelerator(CUDA_Accelerator):
+
+    def __init__(self):
+        self._name = 'hip'
+        self._communication_backend_name = 'nccl'
+        if pynvml is None:
+            self._init_pynvml()
+
+    def _init_pynvml(self):
+        global pynvml
+        try:
+            import pynvml
+        except ImportError:
+            return
+        try:
+            pynvml.nvmlInit()
+        except pynvml.NVMLError:
+            pynvml = None
+            return
+
+    def is_triton_supported(self):
+        return False

--- a/accelerator/real_accelerator.py
+++ b/accelerator/real_accelerator.py
@@ -20,7 +20,7 @@ try:
 except ImportError as e:
     dsa2 = None
 
-SUPPORTED_ACCELERATOR_LIST = ['cuda', 'cpu', 'xpu', 'xpu.external', 'npu', 'mps', 'hpu']
+SUPPORTED_ACCELERATOR_LIST = ['cuda', 'cpu', 'xpu', 'xpu.external', 'npu', 'mps', 'hpu', 'hip']
 
 ds_accelerator = None
 
@@ -154,6 +154,9 @@ def get_accelerator():
             except ImportError as e:
                 pass
         if accelerator_name is None:
+            if hasattr(torch.version, 'hip') and torch.version.hip is not None:
+                accelerator_name = "hip"
+        if accelerator_name is None:
             accelerator_name = "cuda"
 
         ds_set_method = "auto detect"
@@ -186,6 +189,10 @@ def get_accelerator():
         from .hpu_accelerator import HPU_Accelerator
 
         ds_accelerator = HPU_Accelerator()
+    elif accelerator_name == 'hip':
+        from .hip_accelerator import HIP_Accelerator
+
+        ds_accelerator = HIP_Accelerator()
     _validate_accelerator(ds_accelerator)
     if accel_logger is not None:
         accel_logger.info(f"Setting ds_accelerator to {ds_accelerator._name} ({ds_set_method})")

--- a/deepspeed/__init__.py
+++ b/deepspeed/__init__.py
@@ -12,8 +12,13 @@ from torch.optim import Optimizer
 from torch.optim.lr_scheduler import _LRScheduler
 from packaging import version as pkg_version
 
-# Skip Triton import for AMD due to pytorch-triton-rocm module breaking device API in DeepSpeed
-if not (hasattr(torch.version, 'hip') and torch.version.hip is not None):
+# Import utils so logger in accelerator properly logs output
+import deepspeed.utils
+from .accelerator import get_accelerator
+
+# Skip Triton import if not supported by accelerator
+# e.g. pytorch-triton-rocm module breaks device API on AMD w/ DeepSpeed
+if get_accelerator().is_triton_supported():
     try:
         import triton  # noqa: F401 # type: ignore
         HAS_TRITON = True
@@ -25,7 +30,6 @@ else:
 from . import ops
 from . import module_inject
 
-from .accelerator import get_accelerator
 from .runtime.engine import DeepSpeedEngine, DeepSpeedOptimizerCallable, DeepSpeedSchedulerCallable
 from .runtime.engine import ADAM_OPTIMIZER, LAMB_OPTIMIZER
 from .runtime.hybrid_engine import DeepSpeedHybridEngine


### PR DESCRIPTION
This PR adds a `HIP_Accelerator` accelerator abstraction that inherits from `CUDA_Accelerator`, which is possible due to PyTorch for HIP reusing the existing `torch.cuda` interfaces ([see here](https://pytorch.org/docs/stable/notes/hip.html#hip-interfaces-reuse-the-cuda-interfaces)).

The motivation for a new HIP acceleration abstraction however, is to expand the flexibility when supporting AMD, allowing for accelerator function overrides if necessary, such as (see GH-5110):
```python
    def is_triton_supported(self):
        return False
```
The `triton` import skip logic was also updated in this PR to source `is_triton_supported()` from the accelerator.