### PR TITLE
DeepCompile: Fuse allgather and downcast

### DIFF
--- a/csrc/compile/init.cpp
+++ b/csrc/compile/init.cpp
@@ -10,8 +10,10 @@
 
 TORCH_LIBRARY(dc, m)
 {
-    m.def("allgather_param(Tensor a, int graph_id, int id) -> Tensor");
-    m.def("prefetch_params_fused(int graph_id, Tensor[] params, int[] ids) -> ()");
+    m.def("allgather_param(Tensor a, int graph_id, int id, ScalarType? dtype = None) -> Tensor");
+    m.def(
+        "prefetch_params_fused(int graph_id, Tensor[] params, int[] ids,"
+        "                      ScalarType[]? dtypes = None) -> ()");
     m.def("wait_allgather(Tensor(a) a, int graph_id, int id) -> Tensor(a)");
     m.def("release_param(Tensor(a) a, int graph_id, int id, int n_users) -> Tensor(a)");
     m.def("reduce_grad(Tensor a, int graph_id, int id) -> Tensor");

--- a/csrc/compile/z3.h
+++ b/csrc/compile/z3.h
@@ -21,18 +21,26 @@ void register_z3_param(long ds_id,
                        at::Tensor ds_tensor,
                        at::Tensor grad_buffer,
                        bool persistent);
-at::Tensor allgather_param(at::Tensor param_tensor, long graph_id, long ds_id);
+at::Tensor allgather_param(at::Tensor param_tensor,
+                           long graph_id,
+                           long ds_id,
+                           std::optional<at::ScalarType> dtype);
 void set_persistent(long ds_id);
 void prefetch_params_fused(long graph_id,
-                           const std::vector<at::Tensor> params,
-                           const std::vector<long>& ds_ids);
+                           const std::vector<at::Tensor>& params,
+                           const std::vector<long>& ds_ids,
+                           const std::optional<std::vector<at::ScalarType>>& dtypes);
 void prefetch_params_fused_meta(long graph_id,
-                                const std::vector<at::Tensor> params,
-                                const std::vector<long>& ds_ids);
+                                const std::vector<at::Tensor>& params,
+                                const std::vector<long>& ds_ids,
+                                const std::optional<std::vector<at::ScalarType>>& dtypes);
 // for profiling
 void invalidate_gathered_param(long ds_id);
 void clear_all_gathered_params();
-at::Tensor allgather_param_meta(at::Tensor param_tensor, long graph_id, long ds_id);
+at::Tensor allgather_param_meta(at::Tensor param_tensor,
+                                long graph_id,
+                                long ds_id,
+                                std::optional<at::ScalarType> dtype);
 at::Tensor release_param(at::Tensor dummy, long graph_id, long ds_id, long n_users);
 at::Tensor release_param_meta(at::Tensor dummy, long graph_id, long ds_id, long n_users);
 at::Tensor wait_allgather(at::Tensor v, long graph_id, const long ds_id);

--- a/csrc/includes/deepcompile.h
+++ b/csrc/includes/deepcompile.h
@@ -18,6 +18,7 @@
 #include <c10/cuda/CUDAStream.h>
 #include <torch/csrc/cuda/nccl.h>
 #include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
+#include <torch/csrc/distributed/c10d/ParamCommsUtils.hpp>
 #include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
 
 #if __has_include(<torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>)
@@ -261,6 +262,7 @@ public:
         : id_(id),
           shape_(std::move(ds_shape)),
           ds_tensor_(ds_tensor),
+          ds_dtype_(ds_tensor.scalar_type()),
           grad_buffer_(grad_buffer),
           partitioned_(partitioned),
           offset_(offset),
@@ -272,6 +274,7 @@ public:
 
     long getId() const { return id_; }
     std::vector<int64_t> getShape() const { return shape_; }
+    at::ScalarType getDtype() const { return ds_dtype_; }
     at::Tensor getDSTensor() const
     {
         // If the reload event exists and is complete, return the reloaded tensor (if defined)
@@ -343,6 +346,7 @@ public:
 private:
     long id_;
     std::vector<int64_t> shape_;
+    at::ScalarType ds_dtype_;
     at::Tensor ds_tensor_;
     at::Tensor ds_reload_tensor_;
     at::Tensor grad_buffer_;

--- a/deepspeed/compile/fx.py
+++ b/deepspeed/compile/fx.py
@@ -3,7 +3,7 @@
 
 # DeepSpeed Team
 
-from typing import Callable, Any, List
+from typing import Callable, Any, List, Dict
 from collections import defaultdict
 
 import torch
@@ -60,7 +60,8 @@ def add_args_process(graph: Graph,
 def add_postprocess(graph: Graph,
                     node: Node,
                     fn: Callable[..., Any],
-                    extra_args: List[int] = [],
+                    extra_args: List[Any] = [],
+                    extra_kwargs: Dict[str, Any] = {},
                     name=None,
                     meta={}) -> Node:
     # https://github.com/pytorch/examples/blob/main/fx/wrap_output_dynamically.py
@@ -70,7 +71,7 @@ def add_postprocess(graph: Graph,
             args += (a, )
 
         node_users = node.users.keys()
-        new_node = graph.create_node('call_function', fn, args, {}, name=name)
+        new_node = graph.create_node('call_function', fn, args, extra_kwargs, name=name)
         users = {}
         for u in node_users:
             if u != new_node:


### PR DESCRIPTION
With autocast enabled, a majority of weights are downcasted before being used in calculations. Today zero3_compile gathers the FP32 weights before they are downcasted. That is sub-optimal because FP32 weights consumes more bandwidth to allgather and takes more time to downcast.

To reduce communication and downcast time, fuse allgather and downcast in the dc ops. The target type is now passed to allgather_param() and prefetch_params_fused() which will downcast the (partial) weights before launching allgathers.

This corresponds to issue 1 of #7577.

Tested with https://gist.github.com/eternalNight/3c2cf8c703f1e9e7742d3b7f9e1edae3 (run with `deepspeed --num_gpus=N this_file.py -c -p -m 23` to collect torch and memory profiles, and with DINOV2_DEPTH = SIGLIP_DEPTH = 3, LLAMA2_DEPTH = 4 for faster compileation) on 5090 (which has limited inter-GPU bandwidth), time per step decreases from 438ms to 337ms and peak GPU memory usage from 9.5GB to 8.5GB.

Profiles of a single step before this PR:

<img width="1235" height="1029" alt="image" src="https://github.com/user-attachments/assets/d9fe5296-7731-4542-924b-421ff7415054" />

<img width="1466" height="616" alt="image" src="https://github.com/user-attachments/assets/aa192802-8633-4e36-b2c4-f28b1b432663" />

After this PR:

<img width="1218" height="1006" alt="image" src="https://github.com/user-attachments/assets/18a0e09c-155b-4783-adb5-b4d36c5c3691" />

<img width="1537" height="559" alt="image" src="https://github.com/user-attachments/assets/16a2ca74-8a89-4db9-9b68-81844295c61b" />

This PR also reduces peak memory usage because the `fast_free_schedule()` today always arranges param allgathers and downcasts at the beginning of the graph. While the original FP32 params can be freed early, all FP16/BF16-casted params are kept in GPU memory at the beginning of the backward graph, leading to a higher peak in memory usage.

P.S. Probably due to organization branch rule settings, I don't find anywhere to allow reviewers to modify the branch. So I'll update the branch per reviewers' comments and rebase if needed.