### PR TITLE
get_grad_norm_direct: fix a case of empty norm group

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1686,7 +1686,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if len(all_norms) > 0:
                 total_norm = torch.stack(all_norms).square().sum().float()
             else:
-                total_norm = torch.FloatTensor([0.0]).to(self.device)
+                total_norm = torch.FloatTensor(0.0).to(self.device)
             # Sum across all model parallel Device.
             dist.all_reduce(total_norm, op=dist.ReduceOp.SUM, group=self.dp_process_group)
 

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1686,7 +1686,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if len(all_norms) > 0:
                 total_norm = torch.stack(all_norms).square().sum().float()
             else:
-                total_norm = torch.FloatTensor(0.0).to(self.device)
+                total_norm = torch.tensor(0.0, dtype=torch.float32).to(self.device)
             # Sum across all model parallel Device.
             dist.all_reduce(total_norm, op=dist.ReduceOp.SUM, group=self.dp_process_group)
 


### PR DESCRIPTION
fix for [#5145 ](https://github.com/microsoft/DeepSpeed/issues/5145)
empty norm group create a norm tensor with shape=[1], while other norms will be shapeless. torch.stack does not support such case. Fixing empty group norm to be shapless as well, instead of shape=[1].
