### PR TITLE
[MiCS] Remove the handle print on DeepSpeed side

### DIFF
--- a/deepspeed/runtime/zero/mics.py
+++ b/deepspeed/runtime/zero/mics.py
@@ -43,7 +43,7 @@ class MiCS_AllGatherCoalescedHandle(AllGatherCoalescedHandle):
         """
         # let the current stream to op
         try:
-            print("HANDLE", self.allgather_handle)
+            # print("HANDLE", self.allgather_handle)
             instrument_w_nvtx(self.allgather_handle.wait)()
         except (ValueError, RuntimeError) as e:
             log_dist(


### PR DESCRIPTION
When running for MiCS, we found many handle print on DeepSpeed from the output log, this pr is to remove it to suppress this.