### PR TITLE
Fix CPU Adam JIT compilation

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -552,13 +552,6 @@ class OpBuilder(ABC):
             os.environ["PYTORCH_ROCM_ARCH"] = self.get_rocm_gpu_arch()
             cxx_args.append('-DROCM_WAVEFRONT_SIZE=%s' % self.get_rocm_wavefront_size())
 
-        print(f"{self.name=}")
-        print(f"{sources=}")
-        print(f"{extra_include_paths=}")
-        print(f"{cxx_args=}")
-        print(f"{nvcc_args=}")
-        print(f"{self.extra_ldflags()=}")
-        print(f"{verbose=}")
         op_module = load(name=self.name,
                          sources=self.strip_empty_entries(sources),
                          extra_include_paths=self.strip_empty_entries(extra_include_paths),

--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -773,6 +773,7 @@ class CUDAOpBuilder(OpBuilder):
 class TorchCPUOpBuilder(CUDAOpBuilder):
 
     def get_cuda_lib64_path(self):
+        import torch
         if not self.is_rocm_pytorch():
             CUDA_LIB64 = os.path.join(torch.utils.cpp_extension.CUDA_HOME, "lib64")
             if not os.path.exists(CUDA_LIB64):
@@ -794,7 +795,6 @@ class TorchCPUOpBuilder(CUDAOpBuilder):
         return []
 
     def cxx_args(self):
-        import torch
         args = []
         if not self.build_for_cpu:
             CUDA_LIB64 = self.get_cuda_lib64_path()


### PR DESCRIPTION
This PR fixes CPU Adam JIT compilation by including the `CUDA_LIB64` path in the `extra_ldflags` list before calling `load()`.