### PR TITLE
Avoid graph break by enabling compile of record module

### DIFF
--- a/deepspeed/runtime/zero/partitioned_param_coordinator.py
+++ b/deepspeed/runtime/zero/partitioned_param_coordinator.py
@@ -195,7 +195,6 @@ class PartitionedParameterCoordinator:
                     force=self.__log_trace_cache_warnings)
                 self._invalidate_trace()
 
-    @compiler.disable
     def record_module(self, sub_module: Module) -> None:
         """adds sub module to trace"""
         if is_compiling():


### PR DESCRIPTION
Dynamo breaks the graph because currently compile is disabled for record_module.

Re-enabling the compile should avoid the graph break and improve the performance.