### PR TITLE
[XPU] adapt lazy_call func to different versions

### DIFF
--- a/accelerator/xpu_accelerator.py
+++ b/accelerator/xpu_accelerator.py
@@ -159,7 +159,10 @@ class XPU_Accelerator(DeepSpeedAccelerator):
         return
 
     def lazy_call(self, callback):
-        return torch.xpu.lazy_init._lazy_call(callback)
+        if hasattr(torch.xpu, "_lazy_call"):
+            return torch.xpu._lazy_call(callback)
+        else:
+            return torch.xpu.lazy_init._lazy_call(callback)
 
     def communication_backend_name(self):
         return self._communication_backend_name


### PR DESCRIPTION
Previously, lay_call function was wrapped by torch.xpu.lay_init._lazy_call, which is now changed to torch.xpu._lazy_call.

Thus we change this function to adapt different versions.