### PR TITLE
Pin transformers version to work around latest torch requirements

### DIFF
--- a/.github/workflows/hpu-gaudi2.yml
+++ b/.github/workflows/hpu-gaudi2.yml
@@ -111,6 +111,7 @@ jobs:
         run: |
           git clone https://github.com/huggingface/transformers
           cd transformers
+          git checkout 7df93d6ffb48946e532c7d766fe10372e98d78b6
           git rev-parse --short HEAD
           pip install .
 

--- a/.github/workflows/nv-a6000.yml
+++ b/.github/workflows/nv-a6000.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/huggingface/transformers
           cd transformers
+          git checkout 13493215abceafc1653af88b045120014fb4c1fc
           git rev-parse --short HEAD
           python -m pip install .
       - name: Install deepspeed

--- a/.github/workflows/nv-a6000.yml
+++ b/.github/workflows/nv-a6000.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           git clone https://github.com/huggingface/transformers
           cd transformers
-          git checkout 1ef6c5f1c5b96af27d569fd7520c8884898125c1
+          git checkout 20142ab5422fbafcd10e221e37e95f8aaf1bde3c
           git rev-parse --short HEAD
           python -m pip install .
       - name: Install deepspeed

--- a/.github/workflows/nv-a6000.yml
+++ b/.github/workflows/nv-a6000.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           git clone https://github.com/huggingface/transformers
           cd transformers
-          git checkout 20142ab5422fbafcd10e221e37e95f8aaf1bde3c
+          git checkout 7df93d6ffb48946e532c7d766fe10372e98d78b6
           git rev-parse --short HEAD
           python -m pip install .
       - name: Install deepspeed

--- a/.github/workflows/nv-a6000.yml
+++ b/.github/workflows/nv-a6000.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           git clone https://github.com/huggingface/transformers
           cd transformers
-          git checkout 13493215abceafc1653af88b045120014fb4c1fc
+          git checkout 36759f33123208e0b5cd346d6c4ac64487652933
           git rev-parse --short HEAD
           python -m pip install .
       - name: Install deepspeed

--- a/.github/workflows/nv-a6000.yml
+++ b/.github/workflows/nv-a6000.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           git clone https://github.com/huggingface/transformers
           cd transformers
-          git checkout 36759f33123208e0b5cd346d6c4ac64487652933
+          git checkout 1ef6c5f1c5b96af27d569fd7520c8884898125c1
           git rev-parse --short HEAD
           python -m pip install .
       - name: Install deepspeed

--- a/.github/workflows/nv-a6000.yml
+++ b/.github/workflows/nv-a6000.yml
@@ -40,7 +40,7 @@ jobs:
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
       - name: Install transformers
         run: |
-          git clone --depth=1 https://github.com/huggingface/transformers
+          git clone https://github.com/huggingface/transformers
           cd transformers
           git checkout 13493215abceafc1653af88b045120014fb4c1fc
           git rev-parse --short HEAD


### PR DESCRIPTION
Latest transformers seems to break our tests that aren't on torch latest (>= 2.5).  Issue opened here: https://github.com/huggingface/transformers/issues/34795.  This pins our version so these tests can pass in the meantime.