### PR TITLE
Switch pynvml to nvidia-ml-py

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,10 +1,10 @@
 hjson
 ninja
 numpy
+nvidia-ml-py
 packaging>=20.0
 psutil
 py-cpuinfo
 pydantic
-nvidia-ml-py
 torch
 tqdm

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,6 +5,6 @@ packaging>=20.0
 psutil
 py-cpuinfo
 pydantic
-pynvml
+nvidia-ml-py
 torch
 tqdm


### PR DESCRIPTION
Fixes: #5517 

Link to PyPI for nvidia-ml-py [here](https://pypi.org/project/nvidia-ml-py/) showing usage remaining the same as previous pynvml package.