### PR TITLE
modal ci: fix group concurrency

### DIFF
--- a/.github/workflows/modal-accelerate.yml
+++ b/.github/workflows/modal-accelerate.yml
@@ -31,7 +31,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -32,7 +32,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
currently only one modal CI job is possible across all PRs, which is not workable - all running jobs get cancelled on a new PR or existing PR update - fixing the dependency to make the group concurrency work across PRs not to waste valuable resources.
