### PR TITLE
Various fixes to run on mps

### DIFF
--- a/accelerator/mps_accelerator.py
+++ b/accelerator/mps_accelerator.py
@@ -26,7 +26,8 @@ class MPS_Accelerator(DeepSpeedAccelerator):
         return False
 
     def use_host_timers(self):
-        return self.is_synchronized_device()
+        # Event timers are not supported on MPS
+        return True
 
     def resolves_data_dependency(self):
         return self.is_synchronized_device()

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -457,6 +457,9 @@ class DeepSpeedEngine(Module):
         self._is_compiled_autograd_enabled = False
         self._compile_kwargs = {}
 
+        if self.dist_backend is None:
+            self.enable_backward_allreduce = False
+
     def _optimized_linear_offload_setup(self):
         self.optimized_linear_base_weight_sharding = False
         self.optimized_linear_lora_enabled = False
@@ -1309,6 +1312,8 @@ class DeepSpeedEngine(Module):
                 f'Client Optimizer (type = {type(self.client_optimizer)} is not instantiated but Client LR Scheduler is instantiated'
 
     def _broadcast_model(self):
+        if self.dist_backend is None:
+            return
 
         def is_replicated(p):
             if hasattr(p, "ds_status") and p.ds_status is not ZeroParamStatus.AVAILABLE:


### PR DESCRIPTION
Attempting to run DeepSpeed (zero stage 0) with fp32 on MPS device. Ran into a few issues, these fixes resolve them.

* No CUDA-like timer events on MPS, should fall back to host timers
* When abstract accelerator doesn't define a comm backend we shouldn't trigger a broadcast or all-reduce