### PR TITLE
Remove op compilation flags due to perf issue

### DIFF
--- a/op_builder/hpu/builder.py
+++ b/op_builder/hpu/builder.py
@@ -32,9 +32,6 @@ class CPUOpBuilder(OpBuilder):
 
     def cxx_args(self):
         args = ['-O3', '-g', '-Wno-reorder']
-        CPU_ARCH = self.cpu_arch()
-        SIMD_WIDTH = self.simd_width()
-        args += [CPU_ARCH, '-fopenmp', SIMD_WIDTH]
         return args
 
     def libraries_args(self):


### PR DESCRIPTION
in some scenarios some of the optimization
flags for the ops compiler for HPU can cause
a significant performance degradation. 
remove the flags until the issue is resolved