### PR TITLE
Remove Duplicate Declaration of pandas in `Dockerfile`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -132,7 +132,6 @@ RUN pip install psutil \
         sentencepiece \
         msgpack \
         requests \
-        pandas \
         sphinx \
         sphinx_rtd_theme \
         scipy \


### PR DESCRIPTION
### Description

This pull request removes the redundant installation of `pandas` from the `Dockerfile`.
It was previously declared twice, and this update eliminates the duplicate entry, improving the clarity and maintainability of the `Dockerfile`.

https://github.com/microsoft/DeepSpeed/blob/018ece5af2d89a11a4a235f81f94496c78b4f990/docker/Dockerfile#L124

https://github.com/microsoft/DeepSpeed/blob/018ece5af2d89a11a4a235f81f94496c78b4f990/docker/Dockerfile#L135

### Changes

Removed the duplicate pandas installation line from the `RUN pip install` command.