### PR TITLE
Udpate workflow trigger

### DIFF
--- a/.github/workflows/aws-accelerate.yml
+++ b/.github/workflows/aws-accelerate.yml
@@ -16,11 +16,6 @@ on:
       - master
 
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'blogs/**'
-      - 'deepspeed/inference/v2/**'
-      - 'tests/unit/inference/v2/**'
     branches:
       - master
 
@@ -29,8 +24,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-paths:
+    name: Check Paths
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.run_tests }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            run_tests:
+              - '**'
+              - '!docs/**'
+              - '!blogs/**'
+              - '!deepspeed/inference/v2/**'
+              - '!tests/unit/inference/v2/**'
+
   accelerate-tests:
     name: Accelerate Integration Tests
+    needs: check-paths
+    if: needs.check-paths.outputs.should_run == 'true'
     runs-on: [self-hosted, gpu-ci, gpu-l40s, l40s-1gpu, aws]
 
     container:

--- a/.github/workflows/aws-torch-latest.yml
+++ b/.github/workflows/aws-torch-latest.yml
@@ -15,11 +15,6 @@ on:
       - master
 
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'blogs/**'
-      - 'deepspeed/inference/v2/**'
-      - 'tests/unit/inference/v2/**'
     branches:
       - master
 
@@ -28,8 +23,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-paths:
+    name: Check Paths
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.run_tests }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            run_tests:
+              - '**'
+              - '!docs/**'
+              - '!blogs/**'
+              - '!deepspeed/inference/v2/**'
+              - '!tests/unit/inference/v2/**'
+
   unit-tests:
     name: Unit Tests (V1)
+    needs: check-paths
+    if: needs.check-paths.outputs.should_run == 'true'
     runs-on: [self-hosted, gpu-ci, gpu-l40s, l40s-4gpu, aws]
 
     container:


### PR DESCRIPTION
The new CI workflows using AWS are not triggered when the path filters don't match. However, it keeps "waiting for status to be reported" because they are set as "required."
This PR always launches workflow but skips tests when the filter doesn't match.