### PR TITLE
Improve consistency of zero_grad

### DIFF
--- a/deepspeed/runtime/base_optimizer.py
+++ b/deepspeed/runtime/base_optimizer.py
@@ -5,10 +5,11 @@
 
 import os
 import torch
+from typing import Callable, Iterable
 
 from deepspeed.utils import logger
 from deepspeed.utils.tensor_fragment import map_to_flat_opt_states
-from deepspeed.runtime.utils import bwc_tensor_model_parallel_rank
+from deepspeed.runtime.utils import bwc_tensor_model_parallel_rank, zero_grad_params
 
 
 class DeepSpeedOptimizer(object):
@@ -61,3 +62,10 @@ class ZeROOptimizer(DeepSpeedOptimizer):
                 if key == 'params':
                     continue
                 param_group[key] = value
+
+    def _do_zero_grad(self,
+                      params: Iterable[torch.nn.Parameter],
+                      set_to_none_fn: Callable[[torch.Tensor], None],
+                      set_to_none: bool = True,
+                      force: bool = False) -> None:
+        zero_grad_params(params, set_to_none_fn, self.is_gradient_accumulation_boundary, set_to_none, force)

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -8,7 +8,7 @@ Copyright NVIDIA/Megatron
 Helper functions and classes from multiple sources.
 """
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Callable
 from deepspeed.moe.utils import is_moe_param
 import os
 import psutil
@@ -1065,3 +1065,32 @@ def get_norm_with_moe_layers(non_expert_norm, mpu, expert_tensors, norm_type=2):
             total_norm = -1
 
     return total_norm
+
+
+warn_zero_grad_shown = False
+
+
+def warn_zero_grad() -> None:
+    global warn_zero_grad_shown
+    if not warn_zero_grad_shown:
+        msg = "zero_grad() was called but gradients are not cleared because " \
+                "the current iteration is not a gradient accumulation boundary. " \
+                "If you want to clear gradients, please set force=True."
+        logger.info(msg)
+        warn_zero_grad_shown = True
+    return
+
+
+def zero_grad_params(params: Iterable[torch.nn.Parameter], set_to_none_fn: Callable[[torch.Tensor], None],
+                     is_gradient_accumulation_boundary: bool, set_to_none: bool, force: bool) -> None:
+    if not is_gradient_accumulation_boundary and not force:
+        warn_zero_grad()
+        return
+
+    for param in params:
+        if set_to_none:
+            set_to_none_fn(param)
+        else:
+            if param.grad is not None:
+                param.grad.detach_()
+                param.grad.zero_()


### PR DESCRIPTION
DeepSpeed has several ways to call `zero_grad()` but they have the following inconsistency.

- ZeRO 1/2 optimizer's `zero_grad`: Clear .grad and .grad_acc
- ZeRO 3 optimizer's `zero_grad`: Clear .grad and reset `micro_step_id`. This affects whether it overwrites or accumulates gradients after reduce. It also causes a mismatch with engine's `micro_steps`.
- Engine's `zero_grad`: Clear .grad (doesn't call optimizer's zero_grad in its zero_grad). But it calls the optimizer's `zero_grad` after `step()`.

Another confusion is, it doesn't consider the gradient accumulation boundary while backward and step do. Users naturally expect this code like this works:

```python
for batch in data_loader:
    # We need *if* to run zero_grad only at a gradient accumulation boundary
    target_engine.zero_grad() # optimizer.zero_grad() is safer but it shows different behavior with Z1/2 and 3

    outputs = target_engine(batch)
    target_engine.backward(loss)
    optimizer.step()
```

This PR aims to improve the behavior of the optimizers.

- `zero_grad` clears gradients only at a gradient accumulation boundary.
  - Shows a warning once when it is called at steps that are not a gradient accumulation boundary
  - Accepts kwarg `force` to clear gradients
- ZeRO 1/2/3 optimizers and engine's `zero_grad` have the same effect
  - Users can call either of `optimizer.zero_grad` and `engine.zero_grad` with any zero stages
  - Stop resetting `micro_step_id` for Z3 optimizer to make it consistent with engine's `micro_steps`