### PR TITLE
Fix testcases that depends on triton

### DIFF
--- a/tests/unit/ops/transformer/inference/test_attention.py
+++ b/tests/unit/ops/transformer/inference/test_attention.py
@@ -29,6 +29,8 @@ def ref_torch_attention(q, k, v, mask, sm_scale):
 def test_attention(BATCH, H, N_CTX, D_HEAD, causal, use_flash, dtype=torch.float16):
     if not deepspeed.get_accelerator().is_triton_supported():
         pytest.skip("triton is not supported on this system")
+    if not deepspeed.HAS_TRITON:
+        pytest.skip("triton is not installed")
 
     minus_inf = -65504.0
     dev = deepspeed.accelerator.get_accelerator().device_name()

--- a/tests/unit/ops/transformer/inference/test_matmul.py
+++ b/tests/unit/ops/transformer/inference/test_matmul.py
@@ -41,6 +41,8 @@ def run_matmul_ds(a, b, use_triton_ops=False):
 def test_matmul_4d(B, H, M, K, N, dtype, use_triton_ops):
     if not deepspeed.get_accelerator().is_triton_supported():
         pytest.skip("triton is not supported on this system")
+    if not deepspeed.HAS_TRITON:
+        pytest.skip("triton is not installed")
 
     # skip autotune in testing
     from deepspeed.ops.transformer.inference.triton.matmul_ext import fp16_matmul


### PR DESCRIPTION
Error:
```
>       fp16_matmul.skip_autotune()
E       AttributeError: 'NoneType' object has no attribute 'skip_autotune'

ops/transformer/inference/test_attention.py:37: AttributeError
```
due to `fp16_matmul` is `None` when `deepspeed.HAS_TRITON` is `False`