### PR TITLE
No Muon optimizer for embeding and lm_head layer

### DIFF
--- a/deepspeed/__init__.py
+++ b/deepspeed/__init__.py
@@ -68,8 +68,8 @@ dist = None
 
 def set_optimizer_flags(config_class, model):
     if config_class.optimizer_name == MUON_OPTIMIZER:
-        for p in model.parameters():
-            if p.ndim >= 2:
+        for name, p in model.named_parameters():
+            if p.ndim >= 2 and not any(keyword in name.lower() for keyword in ("embed", "lm_head")):
                 setattr(p, "use_muon", True)
             else:
                 setattr(p, "use_muon", False)


### PR DESCRIPTION
This PR follow the suggestion in this artical https://kellerjordan.github.io/posts/muon/#empirical-considerations that non-hidden layers ('embedding' and 'lm_head') needs to be excluded from Muon optimizer.  It check parameter name for `embed` and `lm_head` and not apply `'use_muon'` attribute if any of these string present in the name.

Note in nanochat it also take the same approach (put embedding and lm_head in `adam_groups` to avoid using Muon) https://github.com/karpathy/nanochat/blob/2e938530ce7f38d51052b4e5b37cf5613d0a45fb/nanochat/gpt.py#L226 , so this should be a common practice.



