### PR TITLE
Fix torch include in `op_builder/mlu/fused_adam.py` and update no-torch workflow triggers

### DIFF
--- a/.github/workflows/no-torch.yml
+++ b/.github/workflows/no-torch.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/no-torch.yml'
+      - 'op_builder/**'
   schedule:
     - cron: "0 0 * * *"
 

--- a/op_builder/mlu/fused_adam.py
+++ b/op_builder/mlu/fused_adam.py
@@ -5,7 +5,11 @@
 # DeepSpeed Team
 
 from .builder import MLUOpBuilder
-import torch
+
+try:
+    import torch
+except ImportError as e:
+    pass
 
 
 class MLUFusedAdam:


### PR DESCRIPTION
Changes from #6472 caused the no-torch workflow that is an example of how we build the DeepSpeed release package to fail (so we caught this before a release, see more in #6402).   These changes also copy the style used to include torch in other accelerator op_builder implementations, such as npu [here](https://github.com/microsoft/DeepSpeed/blob/master/op_builder/npu/fused_adam.py#L8) and hpu [here](https://github.com/microsoft/DeepSpeed/blob/828ddfbbda2482412fffc89f5fcd3b0d0eba9a62/op_builder/hpu/fused_adam.py#L15).

This also updates the no-torch workflow to run on all changes to the op_builder directory.  The test runs quickly and shouldn't add any additional testing burden there.

Resolves: #6576