### PR TITLE
Fix Muon optimizer checkpoint resume with bf16 mode

### DIFF
--- a/tests/unit/ops/muon/test_muon.py
+++ b/tests/unit/ops/muon/test_muon.py
@@ -72,3 +72,75 @@ class TestMuonConfigs(DistributedTest):
         after_training = [p.clone().cpu() for p in model.parameters()]
         for initial, final in zip(initial_params, after_training):
             assert not torch.equal(initial.cpu(), final.cpu()), "Parameters should have been updated during training"
+
+
+# Test configurations for bf16 checkpoint resume
+# Tests fix for https://github.com/deepspeedai/DeepSpeed/issues/7746
+bf16_checkpoint_configs = []
+for zero_stage in [1, 2]:
+    bf16_checkpoint_configs.append([zero_stage])
+
+
+@pytest.mark.parametrize('zero_stage', [1, 2])
+class TestMuonBF16CheckpointResume(DistributedTest):
+    """Test that Muon optimizer can resume training from checkpoint with bf16 enabled.
+
+    This tests the fix for issue #7746 where momentum_buffer dtype mismatch
+    caused crashes when resuming from checkpoint.
+    """
+
+    def test(self, zero_stage, tmpdir):
+        if torch.bfloat16 not in get_accelerator().supported_dtypes():
+            pytest.skip("bf16 not supported on this accelerator")
+
+        hidden_dim = 64
+        nlayers = 3
+        batch_size = 4
+
+        config_dict = {
+            "train_batch_size": batch_size,
+            "optimizer": {
+                "type": "muon",
+                "params": {"lr": 0.02}
+            },
+            "bf16": {
+                "enabled": True
+            },
+            "zero_optimization": {
+                "stage": zero_stage,
+            },
+            "zero_allow_untested_optimizer": True,
+        }
+
+        # Create model and train for a few steps to populate optimizer state
+        model = SimpleModel(hidden_dim=hidden_dim, nlayers=nlayers)
+        engine, optimizer, _, _ = deepspeed.initialize(
+            config=config_dict,
+            model=model,
+            model_parameters=model.parameters(),
+            dist_init_required=False,
+        )
+
+        # Train for a few steps to create momentum_buffer state
+        for _ in range(3):
+            x = torch.randn(batch_size, hidden_dim, device=engine.device, dtype=torch.bfloat16)
+            y = torch.randint(0, hidden_dim, (batch_size,), device=engine.device)
+            loss = engine(x, y)
+            engine.backward(loss)
+            engine.step()
+
+        # Save checkpoint
+        ckpt_dir = str(tmpdir)
+        engine.save_checkpoint(ckpt_dir)
+
+        # Load checkpoint
+        engine.load_checkpoint(ckpt_dir)
+
+        # Resume training - this would fail before the fix due to dtype mismatch
+        # in momentum.lerp_(grad, 1 - beta) where momentum is fp32 and grad is bf16
+        for _ in range(3):
+            x = torch.randn(batch_size, hidden_dim, device=engine.device, dtype=torch.bfloat16)
+            y = torch.randint(0, hidden_dim, (batch_size,), device=engine.device)
+            loss = engine(x, y)
+            engine.backward(loss)
+            engine.step()  # This should not raise dtype mismatch error


### PR DESCRIPTION
## Summary

- Fix dtype mismatch crash when resuming Muon optimizer training from checkpoint with bf16 enabled
- Add `load_state_dict` override to cast `momentum_buffer` to match parameter dtype after loading
- Add unit test for bf16 checkpoint resume scenario

## Root Cause

When resuming training from a checkpoint with `bf16` enabled:
1. `momentum_buffer` is saved as `fp32` in the checkpoint
2. After `load_state_dict()`, `momentum_buffer` remains `fp32`
3. Gradients in bf16 mode are `bf16`
4. `momentum.lerp_(grad, 1 - beta)` crashes due to dtype mismatch

## Fix

Added `load_state_dict` override to all Muon optimizer classes that casts optimizer state buffers to match the parameter dtype after loading:

| Class | Buffers Fixed |
|-------|---------------|
| `Muon` | `momentum_buffer` |
| `SingleDeviceMuon` | `momentum_buffer` |
| `MuonWithAuxAdam` | `momentum_buffer`, `exp_avg`, `exp_avg_sq` |
| `SingleDeviceMuonWithAuxAdam` | `momentum_buffer`, `exp_avg`, `exp_avg_sq` |

## Test Plan

- [x] Added `TestMuonBF16CheckpointResume` test class that:
  1. Creates model with bf16 enabled + Muon optimizer
  2. Trains for a few steps (creates momentum_buffer state)
  3. Saves checkpoint
  4. Loads checkpoint  
  5. Resumes training (validates fix)
- [x] Tests both ZeRO stage 1 and stage 2

Fixes: #7746

🤖 Generated with [Claude Code](https://claude.com/claude-code)