### PR TITLE
fix: DeepCompile for torch 2.8

### DIFF
--- a/csrc/compile/z1.cpp
+++ b/csrc/compile/z1.cpp
@@ -6,17 +6,6 @@
 #include "z1.h"
 #include "deepcompile.h"
 
-#define USE_C10D_NCCL
-
-#include <ATen/cuda/CUDAEvent.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAStream.h>
-#include <torch/csrc/cuda/nccl.h>
-#include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
-#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
-
-#include <torch/csrc/distributed/c10d/SymmetricMemory.hpp>
-
 namespace dc {
 
 class Z1CustomOpExecutor : public CustomOpExecutor {

--- a/csrc/compile/z2.cpp
+++ b/csrc/compile/z2.cpp
@@ -6,17 +6,6 @@
 #include "z2.h"
 #include "deepcompile.h"
 
-#define USE_C10D_NCCL
-
-#include <ATen/cuda/CUDAEvent.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAStream.h>
-#include <torch/csrc/cuda/nccl.h>
-#include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
-#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
-
-#include <torch/csrc/distributed/c10d/SymmetricMemory.hpp>
-
 namespace dc {
 
 class Z2CustomOpExecutor : public CustomOpExecutor {

--- a/csrc/compile/z3.cpp
+++ b/csrc/compile/z3.cpp
@@ -6,17 +6,6 @@
 #include "z3.h"
 #include "deepcompile.h"
 
-#define USE_C10D_NCCL
-
-#include <ATen/cuda/CUDAEvent.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAStream.h>
-#include <torch/csrc/cuda/nccl.h>
-#include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
-#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
-
-#include <torch/csrc/distributed/c10d/SymmetricMemory.hpp>
-
 namespace dc {
 
 const size_t TIMEOUT_SYMMETRIC_MEMORY_BARRIER = 60000;

--- a/csrc/includes/deepcompile.h
+++ b/csrc/includes/deepcompile.h
@@ -19,7 +19,12 @@
 #include <torch/csrc/cuda/nccl.h>
 #include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+
+#if __has_include(<torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>)
+#include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
+#else
 #include <torch/csrc/distributed/c10d/SymmetricMemory.hpp>
+#endif
 
 namespace dc {
 


### PR DESCRIPTION
In torch v2.8.0, all symm mem code are moved into a dedicated folder https://github.com/pytorch/pytorch/commit/ffc6cbfaf78ca219092ce64dcf113377ae698300

So this PR tries to address this change by checking if we have it located under `torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp` (new location). If not, we fall back to the original place for backward compatibilities.

This PR also clean up some includes in `z1/2/3.cpp` that has already been included in `deepcompile.h`