### PR TITLE
Fixed extra double quotes when getting var values passed through -x f…

### DIFF
--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -603,9 +603,9 @@ def main(args=None):
             cmd, kill_cmd, env = runner.get_cmd(env, active_resources)
         else:
             cmd = runner.get_cmd(env, active_resources)
-
-    logger.info(f"cmd = {' '.join(cmd)}")
-    result = subprocess.Popen(cmd, env=env)
+    cmd = ' '.join(cmd)
+    logger.info(f"cmd = {cmd}")
+    result = subprocess.Popen(cmd, env=env, shell=True)
 
     def sigkill_handler(signum, frame):
         result.send_signal(signal.SIGINT)


### PR DESCRIPTION
…rom environment variables

When we test by using `os.environ.get("TEST")` in a python shell  to get the correct value from `-x TEST="123"` in a mprun command, we got '"123"' rather than '123',  so we cannot convert  it to an integer value. This patch could fix this bug.