### PR TITLE
Fix moe cpu offload

### DIFF
--- a/.github/workflows/nv-mii.yml
+++ b/.github/workflows/nv-mii.yml
@@ -2,6 +2,12 @@ name: nv-mii
 
 on:
   workflow_dispatch:
+    inputs:
+      mii_branch:
+        description: 'DeepSpeed-MII Branch'
+        required: false
+        default: 'main'
+        type: string
   pull_request:
     paths:
       - '.github/workflows/nv-mii.yml'
@@ -55,7 +61,12 @@ jobs:
 
       - name: MII unit tests
         run: |
-          git clone https://github.com/microsoft/DeepSpeed-MII.git
+          BRANCH="main"
+          if [[ ! -z "${{ github.event.inputs.mii_branch }}" ]]; then
+              BRANCH="${{ github.event.inputs.mii_branch }}"
+          fi
+          echo "Cloning DeepSpeed-MII branch: $BRANCH"
+          git clone -b $BRANCH --depth=1 https://github.com/microsoft/DeepSpeed-MII.git
           cd DeepSpeed-MII
           pip install .[dev]
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1782,8 +1782,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             else:
                 norm_groups.append(self.get_grad_norm_direct(self.averaged_gradients[i], self.params_in_partition[i]))
 
-        if self.has_moe_layers:
-            self._average_expert_grad_norms(norm_groups)
+        if self.has_moe_layers and self.device != 'cpu':
+                self._average_expert_grad_norms(norm_groups)
 
         # calculating L2 norm
         return torch.norm(torch.stack(norm_groups), p=norm_type)

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1782,7 +1782,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             else:
                 norm_groups.append(self.get_grad_norm_direct(self.averaged_gradients[i], self.params_in_partition[i]))
 
-        if self.has_moe_layers and self.device != 'cpu':
+        if self.has_moe_layers:
             self._average_expert_grad_norms(norm_groups)
 
         # calculating L2 norm
@@ -1946,8 +1946,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         for i, norm in enumerate(norm_groups):
             if self.is_moe_param_group[i]:
                 scaled_norm_tensor = norm * 1.0 / dist.get_world_size(group=self.real_dp_process_group[i])
+                if self.device == 'cpu':
+                    scaled_norm_tensor = scaled_norm_tensor.to(get_accelerator().current_device_name())
                 dist.all_reduce(scaled_norm_tensor, group=self.real_dp_process_group[i])
-                norm_groups[i] = scaled_norm_tensor
+                norm_groups[i] = scaled_norm_tensor.to(self.device)
 
     def unscale_and_clip_grads(self, grad_groups_flat, total_norm):
         # compute combined scale factor for this group

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1783,7 +1783,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 norm_groups.append(self.get_grad_norm_direct(self.averaged_gradients[i], self.params_in_partition[i]))
 
         if self.has_moe_layers and self.device != 'cpu':
-                self._average_expert_grad_norms(norm_groups)
+            self._average_expert_grad_norms(norm_groups)
 
         # calculating L2 norm
         return torch.norm(torch.stack(norm_groups), p=norm_type)


### PR DESCRIPTION
The MoE- param gradients norms don't need to be averaged when created on CPU only when using 1-DP training. However, I just moved the tensor back to GPU to get average when having data-parallel on the MoE parameters and using CPU-offload.

This PR addresses https://github.com/microsoft/DeepSpeed/issues/5203