### PR TITLE
disable compile tests for torch<2.0

### DIFF
--- a/tests/unit/runtime/compile/test_compile_wrapper.py
+++ b/tests/unit/runtime/compile/test_compile_wrapper.py
@@ -8,8 +8,12 @@ import torch
 
 import deepspeed
 from deepspeed.accelerator import get_accelerator
+from deepspeed.runtime.utils import required_torch_version
 
 from unit.common import DistributedTest
+
+pytestmark = pytest.mark.skipif(not required_torch_version(min_version=2.0),
+                                reason="Compile tests requires Pytorch version 2.0 or above")
 
 
 @pytest.fixture

--- a/tests/unit/runtime/compile/test_compile_zero.py
+++ b/tests/unit/runtime/compile/test_compile_zero.py
@@ -7,10 +7,14 @@ import pytest
 import torch
 
 from deepspeed.runtime.zero.offload_config import OffloadDeviceEnum
+from deepspeed.runtime.utils import required_torch_version
 
 from unit.runtime.compile.util import compare_loss
 from unit.common import DistributedTest
 from unit.util import bf16_required_version_check
+
+pytestmark = pytest.mark.skipif(not required_torch_version(min_version=2.0),
+                                reason="Compile tests requires Pytorch version 2.0 or above")
 
 
 class TestZeRO(DistributedTest):

--- a/tests/unit/runtime/compile/test_load_config.py
+++ b/tests/unit/runtime/compile/test_load_config.py
@@ -9,8 +9,12 @@ import torch
 from unit.simple_model import SimpleModel
 import deepspeed
 from deepspeed.accelerator import get_accelerator
+from deepspeed.runtime.utils import required_torch_version
 
 from unit.common import DistributedTest
+
+pytestmark = pytest.mark.skipif(not required_torch_version(min_version=2.0),
+                                reason="Compile tests requires Pytorch version 2.0 or above")
 
 custom_backend_called = False
 custom_compler_fn_called = False


### PR DESCRIPTION
Tests running older version of torch will fail the compile tests added in #4878.