### PR TITLE
Fix dtype-related RuntimeError when computing scaled global norm

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1308,7 +1308,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         total_norm = total_norm_cuda[0].item()**(1. / norm_type)
 
         if total_norm == float('inf') or total_norm == -float('inf') or total_norm != total_norm:
-            total_norm = -1
+            total_norm = -1.
 
         return total_norm
 


### PR DESCRIPTION
`complete_grad_norm_calculation_for_cpu_offload` can return a python int even though `scaled_global_norm` expects it to always return a python float which makes `torch.norm` fail with a RuntimeError.