### PR TITLE
fix init_device_mesh for torch 2.4

### DIFF
--- a/deepspeed/comm/torch.py
+++ b/deepspeed/comm/torch.py
@@ -390,7 +390,12 @@ class TorchBackend(Backend):
         if not required_torch_version(min_version=2.2):
             raise RuntimeError(f"Current torch version does not have device mesh"
                                f"api (torch.__version__: {torch.__version__})")
-        return torch.distributed.device_mesh.init_device_mesh(get_accelerator().current_device_name(),
+        if not required_torch_version(max_version=2.4):
+            return torch.distributed.device_mesh.init_device_mesh(get_accelerator().device_name(),
+                                                              mesh_shape,
+                                                              mesh_dim_names=mesh_dim_names)
+        else:
+            return torch.distributed.device_mesh.init_device_mesh(get_accelerator().current_device_name(),
                                                               mesh_shape,
                                                               mesh_dim_names=mesh_dim_names)
 


### PR DESCRIPTION
Start torch 2.4, in [`init_device_mesh()`](https://github.com/pytorch/pytorch/blob/de4c2a3b4e89d96334dc678d1c3f2ae51a6630a0/torch/distributed/device_mesh.py#L915) ,device type with a GPU index, such as "cuda:0", is not allowed.

![image](https://github.com/user-attachments/assets/1ddb61bf-8a15-4e0a-9115-a3681d7f19ff)

