### PR TITLE
[XPU] Use time.time to measure the time when upgrade to pytorch-2.3.

### DIFF
--- a/accelerator/xpu_accelerator.py
+++ b/accelerator/xpu_accelerator.py
@@ -26,7 +26,10 @@ class XPU_Accelerator(DeepSpeedAccelerator):
         return False
 
     def use_host_timers(self):
-        return self.is_synchronized_device()
+        if ipex.__version__ < '2.3':
+            return self.is_synchronized_device()
+        else:
+            return True
 
     def resolves_data_dependency(self):
         return self.is_synchronized_device()


### PR DESCRIPTION
When upgrade to pytorch-2.3, elapsed_time is not supported by XPUEvent, time.time() is suggested to use, WA on xpu_accelerator, when upgrade to pytorch-2.3 on XPU device.