### PR TITLE
Updates needed for NumPy 2+

### DIFF
--- a/deepspeed/autotuning/constants.py
+++ b/deepspeed/autotuning/constants.py
@@ -20,7 +20,6 @@ DEFAULT_TEMPLATE_PATH_ZERO_3 = os.path.join(os.path.dirname(os.path.realpath(__f
 
 METRIC_PERCENT_DIFF_CONST = 0.05
 DS_CONFIG = "ds_config"
-BUFSIZE = 1  # line buffer size for writing files
 
 #########################################
 # autotuner configuration constants

--- a/deepspeed/autotuning/scheduler.py
+++ b/deepspeed/autotuning/scheduler.py
@@ -5,7 +5,7 @@
 
 import copy
 
-from numpy import BUFSIZE
+from numpy import getbufsize
 import json
 import subprocess
 import sys
@@ -28,7 +28,7 @@ thread-N: start each experiment in its own thread
 from deepspeed import comm as dist
 
 TIMEOUT = 5
-
+BUFSIZE = getbufsize()
 
 class ResourceManager:
 

--- a/deepspeed/autotuning/scheduler.py
+++ b/deepspeed/autotuning/scheduler.py
@@ -30,6 +30,7 @@ from deepspeed import comm as dist
 TIMEOUT = 5
 BUFSIZE = getbufsize()
 
+
 class ResourceManager:
 
     def __init__(self, args, hosts, num_gpus_per_node, results_dir, exps_dir, arg_mappings):

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 hjson
 ninja
-numpy
+numpy>=2.0.0
 nvidia-ml-py
 packaging>=20.0
 psutil


### PR DESCRIPTION
NumPy 2 contains what appears to be just a single major breaking change, we used to import np.BUFSIZE, but the change to `getbufsize` is documented [here in the docs](https://github.com/numpy/numpy/blob/efcf2a214dc20ce2cc52022bd15f1e78b0f318f3/doc/source/release/2.0.0-notes.rst#L168) and [here in the code](https://github.com/numpy/numpy/pull/24357/files).

Fixes #5671.
