### PR TITLE
Add compile backend arg for test_set_compiler_fn

### DIFF
--- a/tests/unit/runtime/compile/test_load_config.py
+++ b/tests/unit/runtime/compile/test_load_config.py
@@ -29,7 +29,7 @@ if deepspeed.is_compile_supported():
     def custom_compiler_fn(module: torch.nn.Module):
         global custom_compler_fn_called
         custom_compler_fn_called = True
-        return torch.compile(module)
+        return torch.compile(module, backend=get_accelerator().get_compile_backend())
 
 
 @pytest.fixture


### PR DESCRIPTION
Fix the test_set_compiler_fn UT, current test_set_compiler_fn uses inductor as a backend, which is incompatible with HPU. Added backend arg to torch.compile.