### PR TITLE
[XPU]Use host time to replace xpu time when IPEX version slower than 2.5.

### DIFF
--- a/accelerator/xpu_accelerator.py
+++ b/accelerator/xpu_accelerator.py
@@ -26,7 +26,11 @@ class XPU_Accelerator(DeepSpeedAccelerator):
         return False
 
     def use_host_timers(self):
-        return self.is_synchronized_device()
+        # WA XPU event will be consolidated in 2.5
+        if ipex.__version__ < '2.5':
+            return True
+        else:
+            return self.is_synchronized_device()
 
     def resolves_data_dependency(self):
         return self.is_synchronized_device()


### PR DESCRIPTION
Use the host time to replace xpu event elapsed_time as a WA, on XPU device, use XPU event to measure the time will be consolidated in ipex 2.5.