### PR TITLE
Added support for skipping Inference V2 tests when the accelerator is not compatible.

### DIFF
--- a/tests/unit/compression/test_compression.py
+++ b/tests/unit/compression/test_compression.py
@@ -16,6 +16,7 @@ from deepspeed.compression.helper import convert_conv1d_to_linear
 from deepspeed.accelerator import get_accelerator
 from deepspeed.runtime.utils import required_torch_version
 from unit.common import DistributedTest
+from deepspeed.ops.op_builder import FusedLambBuilder
 
 pytestmark = pytest.mark.skipif(not required_torch_version(min_version=1.5),
                                 reason='Megatron-LM package requires Pytorch version 1.5 or above')
@@ -216,6 +217,7 @@ class TestCompression(DistributedTest):
 
         return ds_config_dict
 
+    @pytest.mark.skipif(not deepspeed.ops.__compatible_ops__[FusedLambBuilder.NAME], reason="lamb is not compatible")
     def test_linear_layer_compress(self, tmpdir):
         model = create_bert_model()
         compressed_model = init_compression(model, self.get_ds_config())
@@ -225,6 +227,7 @@ class TestCompression(DistributedTest):
         assert isinstance(compressed_model.layer[0].attention.self.value, LinearLayer_Compress)
 
     @pytest.mark.skip(reason="megatron-lm is currently broken so this test cannot be run.")
+    @pytest.mark.skipif(not deepspeed.ops.__compatible_ops__[FusedLambBuilder.NAME], reason="lamb is not compatible")
     def test_mpu_compress(self, tmpdir):
         if not required_torch_version(max_version=1.13):
             pytest.skip("megatron not compatible with torch >1.13")

--- a/tests/unit/elasticity/test_elastic.py
+++ b/tests/unit/elasticity/test_elastic.py
@@ -9,7 +9,7 @@ from unit.common import DistributedTest
 from deepspeed.git_version_info import version as ds_version
 import os
 from unit.simple_model import SimpleModel
-from deepspeed.ops.op_builder import FusedAdamBuilder
+from deepspeed.ops.op_builder import FusedAdamBuilder, FusedLambBuilder
 
 if not deepspeed.ops.__compatible_ops__[FusedAdamBuilder.NAME]:
     pytest.skip("This op had not been implemented on this system.", allow_module_level=True)
@@ -150,6 +150,7 @@ def test_proper_mbsz(ds_config):
 class TestNonElasticBatchParams(DistributedTest):
     world_size = 2
 
+    @pytest.mark.skipif(not deepspeed.ops.__compatible_ops__[FusedLambBuilder.NAME], reason="lamb is not compatible")
     def test(self):
         config_dict = {
             "train_batch_size": 2,
@@ -182,6 +183,7 @@ class TestNonElasticBatchParams(DistributedTest):
 class TestNonElasticBatchParamsWithOverride(DistributedTest):
     world_size = 2
 
+    @pytest.mark.skipif(not deepspeed.ops.__compatible_ops__[FusedLambBuilder.NAME], reason="lamb is not compatible")
     def test(self):
         config_dict = {
             "train_batch_size": 2,
@@ -213,6 +215,7 @@ class TestNonElasticBatchParamsWithOverride(DistributedTest):
 class TestElasticConfigChanged(DistributedTest):
     world_size = 2
 
+    @pytest.mark.skipif(not deepspeed.ops.__compatible_ops__[FusedLambBuilder.NAME], reason="lamb is not compatible")
     def test(self):
         config_dict = {
             "train_batch_size": 2,

--- a/tests/unit/inference/v2/inference_test_utils.py
+++ b/tests/unit/inference/v2/inference_test_utils.py
@@ -44,3 +44,10 @@ def allclose(x, y, tolerances: Tuple[int, int] = None):
     else:
         rtol, atol = tolerances
     return torch.allclose(x, y, rtol=rtol, atol=atol)
+
+
+def skip_on_inference_v2():
+    if get_accelerator().device_name() == 'hpu':
+        return True
+    else:
+        return False

--- a/tests/unit/inference/v2/kernels/core_ops/test_bias_activation.py
+++ b/tests/unit/inference/v2/kernels/core_ops/test_bias_activation.py
@@ -11,7 +11,10 @@ import torch
 from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.inference_utils import ActivationType, DtypeEnum
 from deepspeed.inference.v2.kernels.core_ops import CUDABiasActivation
-from ....v2.inference_test_utils import get_dtypes, allclose
+from ....v2.inference_test_utils import get_dtypes, allclose, skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def reference_bias_act_implementation(input: torch.Tensor, bias: Optional[torch.Tensor],

--- a/tests/unit/inference/v2/kernels/core_ops/test_blas_linear.py
+++ b/tests/unit/inference/v2/kernels/core_ops/test_blas_linear.py
@@ -10,8 +10,10 @@ import torch
 
 from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.kernels.core_ops import BlasLibLinear
-from ....v2.inference_test_utils import allclose
+from ....v2.inference_test_utils import allclose, skip_on_inference_v2
 
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 # Note: only testing with FP16 and BF16 because we use TF32 on Ampere and we don't have a good
 # set of tolerances. Since this is just on top of BLAS though, the test is more about
 # making sure the stride/contiguity is correct and that's data type agnostic.

--- a/tests/unit/inference/v2/kernels/core_ops/test_gated_activation.py
+++ b/tests/unit/inference/v2/kernels/core_ops/test_gated_activation.py
@@ -11,7 +11,10 @@ import torch
 from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.kernels.core_ops import CUDAGatedActivation
 from deepspeed.inference.v2.inference_utils import ActivationType
-from ....v2.inference_test_utils import get_dtypes, allclose
+from ....v2.inference_test_utils import get_dtypes, allclose, skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def reference_geglu_implementation(input: torch.Tensor,

--- a/tests/unit/inference/v2/kernels/core_ops/test_post_ln.py
+++ b/tests/unit/inference/v2/kernels/core_ops/test_post_ln.py
@@ -8,7 +8,10 @@ import torch
 
 from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.kernels.core_ops import CUDAFPPostLN
-from ....v2.inference_test_utils import get_dtypes, allclose
+from ....v2.inference_test_utils import get_dtypes, allclose, skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def reference_implementation(residual: torch.Tensor, hidden_states: torch.Tensor, gamma: torch.Tensor,

--- a/tests/unit/inference/v2/kernels/core_ops/test_pre_ln.py
+++ b/tests/unit/inference/v2/kernels/core_ops/test_pre_ln.py
@@ -8,7 +8,10 @@ import torch
 
 from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.kernels.core_ops import CUDAFPPreLN
-from ....v2.inference_test_utils import get_dtypes, allclose
+from ....v2.inference_test_utils import get_dtypes, allclose, skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def reference_implementation(residual: torch.Tensor, hidden_states: torch.Tensor, gamma: torch.Tensor,

--- a/tests/unit/inference/v2/kernels/core_ops/test_rms_norm.py
+++ b/tests/unit/inference/v2/kernels/core_ops/test_rms_norm.py
@@ -9,7 +9,10 @@ import torch
 from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.inference_utils import DtypeEnum
 from deepspeed.inference.v2.kernels.core_ops import CUDARMSNorm, CUDARMSPreNorm
-from ....v2.inference_test_utils import get_dtypes, allclose
+from ....v2.inference_test_utils import get_dtypes, allclose, skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def reference_rms_norm(vals: torch.Tensor, gamma: torch.Tensor, epsilon: float = 1e-5) -> torch.Tensor:

--- a/tests/unit/inference/v2/kernels/cutlass_ops/test_moe_gemm.py
+++ b/tests/unit/inference/v2/kernels/cutlass_ops/test_moe_gemm.py
@@ -9,8 +9,10 @@ import torch
 from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.inference_utils import ActivationType, DtypeEnum
 from deepspeed.inference.v2.kernels.cutlass_ops import MoEGEMM
-from ....v2.inference_test_utils import allclose
+from ....v2.inference_test_utils import allclose, skip_on_inference_v2
 
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 SINGLE_EXPERT_CASES = [(13, 2048, 2048), (256, 1024, 4096), (278, 5120, 2048), (893, 5120, 2560)]
 
 PYTORCH_ACT_FN_MAP = {

--- a/tests/unit/inference/v2/kernels/ragged_ops/test_atom_builder.py
+++ b/tests/unit/inference/v2/kernels/ragged_ops/test_atom_builder.py
@@ -6,9 +6,13 @@
 import pytest
 import torch
 
+from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.kernels.ragged_ops import AtomBuilder
 from .ragged_testing_utils import build_complex_batch
+from ....v2.inference_test_utils import skip_on_inference_v2
 
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 Q_BLOCK_SIZE = 128
 KV_BLOCK_SIZE = 128
 

--- a/tests/unit/inference/v2/kernels/ragged_ops/test_blocked_flash.py
+++ b/tests/unit/inference/v2/kernels/ragged_ops/test_blocked_flash.py
@@ -23,7 +23,7 @@ from deepspeed.inference.v2.ragged import split_kv
 from deepspeed.ops.op_builder import RaggedUtilsBuilder
 
 from .ragged_testing_utils import build_batch_and_manager
-from ....v2.inference_test_utils import allclose
+from ....v2.inference_test_utils import allclose, skip_on_inference_v2
 
 try:
     from flash_attn.flash_attn_interface import flash_attn_varlen_func
@@ -35,6 +35,9 @@ NOTE(cmikeh2): These tests depend on atom construction and KV-cache copying to b
 If one or the other of those is not working, then these tests will fail. Before debugging here,
 make sure that the atom construction and KV-cache copying tests are passing.
 """
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def _blocked_flash_testing_helper(head_size: int, n_heads_q: int, n_heads_kv: int,

--- a/tests/unit/inference/v2/kernels/ragged_ops/test_blocked_kv_copy.py
+++ b/tests/unit/inference/v2/kernels/ragged_ops/test_blocked_kv_copy.py
@@ -9,6 +9,10 @@ import torch
 from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.kernels.ragged_ops import LinearBlockedKVCopy
 from .ragged_testing_utils import build_batch_and_manager, validate_kv_cache
+from ....v2.inference_test_utils import skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 @pytest.mark.inference_v2_ops

--- a/tests/unit/inference/v2/kernels/ragged_ops/test_blocked_rotary_emb.py
+++ b/tests/unit/inference/v2/kernels/ragged_ops/test_blocked_rotary_emb.py
@@ -12,13 +12,16 @@ from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.kernels.ragged_ops import BlockedRotaryEmbeddings, BlockedTrainedRotaryEmbeddings
 from deepspeed.inference.v2.ragged import RaggedBatchWrapper, DSSequenceDescriptor
 from .ragged_testing_utils import build_batch_and_manager, validate_kv_cache
-from ....v2.inference_test_utils import allclose
+from ....v2.inference_test_utils import allclose, skip_on_inference_v2
 """
 NOTE(cmikeh2): It is very possible to see unit test failures (even on FP16) depending on when
 certain values are casted up to or down from float32. If we are seeing accuracy issues, we should
 make sure we are aligning on the training implementation's cast pattern here, given these tolerances
 tend to be sufficient elsewhere.
 """
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def rotary_pos_embs(q: torch.Tensor,

--- a/tests/unit/inference/v2/kernels/ragged_ops/test_logits_gather.py
+++ b/tests/unit/inference/v2/kernels/ragged_ops/test_logits_gather.py
@@ -10,8 +10,11 @@ import torch
 
 from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.kernels.ragged_ops import RaggedLogitsGather
-from ....v2.inference_test_utils import allclose, get_dtypes
+from ....v2.inference_test_utils import allclose, get_dtypes, skip_on_inference_v2
 from .ragged_testing_utils import build_simple_batch
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def baseline_implementation(hidden_states: torch.Tensor, seq_lens: List[int]) -> torch.Tensor:

--- a/tests/unit/inference/v2/kernels/ragged_ops/test_moe_gather.py
+++ b/tests/unit/inference/v2/kernels/ragged_ops/test_moe_gather.py
@@ -14,12 +14,15 @@ from deepspeed.inference.v2.kernels.ragged_ops import (
     RaggedTopKGating,
 )
 from .ragged_testing_utils import build_simple_batch
+from ....v2.inference_test_utils import skip_on_inference_v2
 """
 For simplicity's sake, these tests do rely on ``RaggedTopKGating``  and
 ``MoEScatter`` to produce correct inputs. If either of these kernels is broken
 these tests will fail, so double check the unit test results there before
 debugging here.
 """
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 TEST_CASES = [
     # (n_tokens, n_experts, n_top_k)

--- a/tests/unit/inference/v2/kernels/ragged_ops/test_moe_scatter.py
+++ b/tests/unit/inference/v2/kernels/ragged_ops/test_moe_scatter.py
@@ -10,12 +10,15 @@ from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.inference_utils import DtypeEnum
 from deepspeed.inference.v2.kernels.ragged_ops import MoEScatter, RaggedTopKGating
 from .ragged_testing_utils import build_simple_batch
+from ....v2.inference_test_utils import skip_on_inference_v2
 """
 For simplicity's sake, these tests do rely on ``RaggedTopKGating`` to produce correct
 inputs. If ``RaggedTopKGating`` is broken, these tests will fail, so double check
 the unit test results there before debugging here.
 """
 
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 TEST_CONFIGS = [
     (13, 64, 1),
     (278, 64, 1),

--- a/tests/unit/inference/v2/kernels/ragged_ops/test_ragged_embed.py
+++ b/tests/unit/inference/v2/kernels/ragged_ops/test_ragged_embed.py
@@ -10,8 +10,11 @@ import torch
 
 from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.kernels.ragged_ops import RaggedEmbeddingKernel
-from ....v2.inference_test_utils import allclose, get_dtypes
+from ....v2.inference_test_utils import allclose, get_dtypes, skip_on_inference_v2
 from .ragged_testing_utils import build_batch_and_manager
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def baseline_implementation(token_ids: torch.Tensor,

--- a/tests/unit/inference/v2/kernels/ragged_ops/test_top_k_gating.py
+++ b/tests/unit/inference/v2/kernels/ragged_ops/test_top_k_gating.py
@@ -11,7 +11,10 @@ from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.inference_utils import DtypeEnum
 from deepspeed.inference.v2.kernels.ragged_ops import RaggedTopKGating
 from .ragged_testing_utils import build_simple_batch
-from ...inference_test_utils import allclose
+from ...inference_test_utils import allclose, skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def _top_k_gating_testing_helper(n_tokens: int, n_experts: int, n_top_k: int, seed: int = 0xC0FFEE) -> None:

--- a/tests/unit/inference/v2/model_implementations/parameters/test_contiguify.py
+++ b/tests/unit/inference/v2/model_implementations/parameters/test_contiguify.py
@@ -15,6 +15,10 @@ from deepspeed.inference.v2.model_implementations.flat_model_helpers import (
 )
 from deepspeed.inference.v2.model_implementations.layer_container_base import LayerContainer
 from .utils import SimpleParam, DummyInferenceModel
+from ....v2.inference_test_utils import skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 class TransformerLayerContainer(LayerContainer):

--- a/tests/unit/inference/v2/model_implementations/parameters/test_layer_inheritance.py
+++ b/tests/unit/inference/v2/model_implementations/parameters/test_layer_inheritance.py
@@ -8,8 +8,13 @@ import torch
 
 from deepspeed.inference.v2.inference_parameter import InferenceParameter
 from deepspeed.inference.v2.model_implementations.layer_container_base import LayerContainer
+from deepspeed.accelerator import get_accelerator
 
 from .utils import SimpleParam, DummyInferenceModel
+from ....v2.inference_test_utils import skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 class ParentLayer(LayerContainer):

--- a/tests/unit/inference/v2/model_implementations/parameters/test_mapping.py
+++ b/tests/unit/inference/v2/model_implementations/parameters/test_mapping.py
@@ -6,10 +6,15 @@
 import pytest
 import torch
 
+from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.allocator import on_device
 from deepspeed.inference.v2.inference_parameter import InferenceParameter
 from deepspeed.inference.v2.model_implementations.parameter_base import ParameterBase, ParamList
 from deepspeed.inference.v2.model_implementations.layer_container_base import LayerContainer
+from ....v2.inference_test_utils import skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 class MultiDependencyContainer(ParameterBase):

--- a/tests/unit/inference/v2/model_implementations/parameters/test_multi_parameter_layer.py
+++ b/tests/unit/inference/v2/model_implementations/parameters/test_multi_parameter_layer.py
@@ -6,10 +6,15 @@
 import pytest
 import torch
 
+from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.inference_parameter import InferenceParameter
 from deepspeed.inference.v2.model_implementations.layer_container_base import LayerContainer
 
 from .utils import validate_device, SimpleParam, ListParam, DummyInferenceModel
+from ....v2.inference_test_utils import skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 class MultiParameterLayer(LayerContainer):

--- a/tests/unit/inference/v2/model_implementations/parameters/test_parameter_list.py
+++ b/tests/unit/inference/v2/model_implementations/parameters/test_parameter_list.py
@@ -13,6 +13,10 @@ from deepspeed.inference.v2.model_implementations.layer_container_base import La
 from deepspeed.inference.v2.model_implementations.common_parameters import *
 
 from .utils import validate_device
+from ....v2.inference_test_utils import skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 class SimpleMoELayer(LayerContainer):

--- a/tests/unit/inference/v2/model_implementations/sharding/test_attn_out_sharding.py
+++ b/tests/unit/inference/v2/model_implementations/sharding/test_attn_out_sharding.py
@@ -8,7 +8,10 @@ import torch
 
 from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.model_implementations.sharding import *
+from ....v2.inference_test_utils import skip_on_inference_v2
 
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 # None of the logic should be dependent on head size.
 HEAD_SIZE = 64
 

--- a/tests/unit/inference/v2/model_implementations/sharding/test_mlp_sharding.py
+++ b/tests/unit/inference/v2/model_implementations/sharding/test_mlp_sharding.py
@@ -8,6 +8,10 @@ import torch
 
 from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.model_implementations.sharding import *
+from ....v2.inference_test_utils import skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def round_up_to_256(x: int) -> int:

--- a/tests/unit/inference/v2/model_implementations/sharding/test_qkv_sharding.py
+++ b/tests/unit/inference/v2/model_implementations/sharding/test_qkv_sharding.py
@@ -10,6 +10,10 @@ import torch
 
 from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.model_implementations.sharding import *
+from ....v2.inference_test_utils import skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def fill_with_head_ids(head_size: int, n_heads_q: int, n_heads_kv: Optional[int] = None) -> torch.Tensor:

--- a/tests/unit/inference/v2/modules/test_blas_linear_module.py
+++ b/tests/unit/inference/v2/modules/test_blas_linear_module.py
@@ -13,7 +13,10 @@ from deepspeed.inference.v2.inference_utils import ActivationType, DtypeEnum, is
 from deepspeed.inference.v2.modules import ConfigBundle
 from deepspeed.inference.v2.modules.configs import DSLinearConfig
 from deepspeed.inference.v2.modules.interfaces import DSLinearRegistry
-from ...v2.inference_test_utils import allclose
+from ...v2.inference_test_utils import allclose, skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def reference_implementation(hidden_states: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor],

--- a/tests/unit/inference/v2/modules/test_blocked_attn.py
+++ b/tests/unit/inference/v2/modules/test_blocked_attn.py
@@ -16,13 +16,16 @@ from deepspeed.inference.v2.modules.configs import DSSelfAttentionConfig, Positi
 from deepspeed.inference.v2.modules.interfaces import DSSelfAttentionRegistry, DSSelfAttentionBase
 
 from ..kernels.ragged_ops.ragged_testing_utils import build_batch_and_manager
-from ...v2.inference_test_utils import allclose
+from ...v2.inference_test_utils import allclose, skip_on_inference_v2
 
 try:
     from flash_attn.flash_attn_interface import flash_attn_varlen_func
     validate_accuracy = True
 except ImportError:
     validate_accuracy = False
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def _blocked_flash_testing_helper(head_size: int,

--- a/tests/unit/inference/v2/modules/test_cuda_pre_ln_module.py
+++ b/tests/unit/inference/v2/modules/test_cuda_pre_ln_module.py
@@ -12,7 +12,10 @@ from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.modules import ConfigBundle
 from deepspeed.inference.v2.modules.configs import DSNormConfig
 from deepspeed.inference.v2.modules.interfaces import DSPreNormRegistry
-from ...v2.inference_test_utils import get_dtypes, allclose
+from ...v2.inference_test_utils import get_dtypes, allclose, skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def reference_implementation(residual: torch.Tensor, hidden_states: Optional[torch.Tensor], gamma: torch.Tensor,

--- a/tests/unit/inference/v2/modules/test_custom_module.py
+++ b/tests/unit/inference/v2/modules/test_custom_module.py
@@ -11,7 +11,10 @@ from deepspeed.inference.v2.modules import ConfigBundle
 from deepspeed.inference.v2.modules.interfaces import DSPostNormRegistry
 from deepspeed.inference.v2.modules.configs import DSNormConfig
 from deepspeed.inference.v2.modules.implementations import cuda_post_ln
-from ...v2.inference_test_utils import allclose
+from ...v2.inference_test_utils import allclose, skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def reference_implementation(residual: torch.Tensor, hidden_states: torch.Tensor, gamma: torch.Tensor,

--- a/tests/unit/inference/v2/modules/test_cutlass_moe.py
+++ b/tests/unit/inference/v2/modules/test_cutlass_moe.py
@@ -15,7 +15,10 @@ from deepspeed.inference.v2.modules.configs import DSMoEConfig
 from deepspeed.inference.v2.modules.interfaces import DSMoERegistry
 
 from ..kernels.ragged_ops.ragged_testing_utils import build_simple_batch
-from ...v2.inference_test_utils import allclose, get_dtypes
+from ...v2.inference_test_utils import allclose, get_dtypes, skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def _gating_reference(logits: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/tests/unit/inference/v2/modules/test_post_ln_module.py
+++ b/tests/unit/inference/v2/modules/test_post_ln_module.py
@@ -10,7 +10,10 @@ from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.modules import ConfigBundle
 from deepspeed.inference.v2.modules.configs import DSNormConfig
 from deepspeed.inference.v2.modules.interfaces import DSPostNormRegistry
-from ...v2.inference_test_utils import get_dtypes, allclose
+from ...v2.inference_test_utils import get_dtypes, allclose, skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def reference_implementation(residual: torch.Tensor, hidden_states: torch.Tensor, gamma: torch.Tensor,

--- a/tests/unit/inference/v2/modules/test_pre_rms_module.py
+++ b/tests/unit/inference/v2/modules/test_pre_rms_module.py
@@ -12,7 +12,10 @@ from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.modules import ConfigBundle
 from deepspeed.inference.v2.modules.configs import DSNormConfig
 from deepspeed.inference.v2.modules.interfaces import DSPreNormRegistry
-from ...v2.inference_test_utils import get_dtypes, allclose
+from ...v2.inference_test_utils import get_dtypes, allclose, skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 def reference_implementation(residual: torch.Tensor, hidden_states: Optional[torch.Tensor], gamma: torch.Tensor,

--- a/tests/unit/inference/v2/ragged/test_blocked_allocator.py
+++ b/tests/unit/inference/v2/ragged/test_blocked_allocator.py
@@ -9,7 +9,12 @@ from typing import List
 import pytest
 import torch
 
+from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.ragged.blocked_allocator import BlockedAllocator
+from ...v2.inference_test_utils import skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 @pytest.mark.inference_v2

--- a/tests/unit/inference/v2/ragged/test_manager_configs.py
+++ b/tests/unit/inference/v2/ragged/test_manager_configs.py
@@ -7,7 +7,12 @@ import pytest
 
 from pydantic import ValidationError
 
+from deepspeed.accelerator import get_accelerator
 from deepspeed.inference.v2.ragged import DSStateManagerConfig
+from ...v2.inference_test_utils import skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 @pytest.mark.inference_v2

--- a/tests/unit/inference/v2/ragged/test_ragged_wrapper.py
+++ b/tests/unit/inference/v2/ragged/test_ragged_wrapper.py
@@ -14,6 +14,10 @@ from deepspeed.inference.v2.ragged import (
     RaggedBatchWrapper,
     DSStateManagerConfig,
 )
+from ...v2.inference_test_utils import skip_on_inference_v2
+
+pytestmark = pytest.mark.skipif(skip_on_inference_v2(),
+                                reason=f'Inference V2 not supported by {get_accelerator().device_name()}.')
 
 
 @pytest.mark.inference_v2

--- a/tests/unit/ops/adam/test_cpu_adam.py
+++ b/tests/unit/ops/adam/test_cpu_adam.py
@@ -11,7 +11,7 @@ from cpuinfo import get_cpu_info
 import deepspeed
 from deepspeed.accelerator import get_accelerator
 from deepspeed.ops.adam import FusedAdam
-from deepspeed.ops.op_builder import CPUAdamBuilder
+from deepspeed.ops.op_builder import CPUAdamBuilder, FusedAdamBuilder
 from unit.common import DistributedTest
 
 if not deepspeed.ops.__compatible_ops__[CPUAdamBuilder.NAME]:
@@ -62,6 +62,8 @@ class TestCPUAdam(DistributedTest):
         set_dist_env = False
 
     @pytest.mark.skipif(not get_accelerator().is_available(), reason="only supported in CUDA environments.")
+    @pytest.mark.skipif(not deepspeed.ops.__compatible_ops__[FusedAdamBuilder.NAME],
+                        reason="FusedAdam is not compatible")
     def test_fused_adam_equal(self, dtype, model_size):
         if ("amd" in pytest.cpu_vendor) and (dtype == torch.half):
             pytest.skip("cpu-adam with half precision not supported on AMD CPUs")

--- a/tests/unit/ops/adam/test_hybrid_adam.py
+++ b/tests/unit/ops/adam/test_hybrid_adam.py
@@ -12,7 +12,7 @@ from cpuinfo import get_cpu_info
 import deepspeed
 from deepspeed.accelerator import get_accelerator
 from deepspeed.ops.adam import FusedAdam, DeepSpeedCPUAdam
-from deepspeed.ops.op_builder import CPUAdamBuilder
+from deepspeed.ops.op_builder import CPUAdamBuilder, FusedAdamBuilder
 from unit.common import DistributedTest
 
 if not deepspeed.ops.__compatible_ops__[CPUAdamBuilder.NAME]:
@@ -43,6 +43,8 @@ class TestHybridAdam(DistributedTest):
         set_dist_env = False
 
     @pytest.mark.skipif(not get_accelerator().is_available(), reason="only supported in CUDA environments.")
+    @pytest.mark.skipif(not deepspeed.ops.__compatible_ops__[FusedAdamBuilder.NAME],
+                        reason="FusedAdam is not compatible")
     def test_hybrid_adam_equal(self, dtype, model_size):
         if ("amd" in pytest.cpu_vendor) and (dtype == torch.half):
             pytest.skip("cpu-adam with half precision not supported on AMD CPUs")

--- a/tests/unit/runtime/half_precision/test_dynamic_loss_scale.py
+++ b/tests/unit/runtime/half_precision/test_dynamic_loss_scale.py
@@ -4,10 +4,12 @@
 # DeepSpeed Team
 
 import torch
+import pytest
 import deepspeed
 import numpy as np
 from unit.common import DistributedTest
 from unit.simple_model import SimpleModel
+from deepspeed.ops.op_builder import FusedLambBuilder
 
 
 def run_model_step(model, gradient_list):
@@ -143,6 +145,7 @@ class TestFused(DistributedTest):
         assert optim.cur_iter == expected_iteration
 
 
+@pytest.mark.skipif(not deepspeed.ops.__compatible_ops__[FusedLambBuilder.NAME], reason="lamb is not compatible")
 class TestUnfused(DistributedTest):
     world_size = 1
 

--- a/tests/unit/runtime/test_ds_initialize.py
+++ b/tests/unit/runtime/test_ds_initialize.py
@@ -18,6 +18,7 @@ from deepspeed.ops.adam import FusedAdam
 from deepspeed.runtime.lr_schedules import WARMUP_LR, WarmupLR
 from deepspeed.runtime.config import ADAM_OPTIMIZER
 from deepspeed.runtime.utils import see_memory_usage, required_torch_version
+from deepspeed.ops.op_builder import FusedAdamBuilder
 
 
 @pytest.mark.parametrize('zero_stage', [0, 3])
@@ -68,6 +69,9 @@ class TestClientOptimizer(DistributedTest):
         def _optimizer_callable(params) -> Optimizer:
             return AdamW(params=params)
 
+        if (optimizer_type is None) and (not deepspeed.ops.__compatible_ops__[FusedAdamBuilder.NAME]):
+            pytest.skip("FusedAdam is not compatible")
+
         hidden_dim = 10
         model = SimpleModel(hidden_dim)
 
@@ -96,6 +100,8 @@ class TestClientOptimizer(DistributedTest):
 class TestConfigOptimizer(DistributedTest):
     world_size = 1
 
+    @pytest.mark.skipif(not deepspeed.ops.__compatible_ops__[FusedAdamBuilder.NAME],
+                        reason="FusedAdam is not compatible")
     def test(self, client_parameters):
         ds_config = {"train_batch_size": 1, "optimizer": {"type": "Adam", "params": {"lr": 0.001}}}
 


### PR DESCRIPTION
Added support for skipping Inference V2 tests when the accelerator is not compatible.

This commit implements the capability to skip Inference V2 tests in scenarios where the accelerator does not support Inference V2. A condition check has been added to ensure the tests are bypassed when the hardware configuration lacks support for Inference V2, mitigating potential issues.

Details:
- Implemented a condition check to assess accelerator compatibility with Inference V2.
- In cases of non-support, Inference V2 tests will be skipped, enhancing the reliability of the test suite.
- This enhancement aims to improve compatibility and stability across diverse hardware configurations.