### PR TITLE
[XPU] host timer check version from Torch 2.5 to Torch 2.6

### DIFF
--- a/accelerator/xpu_accelerator.py
+++ b/accelerator/xpu_accelerator.py
@@ -26,8 +26,8 @@ class XPU_Accelerator(DeepSpeedAccelerator):
         return False
 
     def use_host_timers(self):
-        # WA XPU event will be consolidated in 2.5
-        if ipex.__version__ < '2.5':
+        # WA XPU event will be consolidated in 2.6
+        if ipex.__version__ < '2.6':
             return True
         else:
             return self.is_synchronized_device()


### PR DESCRIPTION
Elapsed time would be supported in Torch 2.6.