### PR TITLE
Add new autotp supported model in doc

### DIFF
--- a/docs/_tutorials/automatic-tensor-parallelism.md
+++ b/docs/_tutorials/automatic-tensor-parallelism.md
@@ -126,6 +126,8 @@ The following model families have been successfully tested with automatic tensor
 - bigbird_pegasus
 - bloom
 - camembert
+- chatglm2
+- chatglm3
 - codegen
 - codellama
 - deberta_v2
@@ -144,6 +146,7 @@ The following model families have been successfully tested with automatic tensor
 - m2m_100
 - marian
 - mistral
+- mixtral
 - mpt
 - mvp
 - nezha
@@ -151,8 +154,10 @@ The following model families have been successfully tested with automatic tensor
 - opt
 - pegasus
 - perceiver
+- phi
 - plbart
 - qwen
+- qwen2
 - reformer
 - roberta
 - roformer
@@ -162,6 +167,7 @@ The following model families have been successfully tested with automatic tensor
 - xglm
 - xlm_roberta
 - yoso
+- yuan
 
 # Unsupported Models
 


### PR DESCRIPTION
This PR refresh the list of models supported by AutoTP. Newly added models are:

- mixtral
- yuan
- phi
- qwen2 [reviewing PR #5786 ]
- chatglm2&chatglm3 [reviewing PR #5540 ]