### PR TITLE
Pin HPU tests

### DIFF
--- a/.github/workflows/hpu-gaudi2.yml
+++ b/.github/workflows/hpu-gaudi2.yml
@@ -111,6 +111,8 @@ jobs:
         run: |
           git clone https://github.com/huggingface/transformers
           cd transformers
+          # if needed switch to the last known good SHA until transformers@master is fixed
+          git checkout 6c3f168b3
           git rev-parse --short HEAD
           pip install .
 


### PR DESCRIPTION
HPU tests are impacted by the same issue as other tests that use transformers latest.  This PR pins to a version of transformers before the fix.