### PR TITLE
Fixes on the accelerate side mean we do not need to skip this test

### DIFF
--- a/.github/workflows/nv-accelerate-v100.yml
+++ b/.github/workflows/nv-accelerate-v100.yml
@@ -55,4 +55,4 @@ jobs:
           # tmp fix: force newer datasets version
           #pip install "datasets>=2.0.0"
           pip list
-          pytest $PYTEST_OPTS --color=yes --durations=0 --verbose tests/deepspeed -k "not test_prepare_multiple_models_zero3_inference"
+          pytest $PYTEST_OPTS --color=yes --durations=0 --verbose tests/deepspeed


### PR DESCRIPTION
HF accelerate implemented fixes here: https://github.com/huggingface/accelerate/pull/3131

This means we can revert the changes from #6574