### PR TITLE
Add CI for Habana Labs HPU/Gaudi2

### DIFF
--- a/.github/workflows/gaudi2.yml
+++ b/.github/workflows/gaudi2.yml
@@ -1,0 +1,32 @@
+name: gaudi2
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  unit-tests:
+    # The type of runner that the job will run on
+    runs-on: [self-hosted, intel, gaudi2]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      - id: setup-venv
+        uses: ./.github/workflows/setup-venv
+
+      - name: Python environment
+        run: |
+          pip list

--- a/.github/workflows/gaudi2.yml
+++ b/.github/workflows/gaudi2.yml
@@ -18,15 +18,20 @@ jobs:
   unit-tests:
     # The type of runner that the job will run on
     runs-on: [self-hosted, intel, gaudi2]
+    container:
+      image: vault.habana.ai/gaudi-docker/1.14.0/ubuntu22.04/habanalabs/pytorch-installer-2.1.1:latest
+      ports:
+        - 80
+      options: --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --net=host --ipc=host
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
-      - id: setup-venv
-        uses: ./.github/workflows/setup-venv
-
-      - name: Python environment
+      - name: Check container state
         run: |
-          pip list
+          ldd --version
+          hl-smi
+          python -c "import torch; print('torch:', torch.__version__, torch)"
+          python -c "import torch; print('CUDA available:', torch.cuda.is_available())"

--- a/.github/workflows/gaudi2.yml
+++ b/.github/workflows/gaudi2.yml
@@ -22,7 +22,7 @@ jobs:
       image: vault.habana.ai/gaudi-docker/1.14.0/ubuntu22.04/habanalabs/pytorch-installer-2.1.1:latest
       ports:
         - 80
-      options: --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --net=host --ipc=host
+      options: --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/hpu-gaudi2.yml
+++ b/.github/workflows/hpu-gaudi2.yml
@@ -35,3 +35,12 @@ jobs:
           hl-smi
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
+
+      - name: Install deepspeed
+        run: |
+          pip install .[dev]
+          ds_report
+
+      - name: Python environment
+        run: |
+          pip list

--- a/.github/workflows/hpu-gaudi2.yml
+++ b/.github/workflows/hpu-gaudi2.yml
@@ -1,4 +1,4 @@
-name: gaudi2
+name: hpu-gaudi2
 
 on:
   workflow_dispatch:

--- a/.github/workflows/hpu-gaudi2.yml
+++ b/.github/workflows/hpu-gaudi2.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: "0 0 * * *"
   pull_request:
+    paths:
+      - ".github/workflows/hpu-gaudi2.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/tests/unit/util.py
+++ b/tests/unit/util.py
@@ -47,10 +47,13 @@ def bf16_required_version_check(accelerator_check=True):
     cuda_version_available = CUDA_MAJOR >= 11
     nccl_version_available = NCCL_MAJOR > 2 or (NCCL_MAJOR == 2 and NCCL_MINOR >= 10)
     npu_available = get_accelerator().device_name() == 'npu'
+    hpu_available = get_Accelerator().device_name() == 'hpu'
 
     if torch_version_available and cuda_version_available and nccl_version_available and accelerator_pass:
         return True
     elif npu_available:
+        return True
+    elif hpu_available:
         return True
     else:
         return False

--- a/tests/unit/util.py
+++ b/tests/unit/util.py
@@ -47,7 +47,7 @@ def bf16_required_version_check(accelerator_check=True):
     cuda_version_available = CUDA_MAJOR >= 11
     nccl_version_available = NCCL_MAJOR > 2 or (NCCL_MAJOR == 2 and NCCL_MINOR >= 10)
     npu_available = get_accelerator().device_name() == 'npu'
-    hpu_available = get_Accelerator().device_name() == 'hpu'
+    hpu_available = get_accelerator().device_name() == 'hpu'
 
     if torch_version_available and cuda_version_available and nccl_version_available and accelerator_pass:
         return True


### PR DESCRIPTION
Add basic workflow that tests on hpu-gaudi2.  Currently, ops are not implemented, so the full unit tests are not yet enabled.