### PR TITLE
Updated hpu-gaudi2 tests content.

### DIFF
--- a/.github/workflows/hpu-gaudi2.yml
+++ b/.github/workflows/hpu-gaudi2.yml
@@ -52,7 +52,6 @@ jobs:
         test_compression.py
         test_dist.py
         test_elastic.py
-        (test_intX_quantization.py and test_quantized_linear)
         test_ds_arguments.py
         test_run.py
         test_multinode_runner.py


### PR DESCRIPTION
Updated hpu-gaudi2 tests content as quantizer module is not yet supported.