### PR TITLE
Add default value to "checkpoint_folder" in "load_state_dict" of bf16_optimizer

### DIFF
--- a/deepspeed/runtime/bf16_optimizer.py
+++ b/deepspeed/runtime/bf16_optimizer.py
@@ -495,7 +495,7 @@ class BF16_Optimizer(ZeROOptimizer):
 
     def load_state_dict(self,
                         state_dict_list,
-                        checkpoint_folder,
+                        checkpoint_folder=None,
                         load_optimizer_states=True,
                         load_from_fp32_weights=False,
                         load_serial=None,


### PR DESCRIPTION
Add default value `checkpoint_folder=None` for compatibility.