### PR TITLE
Add hybrid_engine.py as path to trigger the DS-Chat GH workflow

### DIFF
--- a/.github/workflows/nv-ds-chat.yml
+++ b/.github/workflows/nv-ds-chat.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - "deepspeed/runtime/zero/stage_1_and_2.py"
       - "deepspeed/runtime/zero/stage3.py"
+      - "deepspeed/runtime/hybrid_engine.py"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR updates the `nv-ds-chat` GitHub workflow to include `hybrid_engine.py` file in the path. This is done to ensure testing on the DS-Chat flow is done whenever any changes are made to the Hybrid Engine.