### PR TITLE
Disable compile for Z3 hook function

### DIFF
--- a/deepspeed/runtime/zero/partitioned_param_coordinator.py
+++ b/deepspeed/runtime/zero/partitioned_param_coordinator.py
@@ -186,6 +186,7 @@ class PartitionedParameterCoordinator:
         self.__submodule_order.append(sub_module)
         self.__step_id_module_fetched_for[sub_module.id].append(self.__step_id)
 
+    @compiler.disable
     def record_parameters(self, sub_module: Module) -> None:
         """adds sub module to trace"""
         if not self.is_record_trace():


### PR DESCRIPTION
The example shown in https://github.com/huggingface/accelerate/pull/2460#issue-2140799061 required us to disable compile for  `record_parameters` when we run forward under `no_grad()`.
This PR adds `@compiler.disable` to the function.