### PR TITLE
Replace HIP_PLATFORM_HCC with HIP_PLATFORM_AMD

### DIFF
--- a/deepspeed/inference/v2/kernels/core_ops/blas_kernels/blas_utils.h
+++ b/deepspeed/inference/v2/kernels/core_ops/blas_kernels/blas_utils.h
@@ -13,7 +13,7 @@
 #endif
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
-#ifndef __HIP_PLATFORM_HCC__
+#ifndef __HIP_PLATFORM_AMD__
 #include <mma.h>
 #endif
 #include <stdio.h>
@@ -33,7 +33,7 @@ public:
             std::cerr << message << std::endl;
             throw std::runtime_error(message);
         }
-#ifndef __HIP_PLATFORM_HCC__
+#ifndef __HIP_PLATFORM_AMD__
         cublasSetMathMode(_handle, CUBLAS_TENSOR_OP_MATH);
 #endif
     }
@@ -55,7 +55,7 @@ private:
 
 enum class BlasType { FP32, FP16, BF16 };
 
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
 rocblas_operation get_trans_op(bool do_trans)
 {
     return (do_trans) ? rocblas_operation_transpose : rocblas_operation_none;
@@ -99,7 +99,7 @@ int blas_gemm_ex(void* C,
                  const float* beta,
                  BlasType type)
 {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
     rocblas_operation_t transa_op = get_trans_op(transa);
     rocblas_operation_t transb_op = get_trans_op(transb);
 
@@ -155,7 +155,7 @@ int blas_gemm_ex(void* C,
                                          CUBLAS_GEMM_DEFAULT_TENSOR_OP);
 #endif
 
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
     if (status != rocblas_status_success) {
 #else
     if (status != CUBLAS_STATUS_SUCCESS) {
@@ -190,7 +190,7 @@ int blas_strided_batched_gemm(void* C,
                               int batch,
                               BlasType type)
 {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
     rocblas_operation_t transa_op = get_trans_op(transa);
     rocblas_operation_t transb_op = get_trans_op(transb);
 
@@ -257,7 +257,7 @@ int blas_strided_batched_gemm(void* C,
                                                        CUBLAS_GEMM_DEFAULT_TENSOR_OP);
 #endif
 
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
     if (status != rocblas_status_success) {
 #else
     if (status != CUBLAS_STATUS_SUCCESS) {

--- a/deepspeed/inference/v2/ragged/csrc/ragged_ops.cpp
+++ b/deepspeed/inference/v2/ragged/csrc/ragged_ops.cpp
@@ -23,7 +23,7 @@ copies.
 */
 torch::Tensor allocate_fast_host_buffer(torch::Tensor device_mirror)
 {
-#ifdef __HIP_PLATFORM_HCC__
+#ifdef __HIP_PLATFORM_AMD__
     auto options =
         torch::TensorOptions().device(torch::kCPU).pinned_memory(true).dtype(device_mirror.dtype());
     auto buffer = torch::empty(device_mirror.sizes(), options);


### PR DESCRIPTION
This PR resolves a part of https://github.com/microsoft/DeepSpeed/issues/4989 issues.

HIP_PLATFORM_AMD is defined if the HIP platform targets AMD. Note, HIP_PLATFORM_HCC was previously defined if the HIP platform targeted AMD, it is deprecated.
Reference: https://rocm.docs.amd.com/projects/HIP/en/latest/user_guide/hip_porting_guide.html#identifying-hip-target-platform