### PR TITLE
fix: skip aio wait when swap tensors is empty

### DIFF
--- a/deepspeed/runtime/swap_tensor/optimizer_utils.py
+++ b/deepspeed/runtime/swap_tensor/optimizer_utils.py
@@ -343,7 +343,8 @@ class OptimizerSwapper(object):
         for src, dst in zip(unswapped_srcs, unswapped_dsts):
             dst.data.copy_(src.data)
 
-        assert len(swap_tensors) == aio_handle.wait()
+        if len(swap_tensors) > 0:
+            assert len(swap_tensors) == aio_handle.wait()
 
         return swapped_fp16_tensors
 


### PR DESCRIPTION
This PR fixes https://github.com/deepspeedai/DeepSpeed/issues/7703.

The root cause is that when `swap_tensors` is empty, no AIO request is queued. However, `aio.wait()` still checks whether any AIO request has been issued, which can lead to `_num_pending_ops == 0` and trigger the issue:
https://github.com/deepspeedai/DeepSpeed/blob/c069ceb30c2eca0380f65338f04693d9586e09cb/csrc/aio/py_lib/deepspeed_py_io_handle.cpp#L191

The fix is to skip `aio_handle.wait()` when there are no swap tensors queued.
