### PR TITLE
Fix RuntimeError for moe on XPU: tensors found at least two devices

### DIFF
--- a/deepspeed/moe/sharded_moe.py
+++ b/deepspeed/moe/sharded_moe.py
@@ -220,7 +220,7 @@ def top1gating(logits: Tensor,
             tp = 1 if groups.mpu is None else bwc_tensor_model_parallel_world_size(mpu=groups.mpu)
             new_capacity = torch.ceil(new_capacity / tp).mul(tp).to(new_capacity.dtype)
         # Make sure the capacity value does not exceed the number of tokens.
-        capacity = min(new_capacity, torch.tensor(mask1.size(0)))
+        capacity = min(new_capacity, torch.tensor(mask1.size(0)).to(new_capacity.device))
 
     # Compute l_aux
     me = torch.mean(gates, dim=0)

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -1039,7 +1039,7 @@ def get_norm_with_moe_layers(non_expert_norm, mpu, expert_tensors, norm_type=2):
     """
 
     def to_tensor(v):
-        return get_accelerator().FloatTensor([float(v)]).detach()
+        return get_accelerator().FloatTensor(float(v)).detach()
 
     group_norms = [non_expert_norm]
     for exp_name, tensors in expert_tensors.items():

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -1039,7 +1039,7 @@ def get_norm_with_moe_layers(non_expert_norm, mpu, expert_tensors, norm_type=2):
     """
 
     def to_tensor(v):
-        return get_accelerator().FloatTensor(float(v)).detach()
+        return get_accelerator().FloatTensor([float(v)]).detach()
 
     group_norms = [non_expert_norm]
     for exp_name, tensors in expert_tensors.items():


### PR DESCRIPTION
There is following error on XPU while unit testing "DeepSpeed/tests/unit/moe/test_moe.py"
DeepSpeed/deepspeed/moe/sharded_moe.py line 223, in top1gating
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, xpu:0 and cpu!

Fix it by device conversion.