### PR TITLE
Pin to PyTest 8.0.0

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -6,7 +6,7 @@ future
 importlib-metadata>=4
 mup
 pre-commit>=2.20.0
-pytest
+pytest<=8.0.0
 pytest-forked
 pytest-randomly
 pytest-xdist


### PR DESCRIPTION
Fix failures in nv-accelerate-v100 unit tests.

Fix running on this PR: https://github.com/microsoft/DeepSpeed/actions/runs/7923894998/job/21634533848
Original failure [here](https://github.com/microsoft/DeepSpeed/actions/runs/7961285826/job/21748664124?pr=5129#step:7:415):
```
    from _pytest.doctest import (
E   ImportError: cannot import name 'import_path' from '_pytest.doctest' (/tmp/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.8/site-packages/_pytest/doctest.py)
```