### PR TITLE
Revert "BF16 optimizer: Clear lp grads after updating hp grads in hook"

### DIFF
--- a/deepspeed/runtime/bf16_optimizer.py
+++ b/deepspeed/runtime/bf16_optimizer.py
@@ -534,7 +534,7 @@ class BF16_Optimizer(ZeROOptimizer):
 
     def accumulate_hp_grads_and_remove_lp(self, lp_param, group_idx, param_idx):
         assert self.immediate_grad_update
-        self._update_hp_grad(lp_param, group_idx, param_idx, clear_lp_grads=True)
+        self._update_hp_grad(lp_param, group_idx, param_idx, clear_lp_grads=False)
 
     def create_grad_acc_hooks(self):
         self.grad_accs = []


### PR DESCRIPTION
Reverts microsoft/DeepSpeed#5328