### PR TITLE
Pin transformers version for MII tests

### DIFF
--- a/.github/workflows/nv-mii.yml
+++ b/.github/workflows/nv-mii.yml
@@ -46,7 +46,7 @@ jobs:
           git clone https://github.com/huggingface/transformers
           cd transformers
           # if needed switch to the last known good SHA until transformers@master is fixed
-          # git checkout 1cc453d33
+          git checkout bdf36dc
           git rev-parse --short HEAD
           pip install .
 


### PR DESCRIPTION
MII legacy tests use `from transformers import Conversation` [here](https://github.com/microsoft/DeepSpeed-MII/blob/c171c4ee290e96c0d3e618b654be8add5eca973b/mii/legacy/method_table.py#L8).

Conversation was removed from transformers [here](https://github.com/huggingface/transformers/pull/31165) so we pin to a version before that before unpinning.