### PR TITLE
Fix cuda hardcode for inference woq

### DIFF
--- a/deepspeed/inference/quantization/utils.py
+++ b/deepspeed/inference/quantization/utils.py
@@ -107,7 +107,7 @@ class DeQuantizer:
         if self.config['group_size'] % 8 == 0 and \
                 (self.config['num_bits'] == 4 or self.config['num_bits'] == 8) and \
                 self.config['group_dim'] == len(tensor.shape) - 1 and \
-                    self.dtype == torch.float16 and device == 'cuda':
+                    self.dtype == torch.float16 and device == get_accelerator().device_name():
 
             last_dimension_size = self.config['group_size']
             if self.config['num_bits'] == 4:

--- a/deepspeed/inference/quantization/utils.py
+++ b/deepspeed/inference/quantization/utils.py
@@ -14,14 +14,14 @@ import functools
 
 device = get_accelerator().device_name() if get_accelerator().is_available() else 'cpu'
 
-quantizer_cuda_module = None
+quantizer_module = None
 
 
-def get_quantizer_cuda_module():
-    global quantizer_cuda_module
-    if quantizer_cuda_module is None:
-        quantizer_cuda_module = deepspeed.ops.op_builder.QuantizerBuilder().load()
-    return quantizer_cuda_module
+def get_quantizer_module():
+    global quantizer_module
+    if quantizer_module is None:
+        quantizer_module = deepspeed.ops.op_builder.QuantizerBuilder().load()
+    return quantizer_module
 
 
 def tensor_clamp(tensor: Tensor, min, max) -> Tensor:
@@ -112,14 +112,14 @@ class DeQuantizer:
             last_dimension_size = self.config['group_size']
             if self.config['num_bits'] == 4:
                 last_dimension_size = last_dimension_size // 2
-                quantized_tensor = get_quantizer_cuda_module().dequantize_int4_to_half_experimental(
+                quantized_tensor = get_quantizer_module().dequantize_int4_to_half_experimental(
                     tensor.reshape(-1, last_dimension_size), quant_scale, quant_min,
                     tensor.numel() // last_dimension_size, self.config['group_size'])
                 shape = list(tensor.shape)
                 shape[-1] = shape[-1] * 2
             elif self.config['num_bits'] == 8:
                 # last_dimension_size = last_dimension_size // 2
-                quantized_tensor = get_quantizer_cuda_module().dequantize_int8_to_half_experimental(
+                quantized_tensor = get_quantizer_module().dequantize_int8_to_half_experimental(
                     tensor.reshape(-1, last_dimension_size), quant_scale, quant_min,
                     tensor.numel() // last_dimension_size, self.config['group_size'])
                 shape = list(tensor.shape)


### PR DESCRIPTION
This is a simple fix for inference woq part, changing from `'cuda'` to `get_accelerator().device_name()`.