### PR TITLE
Remove check on python36

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,7 +29,7 @@ jobs:
       image: deepspeed/gh-builder:py${{ matrix.pyVersion }}
 
     steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - name: environment
           run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,7 +21,7 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        pyVersion: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        pyVersion: ["3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
 
     runs-on: ubuntu-20.04


### PR DESCRIPTION
With changes from GitHub [finally deprecating](https://github.com/actions/checkout/issues/1474) [node16 based runners](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) (which the checkout@v3 action uses) we need to make changes to support this.  However, with the changes in pydantic v2 that will be merged soon, we will be removing this check there, so we can more easily remove it now so that future PRs are cleaner and it is clear why some changes have been made.