### PR TITLE
DeepSpeedZeroOptimizer_Stage3: remove cuda specific optimizer

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -201,13 +201,12 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             backup_gpu_tensor = torch.randn(1, device=get_accelerator().device_name()).to(self.dtype)
             backup_gpu_param = torch.nn.Parameter(backup_gpu_tensor)
             assert type(init_optimizer) == DeepSpeedCPUAdam, 'Hybrid Optimizer Only Supports DeepSpeedCPUAdam'
-            self.backup_optimizer = torch.optim.AdamW(
-                [backup_gpu_param],
-                lr=self.optimizer.param_groups[0]["lr"],
-                betas=self.optimizer.param_groups[0]["betas"],
-                eps=self.optimizer.param_groups[0]["eps"],
-                weight_decay=self.optimizer.param_groups[0]["weight_decay"],
-                amsgrad=self.optimizer.param_groups[0]["amsgrad"])
+            self.backup_optimizer = torch.optim.AdamW([backup_gpu_param],
+                                                      lr=self.optimizer.param_groups[0]["lr"],
+                                                      betas=self.optimizer.param_groups[0]["betas"],
+                                                      eps=self.optimizer.param_groups[0]["eps"],
+                                                      weight_decay=self.optimizer.param_groups[0]["weight_decay"],
+                                                      amsgrad=self.optimizer.param_groups[0]["amsgrad"])
             # Multiple param_groups configs for back-up optimizer
             if len(self.optimizer.param_groups) > 1:
                 for i in range(1, len(self.optimizer.param_groups)):

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -204,7 +204,6 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             self.backup_optimizer = torch.optim.AdamW(
                 [backup_gpu_param],
                 lr=self.optimizer.param_groups[0]["lr"],
-                bias_correction=self.optimizer.param_groups[0]["bias_correction"],
                 betas=self.optimizer.param_groups[0]["betas"],
                 eps=self.optimizer.param_groups[0]["eps"],
                 weight_decay=self.optimizer.param_groups[0]["weight_decay"],


### PR DESCRIPTION
during cpu offload there was a usage in cuda fused adam, as a backup
optimizer.
This is a specific accelerator code, also in non-critical path.