### PR TITLE
DS_BUILD_OPS should build only compatible ops

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -183,8 +183,8 @@ for op_name, builder in ALL_OPS.items():
     if op_enabled(op_name) and not op_compatible:
         env_var = op_envvar(op_name)
         if not is_env_set(env_var):
-            builder.warning(f"One can disable {op_name} with {env_var}=0")
-        abort(f"Unable to pre-compile {op_name}")
+            builder.warning(f"Skip pre-compile of incompatible {op_name}; One can disable {op_name} with {env_var}=0")
+        continue
 
     # If op is compatible but install is not enabled (JIT mode).
     if is_rocm_pytorch and op_compatible and not op_enabled(op_name):


### PR DESCRIPTION
Currently DS_BUILD_OPS=1 fails on incompatible ops. This is a deviation from [documentation](https://www.deepspeed.ai/tutorials/advanced-install/#pre-install-deepspeed-ops) which states that only compatible ops are built. 

<img width="614" alt="image" src="https://github.com/user-attachments/assets/0f1a184e-b568-4d25-9e9b-e394fb047df2">
