### PR TITLE
optimizations for grad norm calculation and gradient clipping

### DIFF
--- a/deepspeed/ops/lamb/fused_lamb.py
+++ b/deepspeed/ops/lamb/fused_lamb.py
@@ -133,8 +133,8 @@ class FusedLamb(torch.optim.Optimizer):
                 if group['max_grad_norm'] > 0:
                     # norm is in fact norm*scale
                     clip = ((grad_norm / scale) + 1e-6) / group['max_grad_norm']
-                    if clip > 1:
-                        combined_scale = clip * scale
+                    clip = torch.clamp(clip, min=1.0)
+                    combined_scale = clip * scale
 
                 #note: p.grad should not ever be set for correct operation of mixed precision optimizer that sometimes sends None gradients
                 if p.grad is None and grad is None:

--- a/deepspeed/runtime/fp16/fused_optimizer.py
+++ b/deepspeed/runtime/fp16/fused_optimizer.py
@@ -358,8 +358,8 @@ class FP16_Optimizer(DeepSpeedOptimizer):
         if self.clip_grad > 0.:
             # norm is in fact norm*scale
             clip = ((total_norm / self.cur_scale) + 1e-6) / self.clip_grad
-            if clip > 1:
-                combined_scale = clip * self.cur_scale
+            clip = torch.clamp(clip, min=1.0)
+            combined_scale = clip * self.cur_scale
 
         if apply_scale:
             for grad in grad_groups_flat:

--- a/deepspeed/runtime/fp16/unfused_optimizer.py
+++ b/deepspeed/runtime/fp16/unfused_optimizer.py
@@ -246,8 +246,8 @@ class FP16_UnfusedOptimizer(DeepSpeedOptimizer):
         if self.clip_grad > 0.:
             # norm is in fact norm*scale
             clip = ((total_norm / self.cur_scale) + 1e-6) / self.clip_grad
-            if clip > 1:
-                combined_scale = clip * self.cur_scale
+            clip = torch.clamp(clip, min=1.0)
+            combined_scale = clip * self.cur_scale
 
         if apply_scale:
             for group in self.fp32_groups:

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -305,11 +305,7 @@ def _handle_overflow(cpu_sum, x, i):
 def get_global_norm(norm_list):
     """ Compute total from a list of norms
     """
-    total_norm = 0.0
-    for norm in norm_list:
-        total_norm += norm**2.0
-    # logger.info(f'norm_list = {norm_list} global = {sqrt(total_norm)}')
-    return sqrt(total_norm)
+    return torch.linalg.norm(torch.tensor(norm_list))
 
 
 def clip_grad_norm_(parameters, max_norm, norm_type=2, mpu=None):


### PR DESCRIPTION
This PR add the below functionality:

   1. repalce for-loop with torch.linalg.norm for better performance.
   2. replace clipping with torch.clamp for better performance