### PR TITLE
Monitor was always enabled causing performance degradation

### DIFF
--- a/deepspeed/monitor/config.py
+++ b/deepspeed/monitor/config.py
@@ -140,5 +140,5 @@ class DeepSpeedMonitorConfig(DeepSpeedConfigModel):
     @root_validator
     def check_enabled(cls, values):
         values["enabled"] = values.get("tensorboard").enabled or values.get("wandb").enabled or values.get(
-            "csv_monitor").enabled or values.get("comet")
+            "csv_monitor").enabled or values.get("comet").enabled
         return values


### PR DESCRIPTION
The Boolean expression for the monitor to be enabled was incorrect, as instead of using the `enabled` field, it used the comet configuration object, making the expression always True.

This caused performance degradation (we've observed ~10% drop) as it erroneously invoked the events logging flow along with the expensive calculation of `loss.mean().item()`.