### PR TITLE
fix: Add `csrc/compile` to include paths for DeepCompile builder

### DIFF
--- a/op_builder/dc.py
+++ b/op_builder/dc.py
@@ -37,4 +37,4 @@ class DeepCompileBuilder(TorchCPUOpBuilder):
             CUDA_INCLUDE = [
                 os.path.join(torch.utils.cpp_extension.ROCM_HOME, "include"),
             ]
-        return ['csrc/includes'] + CUDA_INCLUDE
+        return ['csrc/includes', 'csrc/compile'] + CUDA_INCLUDE


### PR DESCRIPTION
Since currently `z1.h`, `z2.h` and `z3.h` are located under `csrc/compile`, without this patch, torch hipify will fail to identify these hipified headers on AMD platform:

```log
In file included from torch/include/ATen/cuda/CUDAEvent.h:3,
                  from deepspeed/ops/csrc/includes/deepcompile.h:16,
                  from deepspeed/ops/csrc/compile/z1.h:6,
                  from deepspeed/ops/csrc/compile/z1_hip.cpp:7:
 torch/include/ATen/cuda/ATenCUDAGeneral.h:3:10: fatal error: cuda.h: No such file or directory
     3 | #include <cuda.h>
       |          ^~~~~~~~
 compilation terminated.
```