### PR TITLE
fix: avoid IndexError in BF16_Optimizer.destroy() when using DummyOptim

### DIFF
--- a/deepspeed/runtime/bf16_optimizer.py
+++ b/deepspeed/runtime/bf16_optimizer.py
@@ -105,7 +105,6 @@ class BF16_Optimizer(ZeROOptimizer):
     def destroy(self):
         if not self.using_real_optimizer:
             return
-
         for i, _ in enumerate(self.optimizer.param_groups):
             for p in self.bf16_groups[i]:
                 if getattr(p, '_hp_mapping', None):


### PR DESCRIPTION
fix: avoid IndexError in BF16_Optimizer.destroy() when using DummyOptim

Short-circuit BF16_Optimizer.destroy() if using_real_optimizer is False.
When initialized with optimizer=None (DummyOptim), bf16_groups remains empty, causing an IndexError when accessing it in destroy().

Resolves #7752