### PR TITLE
Avoid gds build errors on ROCm

### DIFF
--- a/op_builder/gds.py
+++ b/op_builder/gds.py
@@ -36,6 +36,11 @@ class GDSBuilder(AsyncIOBuilder):
         return super().extra_ldflags() + ['-lcufile']
 
     def is_compatible(self, verbose=False):
+        if self.is_rocm_pytorch():
+            if verbose:
+                self.warning(f'{self.NAME} is not compatible with ROCM')
+            return False
+
         try:
             import torch.utils.cpp_extension
         except ImportError:

--- a/op_builder/gds.py
+++ b/op_builder/gds.py
@@ -43,13 +43,8 @@ class GDSBuilder(AsyncIOBuilder):
                 self.warning("Please install torch if trying to pre-compile GDS")
             return False
 
-        if not self.is_rocm_pytorch():
-            CUDA_HOME = torch.utils.cpp_extension.CUDA_HOME
-            CUDA_LIB64 = os.path.join(CUDA_HOME, "lib64")
-        else:
-            CUDA_HOME = torch.utils.cpp_extension.ROCM_HOME
-            CUDA_LIB64 = os.path.join(CUDA_HOME, "lib")
-
+        CUDA_HOME = torch.utils.cpp_extension.CUDA_HOME
+        CUDA_LIB64 = os.path.join(CUDA_HOME, "lib64")
         gds_compatible = self.has_function(funcname="cuFileDriverOpen",
                                            libraries=("cufile", ),
                                            library_dirs=(

--- a/op_builder/gds.py
+++ b/op_builder/gds.py
@@ -43,8 +43,13 @@ class GDSBuilder(AsyncIOBuilder):
                 self.warning("Please install torch if trying to pre-compile GDS")
             return False
 
-        CUDA_HOME = torch.utils.cpp_extension.CUDA_HOME
-        CUDA_LIB64 = os.path.join(CUDA_HOME, "lib64")
+        if not self.is_rocm_pytorch():
+            CUDA_HOME = torch.utils.cpp_extension.CUDA_HOME
+            CUDA_LIB64 = os.path.join(CUDA_HOME, "lib64")
+        else:
+            CUDA_HOME = torch.utils.cpp_extension.ROCM_HOME
+            CUDA_LIB64 = os.path.join(CUDA_HOME, "lib")
+
         gds_compatible = self.has_function(funcname="cuFileDriverOpen",
                                            libraries=("cufile", ),
                                            library_dirs=(


### PR DESCRIPTION
This PR is to avoid the below error during DeepSpeed build on ROCm. The error is because of the incompatibility of GDSBuilder extension on ROCm. 

```
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-lv1v39xc/setup.py", line 180, in <module>
        op_compatible = builder.is_compatible()
      File "/tmp/pip-req-build-lv1v39xc/op_builder/gds.py", line 47, in is_compatible
        CUDA_LIB64 = os.path.join(CUDA_HOME, "lib64")
      File "/opt/conda/envs/py_3.9/lib/python3.9/posixpath.py", line 76, in join
        a = os.fspath(a)
    TypeError: expected str, bytes or os.PathLike object, not NoneType
    Total number of unsupported CUDA function calls: 0


    Total number of replaced kernel launches: 1
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output
```

cc: @jithunnair-amd 