### PR TITLE
ZeRO0 does not handle BF16 gradients properly

### DIFF
--- a/deepspeed/runtime/bf16_optimizer.py
+++ b/deepspeed/runtime/bf16_optimizer.py
@@ -292,9 +292,6 @@ class BF16_Optimizer(ZeROOptimizer):
         self.clear_lp_grads()
         loss.backward(**bwd_kwargs)
 
-        if update_hp_grads:
-            self.update_hp_grads(clear_lp_grads=clear_lp_grads)
-
     @torch.no_grad()
     def _update_hp_grad(self, lp, group_idx, param_idx, clear_lp_grads):
         if lp.grad is None:
@@ -310,7 +307,7 @@ class BF16_Optimizer(ZeROOptimizer):
 
         # clear gradients
         if clear_lp_grads:
-            lp.grad._zero()
+            lp.grad.zero_()
 
     @torch.no_grad()
     def _update_hp_grads_func(self, clear_lp_grads=False):

--- a/deepspeed/runtime/bf16_optimizer.py
+++ b/deepspeed/runtime/bf16_optimizer.py
@@ -280,14 +280,8 @@ class BF16_Optimizer(ZeROOptimizer):
 
         self.clear_hp_grads()
 
-    def backward(self, loss, update_hp_grads=True, clear_lp_grads=False, **bwd_kwargs):
-        """Perform a backward pass and copy the low-precision gradients to the
-        high-precision copy.
-
-        We copy/accumulate to the high-precision grads now to prevent accumulating in the
-        bf16 grads after successive backward() calls (i.e., grad accumulation steps > 1)
-
-        The low-precision grads are deallocated during this procedure.
+    def backward(self, loss, **bwd_kwargs):
+        """Clears BF16 gradients and calls backward.
         """
         self.clear_lp_grads()
         loss.backward(**bwd_kwargs)

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -2000,6 +2000,9 @@ class DeepSpeedEngine(Module):
             # Traditional code path that allreduces the module parameter grads
             self.allreduce_gradients()
 
+        if not self.zero_optimization() and self.bfloat16_enabled():
+            self.optimizer.update_hp_grads()
+
         self._stop_timers(self.engine_timers.backward_reduce_timers)
 
         self._stop_timers(self.engine_timers.backward_timers)


### PR DESCRIPTION
The combination of BF16 and ZeRO0 (no ZeRO optimization) has some issues with handling gradients. `BF16_Optimizer` seems to be designed to accumulate gradients in FP32, but this doesn't match other parts.

- DeepSpeed engine converts BF16 gradients and accumulate them in FP32 soon after the backward pass using `BF16_Optimizer`. However, the engine performs allreduce on BF16 gradients after that. As the result, gradients are not properly reduced.
- The engine calls `BF16_Optimizer`'s `backward()`. This clears BF16 gradients. So it doesn't work when the gradient accumulation step > 1.

There are two possible approaches to resolve this issue:
1. Accumulate gradients in BF16 until the boundary of gradient accumulation steps (We should clear BF16 gradient only at the gradient accumulation boundary). Then perform allreduce, conversion to FP32, and parameter update.
2. Accumulate gradients in FP32 and run allreduce.

This PR takes the first approach to resolve the issue. ZeRO 1/2/3 follows the first approach though the second one has the advantage in terms the precision for gradient accumulation.