### PR TITLE
BF16 optimizer: Clear lp grads after updating hp grads in hook

### DIFF
--- a/deepspeed/runtime/bf16_optimizer.py
+++ b/deepspeed/runtime/bf16_optimizer.py
@@ -532,7 +532,7 @@ class BF16_Optimizer(ZeROOptimizer):
 
     def accumulate_hp_grads_and_remove_lp(self, lp_param, group_idx, param_idx):
         assert self.immediate_grad_update
-        self._update_hp_grad(lp_param, group_idx, param_idx, clear_lp_grads=False)
+        self._update_hp_grad(lp_param, group_idx, param_idx, clear_lp_grads=True)
 
     def create_grad_acc_hooks(self):
         self.grad_accs = []


### PR DESCRIPTION
This fix is to solve:

- Previous iteration's lp grads will still alive during the next iteration's forward. This increases the memory footprint.
- The hook behavior is not aligned to its name accumulate_hp_grads_and_remove_lp