### PR TITLE
Include Cuda path in TorchCPUOpBuilder ldflags

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -789,11 +789,9 @@ class TorchCPUOpBuilder(CUDAOpBuilder):
             return ['-fopenmp']
 
         if not self.is_rocm_pytorch():
-            flags = ['-lcurand']
-        else:
-            flags = []
+            return ['-lcurand', f'-L{self.cuda_lib64()}']
 
-        return flags + [f"-L{self.cuda_lib64()}"]
+        return []
 
     def cxx_args(self):
         args = []

--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -772,8 +772,7 @@ class CUDAOpBuilder(OpBuilder):
 
 class TorchCPUOpBuilder(CUDAOpBuilder):
 
-    @staticmethod
-    def cuda_lib64():
+    def cuda_lib64(self):
         import torch
         if not self.is_rocm_pytorch():
             CUDA_LIB64 = os.path.join(torch.utils.cpp_extension.CUDA_HOME, "lib64")


### PR DESCRIPTION
`CPUAdamBuilder` was crashing because of linker not finding cuda libraries

```
Emitting ninja build file 	py39_cu121/cpu_adam/build.ninja...
Building extension module cpu_adam...
Allowing ninja to set a default number of workers... (overridable by setting the environment variable MAX_JOBS=N)
[1/1] c++ cpu_adam.o cpu_adam_impl.o -shared -lcurand -L/home/.../lib/python3.9/site-packages/torch/lib -lc10 -ltorch_cpu -ltorch -ltorch_python -o cpu_adam.so
FAILED: cpu_adam.so 
c++ cpu_adam.o cpu_adam_impl.o -shared -lcurand -L/home/.../python3.9/site-packages/torch/lib -lc10 -ltorch_cpu -ltorch -ltorch_python -o cpu_adam.so
/usr/bin/ld: cannot find -lcurand
collect2: error: ld returned 1 exit status
```