### PR TITLE
Free memory in universal checkpointing tests

### DIFF
--- a/tests/unit/checkpoint/test_universal_checkpoint.py
+++ b/tests/unit/checkpoint/test_universal_checkpoint.py
@@ -131,8 +131,7 @@ def train_save_convert(ds_config, hidden_dim, load_optim, use_torch_adam, dtype,
         torch.save((model_state, optimizer_state), os.path.join(tmpdir, "baseline_state.pt"))
 
     dist.barrier()
-
-    return model, sd
+    model.destroy()
 
 
 @pytest.fixture
@@ -212,6 +211,8 @@ class TestZeROUniversalCheckpointDP(DistributedTest):
             loss = univ_model(batch[0], batch[1])
             univ_model.backward(loss)
             univ_model.step()
+
+        univ_model.destroy()
 
     @pytest.mark.world_size(2)
     def test_dp_world_size_2to2(self, baseline_ws2, tmpdir, dtype, ds_config, load_optim, use_torch_adam):

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -25,8 +25,6 @@ from _pytest.fixtures import FixtureLookupError, FixtureFunctionMarker
 # Worker timeout for tests that hang
 DEEPSPEED_TEST_TIMEOUT = int(os.environ.get('DS_UNITTEST_TIMEOUT', '600'))
 
-warn_reuse_dist_env = False
-
 
 def is_rocm_pytorch():
     return hasattr(torch.version, 'hip') and torch.version.hip is not None
@@ -177,13 +175,6 @@ class DistributedExec(ABC):
             if self.reuse_dist_env:
                 print("Ignoring reuse_dist_env for hpu")
                 self.reuse_dist_env = False
-
-        global warn_reuse_dist_env
-        if self.reuse_dist_env and not warn_reuse_dist_env:
-            # Currently we see memory leak for tests that reuse distributed environment
-            print("Ignoring reuse_dist_env and forcibly setting it to False")
-            warn_reuse_dist_env = True
-        self.reuse_dist_env = False
 
         if self.reuse_dist_env:
             if num_procs not in self._pool_cache:


### PR DESCRIPTION
Tests in universal checkpointing were not freeing the engine after use when `reuse_dist_env` was set to `True`, leading to memory leaks.
This PR ensure freeing the engine in the tests and enables `reuse_dist_env`.