### PR TITLE
Fix transformers/torch errors on nn.RMSNorm by pinning transformers.

### DIFF
--- a/.github/workflows/hpu-gaudi2.yml
+++ b/.github/workflows/hpu-gaudi2.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           git clone https://github.com/huggingface/transformers
           cd transformers
-          git checkout v4.44.1 # Pin to specific version before we can update torch version to 2.4+ for nn.RMSNorm
+          git checkout v4.44.2 # Pin to specific version before we can update torch version to 2.4+ for nn.RMSNorm
           git rev-parse --short HEAD
           pip install .
 

--- a/.github/workflows/hpu-gaudi2.yml
+++ b/.github/workflows/hpu-gaudi2.yml
@@ -111,6 +111,7 @@ jobs:
         run: |
           git clone https://github.com/huggingface/transformers
           cd transformers
+          git checkout v4.44.1 # Pin to specific version before we can update torch version to 2.4+ for nn.RMSNorm
           git rev-parse --short HEAD
           pip install .
 


### PR DESCRIPTION
HPU pipeline was failing due to updated transformers package that seems to have a dependency on torch 2.4: https://github.com/microsoft/DeepSpeed/actions/runs/10586654075/job/29335873815

Opened an issue with transformers to investigate: https://github.com/huggingface/transformers/issues/33176

CC: @nelyahu - we can also fix this when/if there is a package with torch 2.4