### PR TITLE
Pin transformers version in cpu-torch-latest due to multiprocessing error.

### DIFF
--- a/.github/workflows/cpu-torch-latest.yml
+++ b/.github/workflows/cpu-torch-latest.yml
@@ -37,6 +37,15 @@ jobs:
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
+      - name: Install transformers
+        run: |
+          git clone https://github.com/huggingface/transformers
+          cd transformers
+          # if needed switch to the last known good SHA until transformers@master is fixed
+          git checkout 6c3f168b3
+          git rev-parse --short HEAD
+          pip install .
+
       - name: Install deepspeed
         run: |
           pip install .[dev,autotuning]


### PR DESCRIPTION
This is a copy of https://github.com/microsoft/DeepSpeed/pull/6820 for the cpu-torch-latest tests.

This PR will revert/fix these: https://github.com/microsoft/DeepSpeed/pull/6822