### PR TITLE
Don't error out when cpu accelerator doesn't have torch (as default for whl building)

### DIFF
--- a/.github/workflows/no-torch.yml
+++ b/.github/workflows/no-torch.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - 'accelerator/**'
       - '.github/workflows/no-torch.yml'
       - 'op_builder/**'
   schedule:

--- a/accelerator/cpu_accelerator.py
+++ b/accelerator/cpu_accelerator.py
@@ -5,6 +5,8 @@
 
 from .abstract_accelerator import DeepSpeedAccelerator
 
+# During setup stage torch may not be installed, pass on no torch will
+# allow op builder related API to be executed.
 try:
     import torch
 except ImportError as e:

--- a/accelerator/cpu_accelerator.py
+++ b/accelerator/cpu_accelerator.py
@@ -3,8 +3,12 @@
 
 # DeepSpeed Team
 
-import torch
 from .abstract_accelerator import DeepSpeedAccelerator
+
+try:
+    import torch
+except ImportError as e:
+    pass
 
 try:
     import oneccl_bindings_for_pytorch  # noqa: F401 # type: ignore


### PR DESCRIPTION
This fixes a bug introduced in #6845, which breaks the `no-torch` workflow that we require in order to do releases where we do not require torch to be in the environment when building an sdist.  This adds the same logic to the cpuaccelerator that the cudaaccelerator had where we don't require torch to be installed to build the whl.