### PR TITLE
Trust intel server for XPU tests

### DIFF
--- a/.github/workflows/xpu-max1100.yml
+++ b/.github/workflows/xpu-max1100.yml
@@ -51,7 +51,7 @@ jobs:
         pip install --upgrade pip
         pip install py-cpuinfo
         pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 --index-url https://download.pytorch.org/whl/xpu
-        pip install intel-extension-for-pytorch==2.7.10+xpu oneccl_bind_pt==2.7.0+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us
+        pip install intel-extension-for-pytorch==2.7.10+xpu oneccl_bind_pt==2.7.0+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us --trusted-host pytorch-extension.intel.com
         pip install .[dev,autotuning]
 
     - name: Check container state


### PR DESCRIPTION
The SSL certificate of Intel's wheel server has expired. To unblock PRs, trust `pytorch-extension.intel.com`.