### PR TITLE
Unpin accelerate tests, update lightning with node16 removal.

### DIFF
--- a/.github/workflows/nv-accelerate-v100.yml
+++ b/.github/workflows/nv-accelerate-v100.yml
@@ -47,7 +47,6 @@ jobs:
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch
           git clone https://github.com/huggingface/accelerate
           cd accelerate
-          git checkout ae9cb6e4db6f81fd18148c2cc67d72b903d81a46
           git rev-parse --short HEAD
           # installing dependencies
           pip install .[testing]

--- a/.github/workflows/nv-lightning-v100.yml
+++ b/.github/workflows/nv-lightning-v100.yml
@@ -21,8 +21,6 @@ jobs:
   unit-tests:
     runs-on: [self-hosted, nvidia, cu121, v100]
 
-    env: {ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true} # Allow using Node16 actions
-
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
HF accelerate fixes implemented in https://github.com/huggingface/accelerate/pull/3145 mean that we no longer need to pin the Accelerate version!

nv-lightning tests now run on Ubuntu 20.04+, so we support >node 16, so we can remove the explicit permissions for that in the env config.