### PR TITLE
allow debug/experimental compiler backends

### DIFF
--- a/deepspeed/runtime/compiler.py
+++ b/deepspeed/runtime/compiler.py
@@ -35,7 +35,7 @@ def get_backend_fn(backend: Union[str, Callable]) -> Union[str, Callable]:
         return backend
 
     elif isinstance(backend, str):
-        if backend in torch._dynamo.list_backends():
+        if backend in torch._dynamo.list_backends(exclude_tags=()):
             return backend
 
         # Get module name from backend name


### PR DESCRIPTION
As mentioned at https://github.com/microsoft/DeepSpeed/pull/4878#discussion_r1493712812, we are currently unable to enable debug or experimental backends for the compiler. This PR enables users to utilize these backends.