### PR TITLE
Fix `no-torch` workflow and update real_accelerator

### DIFF
--- a/.github/workflows/no-torch.yml
+++ b/.github/workflows/no-torch.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/workflows/no-torch.yml'
       - 'op_builder/**'
+      - 'accelerator/**'
   schedule:
     - cron: "0 0 * * *"
 

--- a/accelerator/real_accelerator.py
+++ b/accelerator/real_accelerator.py
@@ -125,9 +125,10 @@ def get_accelerator():
         if accelerator_name is None:
             try:
                 import intel_extension_for_pytorch as ipex
-
                 if ipex._C._has_xpu():
                     accelerator_name = "xpu"
+                else:
+                    accelerator_name = "cpu"
             except ImportError as e:
                 pass
         if accelerator_name is None:
@@ -161,6 +162,7 @@ def get_accelerator():
             except ImportError as e:
                 pass
         if accelerator_name is None:
+            # borrow this log from PR#5084
             try:
                 import torch
 
@@ -172,16 +174,16 @@ def get_accelerator():
                 # For reference: https://github.com/microsoft/DeepSpeed/pull/6810
                 if torch.cuda.device_count() > 0 and torch.cuda.is_available():  #ignore-cuda
                     accelerator_name = "cuda"
+                else:
+                    if accel_logger is not None:
+                        accel_logger.warn(
+                            "Setting accelerator to CPU. If you have GPU or other accelerator, we were unable to detect it."
+                        )
+                    accelerator_name = "cpu"
             except (RuntimeError, ImportError) as e:
                 # TODO need a more decent way to detect which accelerator to use, consider using nvidia-smi command for detection
+                accelerator_name = "cuda"
                 pass
-        if accelerator_name is None:
-            # borrow this log from PR#5084
-            if accel_logger is not None:
-                accel_logger.warn(
-                    "Setting accelerator to CPU. If you have GPU or other accelerator, we were unable to detect it.")
-            # cpu added as catch-all when accelerator detection fails
-            accelerator_name = "cpu"
 
         ds_set_method = "auto detect"
 


### PR DESCRIPTION
This reverts #6845, since this breaks the `no-torch` workflow that we require in order to do releases where we do not require torch to be in the environment when building an sdist.

FYI @keiwoo (we want to make the change, but this will revert and at least trigger this test when we re-apply these changes.