### PR TITLE
Take **kwargs in __init__ of DeepSpeedZeroOptimizer subclasses

### DIFF
--- a/deepspeed/runtime/superoffload/superoffload_stage3.py
+++ b/deepspeed/runtime/superoffload/superoffload_stage3.py
@@ -3,7 +3,6 @@
 
 # DeepSpeed Team
 
-import sys
 import time
 import torch
 from typing import List
@@ -26,42 +25,7 @@ class SuperOffloadOptimizer_Stage3(DeepSpeedZeroOptimizer_Stage3):
         init_optimizer,
         timers,
         ds_config,
-        static_loss_scale=1.0,
-        dynamic_loss_scale=False,
-        dynamic_loss_args=None,
-        verbose=True,
-        contiguous_gradients=True,
-        reduce_bucket_size=500000000,
-        prefetch_bucket_size=50000000,
-        max_reuse_distance=1000000000,
-        max_live_parameters=1000000000,
-        param_persistence_threshold=100000,
-        model_persistence_threshold=sys.maxsize,
-        dp_process_group=None,
-        reduce_scatter=True,
-        overlap_comm=False,
-        offload_optimizer_config=None,
-        offload_param_config=None,
-        sub_group_size=1000000000000,
-        offload_ratio=0.0,
-        mpu=None,
-        clip_grad=0.0,
-        gradient_accumulation_dtype=torch.float32,
-        communication_data_type=torch.float16,
-        postscale_gradients=True,
-        gradient_predivide_factor=1.0,
-        gradient_accumulation_steps=1,
-        elastic_checkpoint=False,
-        aio_config=None,
-        all2all_process_group=None,
-        zero_hpz_partition_size=1,
-        zero_quantized_weights=False,
-        zero_quantized_nontrainable_weights=False,
-        zero_module_granularity_threshold=0,
-        zeropp_loco_param=None,
-        log_trace_cache_warnings=False,
-        enable_sanity_checks=False,
-        cpuadam_cores_perc=0.8,
+        **kwargs,
     ):
 
         self.sub_group_to_param_num = {}
@@ -70,16 +34,7 @@ class SuperOffloadOptimizer_Stage3(DeepSpeedZeroOptimizer_Stage3):
         self.async_cpuadam_num = 0
         self.max_grad_numel = 0
 
-        super().__init__(module, init_optimizer, timers, ds_config, static_loss_scale, dynamic_loss_scale,
-                         dynamic_loss_args, verbose, contiguous_gradients, reduce_bucket_size, prefetch_bucket_size,
-                         max_reuse_distance, max_live_parameters, param_persistence_threshold,
-                         model_persistence_threshold, dp_process_group, reduce_scatter, overlap_comm,
-                         offload_optimizer_config, offload_param_config, sub_group_size, offload_ratio, mpu, clip_grad,
-                         gradient_accumulation_dtype, communication_data_type, postscale_gradients,
-                         gradient_predivide_factor, gradient_accumulation_steps, elastic_checkpoint, aio_config,
-                         all2all_process_group, zero_hpz_partition_size, zero_quantized_weights,
-                         zero_quantized_nontrainable_weights, zero_module_granularity_threshold, zeropp_loco_param,
-                         log_trace_cache_warnings, enable_sanity_checks)
+        super().__init__(module, init_optimizer, timers, ds_config, **kwargs)
 
         optimizer_config = {
             "lr": self.optimizer.param_groups[0]["lr"],
@@ -88,6 +43,7 @@ class SuperOffloadOptimizer_Stage3(DeepSpeedZeroOptimizer_Stage3):
             "weight_decay": self.optimizer.param_groups[0]["weight_decay"],
             "amsgrad": self.optimizer.param_groups[0]["amsgrad"]
         }
+        cpuadam_cores_perc = kwargs.get("cpuadam_cores_perc", 0.8)
         self.superoffload_cpu_optimizer = SuperOffloadCPUOptimizer(optimizer_config=optimizer_config,
                                                                    cpuadam_cores_perc=cpuadam_cores_perc,
                                                                    max_grad_numel=self.max_grad_numel)

--- a/deepspeed/runtime/zenflow/zenflow_stage_1_and_2.py
+++ b/deepspeed/runtime/zenflow/zenflow_stage_1_and_2.py
@@ -46,49 +46,18 @@ SELECTIVE_OPTIMIZER_TIMERS = [
 
 class ZenFlowZeroOptimizer(DeepSpeedZeroOptimizer):
 
-    def __init__(self,
-                 init_optimizer,
-                 param_names,
-                 timers,
-                 optimizer_params,
-                 static_loss_scale=1.0,
-                 dynamic_loss_scale=False,
-                 dynamic_loss_args=None,
-                 verbose=True,
-                 contiguous_gradients=True,
-                 reduce_bucket_size=500000000,
-                 use_multi_rank_bucket_allreduce=True,
-                 allgather_bucket_size=5000000000,
-                 dp_process_group=None,
-                 expert_parallel_group=None,
-                 expert_data_parallel_group=None,
-                 reduce_scatter=True,
-                 overlap_comm=False,
-                 offload_optimizer_config=None,
-                 zenflow_config=None,
-                 mpu=None,
-                 clip_grad=0.0,
-                 gradient_accumulation_dtype=torch.float32,
-                 communication_data_type=torch.float16,
-                 postscale_gradients=True,
-                 gradient_predivide_factor=1.0,
-                 gradient_accumulation_steps=1,
-                 ignore_unused_parameters=True,
-                 partition_grads=True,
-                 round_robin_gradients=False,
-                 has_moe_layers=False,
-                 fp16_master_weights_and_gradients=False,
-                 elastic_checkpoint=False,
-                 check_grad_overflow=True):
+    def __init__(
+        self,
+        init_optimizer,
+        param_names,
+        timers,
+        optimizer_params,
+        **kwargs,
+    ):
 
-        super().__init__(init_optimizer, param_names, timers, optimizer_params, static_loss_scale, dynamic_loss_scale,
-                         dynamic_loss_args, verbose, contiguous_gradients, reduce_bucket_size,
-                         use_multi_rank_bucket_allreduce, allgather_bucket_size, dp_process_group,
-                         expert_parallel_group, expert_data_parallel_group, reduce_scatter, overlap_comm,
-                         offload_optimizer_config, zenflow_config, mpu, clip_grad, gradient_accumulation_dtype,
-                         communication_data_type, postscale_gradients, gradient_predivide_factor,
-                         gradient_accumulation_steps, ignore_unused_parameters, partition_grads, round_robin_gradients,
-                         has_moe_layers, fp16_master_weights_and_gradients, elastic_checkpoint)
+        super().__init__(init_optimizer, param_names, timers, optimizer_params, **kwargs)
+
+        zenflow_config = kwargs.get("zenflow_config", None)
 
         self.micro_step = -1
         self.full_warm_up_rounds = zenflow_config.full_warm_up_rounds
@@ -98,7 +67,7 @@ class ZenFlowZeroOptimizer(DeepSpeedZeroOptimizer):
         self.zf_stage3 = False
 
         if self.offload_selective_optimizer:
-            assert overlap_comm, "offload selective optimizer should be used with overlap_comm"
+            assert kwargs.get("overlap_comm", False), "offload selective optimizer should be used with overlap_comm"
 
         self._configure_zenflow(zenflow_config)
 

--- a/deepspeed/runtime/zero/mics.py
+++ b/deepspeed/runtime/zero/mics.py
@@ -6,7 +6,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
 from typing import List
 
 import deepspeed
@@ -370,42 +369,17 @@ class MiCS_Optimizer(DeepSpeedZeroOptimizer_Stage3):
                  param_names,
                  timers,
                  ds_config,
-                 static_loss_scale=1,
-                 dynamic_loss_scale=False,
-                 dynamic_loss_args=None,
-                 verbose=True,
-                 contiguous_gradients=True,
-                 reduce_bucket_size=500000000,
-                 prefetch_bucket_size=50000000,
-                 max_reuse_distance=1000000000,
-                 max_live_parameters=1000000000,
-                 param_persistence_threshold=100000,
-                 model_persistence_threshold=sys.maxsize,
-                 dp_process_group=None,
-                 reduce_scatter=True,
-                 overlap_comm=False,
-                 offload_optimizer_config=None,
-                 offload_param_config=None,
-                 sub_group_size=1000000000000,
-                 offload_ratio=0.0,
-                 mpu=None,
-                 clip_grad=0,
                  gradient_accumulation_dtype=torch.float16,
-                 communication_data_type=torch.float16,
-                 postscale_gradients=True,
-                 gradient_predivide_factor=1,
-                 gradient_accumulation_steps=1,
-                 elastic_checkpoint=False,
-                 aio_config=None):
+                 **kwargs):
 
         log_dist("Init MiCS optimizer", ranks=[0])
-        super().__init__(module, init_optimizer, param_names, timers, ds_config, static_loss_scale, dynamic_loss_scale,
-                         dynamic_loss_args, verbose, contiguous_gradients, reduce_bucket_size, prefetch_bucket_size,
-                         max_reuse_distance, max_live_parameters, param_persistence_threshold,
-                         model_persistence_threshold, dp_process_group, reduce_scatter, overlap_comm,
-                         offload_optimizer_config, offload_param_config, sub_group_size, offload_ratio, mpu, clip_grad,
-                         gradient_accumulation_dtype, communication_data_type, postscale_gradients,
-                         gradient_predivide_factor, gradient_accumulation_steps, elastic_checkpoint, aio_config)
+        super().__init__(module,
+                         init_optimizer,
+                         param_names,
+                         timers,
+                         ds_config,
+                         gradient_accumulation_dtype=gradient_accumulation_dtype,
+                         **kwargs)
         first_param = next(module.parameters())
         # overload the dp_process_group and partition_count
         assert hasattr(first_param, "comm"), " ".join([


### PR DESCRIPTION
DeepSpeedZeroOptimizer provides a rich, evolving list of keyword arguments. It is tedious and error-prone to list all of them in its subclasses. As an example, the recent introduction of zenflow_config in the middle of that list has caused unit test failures (e.g. https://github.com/deepspeedai/DeepSpeed/actions/runs/18560070656/job/52906645682?pr=7633)

Convert the keyword argument list in DeepSpeedZeroOptimizer subclasses to **kwargs for the consistency of configurable items and their default values. Passing an unknown parameter to such subclasses will now raise an error on their call to DeepSpeedZeroOptimizer.__init__() instead of their own __init__(). It still ensures that typo in such parameters fail early.