### PR TITLE
Add Qwen2.5 to AutoTP model list

### DIFF
--- a/docs/_tutorials/automatic-tensor-parallelism.md
+++ b/docs/_tutorials/automatic-tensor-parallelism.md
@@ -161,6 +161,7 @@ The following model families have been successfully tested with automatic tensor
 - qwen2
 - qwen2-moe
 - qwen2.5
+- qwen3
 - reformer
 - roberta
 - roformer


### PR DESCRIPTION
The AutoTP supported models does not include Qwen2.5, which is already supported.  Update the document.
(https://www.deepspeed.ai/tutorials/automatic-tensor-parallelism/#supported-models)