### PR TITLE
Fix memory leak for pipelined optimizer swapper

### DIFF
--- a/deepspeed/runtime/swap_tensor/pipelined_optimizer_swapper.py
+++ b/deepspeed/runtime/swap_tensor/pipelined_optimizer_swapper.py
@@ -8,6 +8,7 @@ Functionality of swapping optimizer tensors to/from (NVMe) storage devices.
 
 from deepspeed.ops.op_builder import AsyncIOBuilder
 from deepspeed import comm as dist
+import torch
 
 from deepspeed.runtime.swap_tensor.constants import *
 from deepspeed.runtime.swap_tensor.utils import swap_in_tensors, swap_out_tensors, print_object
@@ -154,6 +155,8 @@ class PipelinedOptimizerSwapper(OptimizerSwapper):
 
     def _complete_swap_out(self, swap_out_type):
         self.swap_ops[swap_out_type].wait()
+        for buffer in self.swap_ops[swap_out_type].state_buffers:
+            buffer = torch.Tensor()
         self.swap_buffer_manager.free(self.swap_ops[swap_out_type].allocated_buffers)
         self.swap_ops[swap_out_type] = None
 


### PR DESCRIPTION
We identified a memory leak when training with NVMe offloaded optimizer states. The issue occurs when `pipeline_write=true`, where the tensors that have swapped out and written to NVMe are not deallocated, leading to a memory leak.

This PR resolves the issue by deallocating the unused tensors which have swapped out to NVMe.


