### PR TITLE
Unpin pytest-subtests now that 0.14.1 is released

### DIFF
--- a/.github/workflows/nv-accelerate-v100.yml
+++ b/.github/workflows/nv-accelerate-v100.yml
@@ -52,7 +52,5 @@ jobs:
           pip install .[testing]
           # force protobuf version due to issues
           pip install "protobuf<4.21.0"
-          # force pytest-subtests version due to issues
-          pip install pytest-subtests==0.13.1
           pip list
           pytest $PYTEST_OPTS --color=yes --durations=0 --verbose tests/deepspeed


### PR DESCRIPTION
The issue we encountered was covered here: https://github.com/pytest-dev/pytest-subtests/issues/173

And is resolved with the latest changes from this PR: https://github.com/pytest-dev/pytest-subtests/issues/174, and is published in the latest version 0.14.1.