### PR TITLE
Disable torch.nn.init when counting parmeters in initializing PipelineModule

### DIFF
--- a/deepspeed/runtime/pipe/module.py
+++ b/deepspeed/runtime/pipe/module.py
@@ -83,6 +83,18 @@ class TiedLayerSpec(LayerSpec):
         self.tied_weight_attr = [tied_weight_attr] if type(tied_weight_attr) == str else tied_weight_attr
 
 
+class _DisableInit(torch.overrides.TorchFunctionMode):
+    def __torch_function__(self, func, types, args=(), kwargs=None):
+        kwargs = kwargs or {}
+        if getattr(func, '__module__', None) == 'torch.nn.init':
+            if 'tensor' in kwargs:
+                return kwargs['tensor']
+            else:
+                return args[0]
+        else:
+            return func(*args, **kwargs)
+
+
 class PipelineModule(nn.Module):
     """Modules to be parallelized with pipeline parallelism.
 
@@ -269,7 +281,8 @@ class PipelineModule(nn.Module):
                 A list of frozen parameter names
         """
         if isinstance(layer, LayerSpec):
-            l = layer.build()
+            with _DisableInit():
+                l = layer.build()
             return [n for n, p in l.named_parameters() if not p.requires_grad]
         elif isinstance(layer, nn.Module):
             return [n for n, p in layer.named_parameters() if not p.requires_grad]
@@ -287,7 +300,8 @@ class PipelineModule(nn.Module):
         param_counts = [0] * len(self._layer_specs)
         for idx, layer in enumerate(self._layer_specs):
             if isinstance(layer, LayerSpec):
-                l = layer.build()
+                with _DisableInit():
+                    l = layer.build()
                 params = filter(lambda p: p.requires_grad, l.parameters())
                 param_counts[idx] = sum(p.numel() for p in params)
             elif isinstance(layer, nn.Module):


### PR DESCRIPTION
Disable any function call in torch.nn.init when counting parameters in initializing PipelineModule.

This change can greatly save the launching time of pipeline parallelism, by speeding up parameter partitioning. I have tested it with Llama2 70B, reducing the partition time from 8 minutes to less than 1 second.