### PR TITLE
Fix illegal memory access with multi_tensor_apply size above INT_MAX

### DIFF
--- a/csrc/adam/multi_tensor_apply.cuh
+++ b/csrc/adam/multi_tensor_apply.cuh
@@ -28,7 +28,7 @@ constexpr int depth_to_max_blocks[5] = {320, 320, 320, 320, 320};
 template <int n>
 struct TensorListMetadata {
     void* addresses[n][depth_to_max_tensors[n - 1]];
-    int sizes[depth_to_max_tensors[n - 1]];
+    int64_t sizes[depth_to_max_tensors[n - 1]];
     unsigned char block_to_tensor[depth_to_max_blocks[n - 1]];
     int block_to_chunk[depth_to_max_blocks[n - 1]];  // I fear this needs to be a full int.
     int start_tensor_this_launch;


### PR DESCRIPTION
This change fixes an overflow issue in `TensorListMetadata` where the `sizes` array used `int` (32-bit signed integer). This caused incorrect behavior (e.g., no parameter updates) when handling tensor sizes exceeding `INT_MAX` (2^31 - 1).

The change here is identical to NVIDIA/apex PR [#1825](https://github.com/NVIDIA/apex/pull/1825) for `multi_tensor_apply.cuh`.

For further details regarding this fix, please refer to issue [#7640](https://github.com/deepspeedai/DeepSpeed/issues/7640).