### PR TITLE
set the default to use set_to_none for clearing gradients in BF16 optimizer.

### DIFF
--- a/deepspeed/runtime/bf16_optimizer.py
+++ b/deepspeed/runtime/bf16_optimizer.py
@@ -341,7 +341,7 @@ class BF16_Optimizer(ZeROOptimizer):
 
         # clear gradients
         if clear_lp_grads:
-            lp.grad._zero()
+            lp.grad.zero_()
 
     @torch.no_grad()
     def _update_hp_grads_func(self, clear_lp_grads=False):
@@ -447,6 +447,8 @@ class BF16_Optimizer(ZeROOptimizer):
         zero_grads_list = []
         for group in self.bf16_groups:
             for param in group:
+                if param.grad is not None:
+                    assert param.grad.grad_fn == None
                 if set_to_none:
                     param.grad = None
                 elif param.grad is not None:

--- a/deepspeed/runtime/bf16_optimizer.py
+++ b/deepspeed/runtime/bf16_optimizer.py
@@ -443,15 +443,15 @@ class BF16_Optimizer(ZeROOptimizer):
     def clear_lp_grads(self):
 
         # using zero_() fixed memory address for graph replay
-        set_to_none = set_to_none = False if self.graph_harvesting else True
+        set_to_none = False if self.graph_harvesting else True
         zero_grads_list = []
         for group in self.bf16_groups:
             for param in group:
-                if param.grad is not None:
-                    assert param.grad.grad_fn == None
                 if set_to_none:
                     param.grad = None
                 elif param.grad is not None:
+                    if param.grad.grad_fn is not None:
+                        param.grad.detach_()
                     zero_grads_list.append(param.grad)
         if not set_to_none and len(zero_grads_list) > 0:
             torch._foreach_zero_(zero_grads_list)

--- a/deepspeed/runtime/bf16_optimizer.py
+++ b/deepspeed/runtime/bf16_optimizer.py
@@ -441,11 +441,18 @@ class BF16_Optimizer(ZeROOptimizer):
             self.fp32_groups_has_gradients[i] = [False] * len(group)
 
     def clear_lp_grads(self):
+
+        # using zero_() fixed memory address for graph replay
+        set_to_none = set_to_none = False if self.graph_harvesting else True
+        zero_grads_list = []
         for group in self.bf16_groups:
             for param in group:
-                if param.grad is not None:
-                    # Using zero_() fixed memory address for graph replay
-                    param.grad.zero_()
+                if set_to_none:
+                    param.grad = None
+                elif param.grad is not None:
+                    zero_grads_list.append(param.grad)
+        if not set_to_none and len(zero_grads_list) > 0:
+            torch._foreach_zero_(zero_grads_list)
 
     def state_dict(self):
         state_dict = {}

--- a/docs/_sass/minimal-mistakes/_sidebar.scss
+++ b/docs/_sass/minimal-mistakes/_sidebar.scss
@@ -76,10 +76,9 @@
 
   @include breakpoint($large) {
     position: absolute;
-    top: 0;
+    top: auto;
     right: 0;
     width: $right-sidebar-width-narrow;
-    margin-right: -1.5 * $right-sidebar-width-narrow;
     padding-left: 1em;
     z-index: 10;
 
@@ -94,7 +93,6 @@
 
   @include breakpoint($x-large) {
     width: $right-sidebar-width;
-    margin-right: -1.5 * $right-sidebar-width;
   }
 }
 


### PR DESCRIPTION
as discussed in #5175,  set the default to use set_to_none for clearing gradients in BF16 optimizer.
Additionally, for the case of zero clearing, use foreach_zero.
Verified correctness with mega-ds llama 7B training.

FYI @loadams 