### PR TITLE
Enable torch.autocast with ZeRO

### DIFF
--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -156,6 +156,24 @@ def get_amp_params(param_dict):
         return False
 
 
+def get_torch_autocast_enabled(param_dict):
+    if TORCH_AUTOCAST in param_dict.keys():
+        return get_scalar_param(param_dict[TORCH_AUTOCAST], TORCH_AUTOCAST_ENABLED, TORCH_AUTOCAST_ENABLED_DEFAULT)
+    else:
+        return False
+
+
+def get_torch_autocast_dtype(param_dict):
+    if TORCH_AUTOCAST in param_dict:
+        if TORCH_AUTOCAST_DTYPE in param_dict[TORCH_AUTOCAST]:
+            try:
+                return DtypeEnum(param_dict[TORCH_AUTOCAST][TORCH_AUTOCAST_DTYPE]).value
+            except KeyError:
+                raise ValueError(
+                    f"Invalid dtype for torch autocast: {param_dict[TORCH_AUTOCAST][TORCH_AUTOCAST_DTYPE]}")
+    return None
+
+
 def get_fp16_enabled(param_dict):
     if FP16 in param_dict.keys():
         return get_scalar_param(param_dict[FP16], FP16_ENABLED, FP16_ENABLED_DEFAULT)
@@ -835,6 +853,8 @@ class DeepSpeedConfig(object):
         self.fp16_master_weights_and_gradients = get_fp16_master_weights_and_grads_enabled(param_dict)
         self.amp_enabled = get_amp_enabled(param_dict)
         self.amp_params = get_amp_params(param_dict)
+        self.torch_autocast_enabled = get_torch_autocast_enabled(param_dict)
+        self.torch_autocast_dtype = get_torch_autocast_dtype(param_dict)
         self.loss_scale = get_loss_scale(param_dict)
         self.initial_dynamic_scale = get_initial_dynamic_scale(param_dict)
         self.dynamic_loss_scale_args = get_dynamic_loss_scale_args(param_dict)

--- a/deepspeed/runtime/constants.py
+++ b/deepspeed/runtime/constants.py
@@ -203,6 +203,23 @@ AMP_ENABLED = "enabled"
 AMP_ENABLED_DEFAULT = False
 
 #########################################
+# Torch AMP support
+#########################################
+TORCH_AUTOCAST_FORMAT = '''
+PyTorch autocast config should be of the format:
+"torch_autocast": {
+  "enabled": true,
+  "dtype": "bfloat16",
+}
+'''
+TORCH_AUTOCAST = "torch_autocast"
+
+TORCH_AUTOCAST_ENABLED = "enabled"
+TORCH_AUTOCAST_ENABLED_DEFAULT = False
+TORCH_AUTOCAST_DTYPE = "dtype"
+TORCH_AUTOCAST_DTYPE_DEFAULT = None
+
+#########################################
 # Gradient clipping
 #########################################
 # Gradient clipping. By default, this feature is not enabled.

--- a/deepspeed/runtime/torch_autocast.py
+++ b/deepspeed/runtime/torch_autocast.py
@@ -7,37 +7,47 @@ from typing import Iterable, Set
 
 import torch
 
-
 LOWER_PRECISION_SAFE_MODULES = [
-    "torch.nn.Linear",
-    "torch.nn.Conv1d",
-    "torch.nn.Conv2d",
-    "torch.nn.Conv3d",
+    torch.nn.Linear,
+    torch.nn.Conv1d,
+    torch.nn.Conv2d,
+    torch.nn.Conv3d,
 ]
 
-
-SUPPORTED_DTYPES = {
-    torch.float16,
-    torch.bfloat16,
-    torch.float32
-}
+TORCH_AUTOCAST_INITIALIZED = False
 
 
-def validate_auto_cast_settings(engine):
-    # Verify autocast setting
-    if engine.torch_autocast_enabled():
-        assert not engine.fp16_enabled(), "Cannot enable both torch autocast and fp16"
-        assert not engine.bfloat16_enabled(), "Cannot enable both torch autocast and bfloat16"
+def _validate_auto_cast_settings(engine):
 
-    assert all(p.dtype == torch.float32 for p in engine.parameters()), "All parameters must be float32 for torch autocast"
+    assert not engine.fp16_enabled(), "Cannot enable both torch autocast and fp16"
+    assert not engine.bfloat16_enabled(), "Cannot enable both torch autocast and bfloat16"
+
+    assert all(p.dtype == torch.float32
+               for p in engine.parameters()), "All parameters must be float32 for torch autocast"
+    assert engine.communication_data_type == torch.float32, "Communication data type must be float32 for torch autocast"
 
 
-def init_autocast_params(model: torch.nn.Module, dtype: torch.dtype) -> None:
+def init_autocast_params(engine, dtype: torch.dtype) -> None:
+
+    _validate_auto_cast_settings(engine)
+    model = engine.module
+
     for module in model.modules():
-        if module.__class__.__name__ in LOWER_PRECISION_SAFE_MODULES:
+        if module.__class__ in LOWER_PRECISION_SAFE_MODULES:
             for p in module.parameters(recurse=False):
                 p.autocast_dtype = dtype
 
+    global TORCH_AUTOCAST_INITIALIZED
+    TORCH_AUTOCAST_INITIALIZED = True
 
-def get_autocast_dtypes(params: Iterable) -> Set[torch.dtype]:
-    return {p.autocast_dtype if hasattr(p, "autocast_dtype") else p.dtype for p in params}
+
+def is_autocast_initialized() -> bool:
+    return TORCH_AUTOCAST_INITIALIZED
+
+
+def get_autocast_dtype(param: torch.nn.Parameter) -> torch.dtype:
+    return param.autocast_dtype if hasattr(param, "autocast_dtype") else param.dtype
+
+
+def get_all_autocast_dtypes(params: Iterable) -> Set[torch.dtype]:
+    return {get_autocast_dtype(p) for p in params}

--- a/deepspeed/runtime/torch_autocast.py
+++ b/deepspeed/runtime/torch_autocast.py
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from typing import Iterable, Set
+
+import torch
+
+
+LOWER_PRECISION_SAFE_MODULES = [
+    "torch.nn.Linear",
+    "torch.nn.Conv1d",
+    "torch.nn.Conv2d",
+    "torch.nn.Conv3d",
+]
+
+
+SUPPORTED_DTYPES = {
+    torch.float16,
+    torch.bfloat16,
+    torch.float32
+}
+
+
+def validate_auto_cast_settings(engine):
+    # Verify autocast setting
+    if engine.torch_autocast_enabled():
+        assert not engine.fp16_enabled(), "Cannot enable both torch autocast and fp16"
+        assert not engine.bfloat16_enabled(), "Cannot enable both torch autocast and bfloat16"
+
+    assert all(p.dtype == torch.float32 for p in engine.parameters()), "All parameters must be float32 for torch autocast"
+
+
+def init_autocast_params(model: torch.nn.Module, dtype: torch.dtype) -> None:
+    for module in model.modules():
+        if module.__class__.__name__ in LOWER_PRECISION_SAFE_MODULES:
+            for p in module.parameters(recurse=False):
+                p.autocast_dtype = dtype
+
+
+def get_autocast_dtypes(params: Iterable) -> Set[torch.dtype]:
+    return {p.autocast_dtype if hasattr(p, "autocast_dtype") else p.dtype for p in params}

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -11,6 +11,9 @@ import socket
 import subprocess
 from abc import ABC, abstractmethod
 from pathlib import Path
+import random
+import numpy as np
+from typing import Callable, Any
 
 import torch
 import torch.multiprocessing as mp
@@ -505,3 +508,54 @@ def preferred_dtype():
         return torch.bfloat16
     else:
         return torch.float32
+
+
+class EnableDeterminism:
+
+    def __init__(self, seed: int):
+        local_rank = int(os.getenv("LOCAL_RANK", "0"))
+
+        self.seed = seed + local_rank
+        self.saved_random_state = None
+        self.saved_np_random_state = None
+        self.saved_cuda_launch_blocking = None
+        self.saved_cublas_workspace_config = None
+        self.saved_deterministic_algorithms = None
+
+    def __enter__(self):
+        self.saved_random_state = random.getstate()
+        self.saved_np_random_state = np.random.get_state()
+        self.saved_acc_rng_state = get_accelerator().get_rng_state()
+        self.saved_cuda_launch_blocking = os.environ.get("CUDA_LAUNCH_BLOCKING", "")
+        self.saved_cublas_workspace_config = os.environ.get("CUBLAS_WORKSPACE_CONFIG", "")
+        self.saved_deterministic_algorithms = torch.are_deterministic_algorithms_enabled()
+
+        random.seed(self.seed)
+        np.random.seed(self.seed)
+        get_accelerator().manual_seed(self.seed)
+        get_accelerator().manual_seed_all(self.seed)
+
+        os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
+        torch.use_deterministic_algorithms(True)
+
+    def __exit__(self, type, value, traceback):
+        random.setstate(self.saved_random_state)
+        np.random.set_state(self.saved_np_random_state)
+        get_accelerator().set_rng_state(self.saved_acc_rng_state)
+        os.environ["CUDA_LAUNCH_BLOCKING"] = self.saved_cuda_launch_blocking
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = self.saved_cublas_workspace_config
+        torch.use_deterministic_algorithms(self.saved_deterministic_algorithms)
+
+
+def enable_determinism(seed: int):
+
+    def decorator(func: Callable) -> Callable:
+
+        def wrapper(*args: Any, **kwargs: Any):
+            with EnableDeterminism(seed):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/unit/runtime/zero/test_zero_autocast.py
+++ b/tests/unit/runtime/zero/test_zero_autocast.py
@@ -1,0 +1,118 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import random
+import os
+import numpy as np
+from typing import Callable, Any
+from copy import deepcopy
+
+import pytest
+
+import torch
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.cuda.amp import autocast, GradScaler
+
+from unit.common import DistributedTest, preferred_dtype, enable_determinism
+from unit.simple_model import SimpleModel, random_dataloader
+from unit.util import bf16_required_version_check
+
+import deepspeed
+from deepspeed.accelerator import get_accelerator
+from deepspeed.runtime.zero import GatheredParameters
+from deepspeed.git_version_info import torch_info
+from deepspeed.runtime.zero.offload_config import OffloadDeviceEnum
+
+
+RTOL = 0.01
+ATOL = 0.0
+
+
+def step_amp(baseline_model,
+                baseline_optimizer,
+                target_engine,
+                dtype,
+                baseline_scaler,
+                x, y,
+                rtol, atol):
+    # Runs the forward pass with autocasting.
+    with torch.autocast(device_type="cuda", dtype=dtype):
+        baseline_optimizer.zero_grad()
+        baseline_loss = baseline_model(x, y)
+
+    baseline_scaler.scale(baseline_loss).backward()
+    baseline_scaler.step(baseline_optimizer)
+    baseline_scaler.update()
+
+    target_loss = target_engine(x, y)
+
+    assert torch.allclose(baseline_loss.float(), target_loss.float(), rtol=rtol, atol=atol)
+
+    target_engine.backward(target_loss)
+    target_engine.step()
+
+
+@enable_determinism(123)
+def compare_loss(zero_stage, dtype):
+    iteration = 5
+    hidden_dim = 10
+    lr = 0.001
+
+    if dtype == torch.bfloat16 and not bf16_required_version_check():
+        raise ValueError("DeepSpeed BFloat16 tests need torch >= 1.10, NCCL >= 2.10.3, CUDA > =11.0 and HW support for BFloat16 to run correctly")
+
+    config_dict = {
+        "train_micro_batch_size_per_gpu": 1,
+        "steps_per_print": 1,
+        "zero_optimization": {
+            "stage": zero_stage,
+        },
+        "torch_autocast": {
+            "enabled": True,
+            "dtype": str(dtype)
+        }
+    }
+
+    model_cls = SimpleModel
+    model = model_cls(hidden_dim)
+
+    deepspeed.init_distributed(dist_backend='nccl')
+
+    i = get_accelerator().current_device()
+    device = get_accelerator().current_device_name()
+    baseline_model = DDP(deepcopy(model).to(device=device, dtype=torch.float32), device_ids=[i], output_device=i)
+    baseline_optimizer = torch.optim.AdamW(baseline_model.parameters(), lr=lr, weight_decay=0.0)
+    baseline_scaler = torch.amp.GradScaler()
+
+    stage_3_enabled = config_dict["zero_optimization"]["stage"] == 3
+    if stage_3_enabled:
+        with deepspeed.zero.Init(config_dict_or_path=config_dict):
+            target_model = model_cls(hidden_dim)
+        with GatheredParameters(target_model.parameters(), modifier_rank=0):
+            for p1, p2 in zip(target_model.parameters(), model.parameters()):
+                p1.data.copy_(p2.data)
+    else:
+        target_model = deepcopy(model)
+
+    ds_optimizer = torch.optim.Adam(target_model.parameters(), lr=lr)
+    target_engine, _, _, _ = deepspeed.initialize(config=config_dict,
+                                                                model=target_model,
+                                                                optimizer=ds_optimizer)
+    train_batch_size = config_dict["train_micro_batch_size_per_gpu"]
+
+    xs = [torch.randn(train_batch_size, hidden_dim, device=device, dtype=torch.float32) for _ in range(iteration)]
+    ys = [torch.randn_like(x) for x in xs]
+
+    for i, (x, y) in enumerate(zip(xs, ys)):
+        step_amp(baseline_model, baseline_optimizer, target_engine, dtype, baseline_scaler, x, y, RTOL, ATOL)
+
+
+@pytest.mark.parametrize("zero_stage", [1, 2])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+class TestZeroAutoCast(DistributedTest):
+    world_size = 2
+
+    def test(self, zero_stage, dtype):
+        compare_loss(zero_stage, dtype)


### PR DESCRIPTION
This PR supports `torch.autocast` with ZeRO. You need to enable `torch.autocast` in DeepSpeed config.

```json
"torch_autocast": {
  "enabled": true,
  "dtype": "bfloat16"
}
```

You don't need to explicitly call `torch.autocast` in your code. The grad scaler is also applied in the DeepSpeed optimizer.

All the parameters are maintained in FP32 but certain operators and layers are computed in the specified dtype. With ZeRO enabled, the communication (allreduce/reduce_scatter) for specified layers are also done in the specified dtype ([List of modules](https://github.com/microsoft/DeepSpeed/blob/0e52edb6a3cc940a9d8c53f7343f3473ebd69bbb/deepspeed/runtime/torch_autocast.py)).
You cannot enable `fp16` or `bf16` with `torch.autocast`.

(Currently working on ZeRO3)