### PR TITLE
deepcompile: Create dummy inputs using empty_strided

### DIFF
--- a/deepspeed/compile/backend.py
+++ b/deepspeed/compile/backend.py
@@ -151,11 +151,12 @@ def set_example_values_to_symints(real_inputs, param_indices=None):
                     else:
                         stride.append(fs)
                 with unset_fake_temporarily():
-                    dummy_v = torch.zeros(shape,
-                                          dtype=v.dtype,
-                                          layout=v.layout,
-                                          device=v.device,
-                                          requires_grad=v.requires_grad).as_strided(shape, stride)
+                    dummy_v = torch.empty_strided(shape,
+                                                  stride,
+                                                  dtype=v.dtype,
+                                                  layout=v.layout,
+                                                  device=v.device,
+                                                  requires_grad=v.requires_grad).zero_()
 
                     # Create Parameter if this input index corresponds to a parameter
                     if i in param_idx_set:


### PR DESCRIPTION
CUDA tensors may have a larger storage than numel() * dtype.itemsize due to alignment considerations. Creating dummy tensors by torch.zero().as_strided() leads to out-of-bound errors in such cases.

Create dummy inputs by empty_strided().zero_() instead.