### PR TITLE
fix: handle exception when loading cache file in test_inference.py

### DIFF
--- a/tests/unit/inference/test_inference.py
+++ b/tests/unit/inference/test_inference.py
@@ -94,7 +94,10 @@ def _hf_model_list() -> List[ModelInfo]:
     model_data = {"cache_time": 0, "model_list": []}
     if os.path.isfile(cache_file_path):
         with open(cache_file_path, 'rb') as f:
-            model_data = pickle.load(f)
+            try:
+                model_data = pickle.load(f)
+            except Exception as e:
+                print(f"Error loading cache file {cache_file_path}: {e}")
 
     current_time = time.time()
 


### PR DESCRIPTION
This PR is to fix CI failures such as https://github.com/microsoft/DeepSpeed/actions/runs/10085903860/job/27887546470#step:8:3616
cc @tjruwase 