### PR TITLE
bf16_optimizer + immediate_grad_update: skip grad acc on backward

### DIFF
--- a/deepspeed/runtime/bf16_optimizer.py
+++ b/deepspeed/runtime/bf16_optimizer.py
@@ -338,7 +338,7 @@ class BF16_Optimizer(ZeROOptimizer):
         self.clear_lp_grads()
         loss.backward(**bwd_kwargs)
 
-        if update_hp_grads:
+        if not self.immediate_grad_update and update_hp_grads:
             self.update_hp_grads(clear_lp_grads=clear_lp_grads)
 
     @torch.no_grad()


### PR DESCRIPTION
when using immediate_grad_update, gradient accumulation is performed using hook during the backward of each module. thus the call to update_hp_grads at the end of the backward has to be skipped to avoid additional overhead. although no accuracy issue is expected as gradients are cleared after the hook.