### PR TITLE
Fix issue with BF16 optimizer selection

### DIFF
--- a/deepspeed/runtime/base_optimizer.py
+++ b/deepspeed/runtime/base_optimizer.py
@@ -355,7 +355,9 @@ class ZeROOptimizer(DeepSpeedOptimizer):
                 return self.external_loss_scale * value
             if self.torch_autocast_gradscaler:
                 return self.torch_autocast_gradscaler.scale(value)
-            return self.loss_scaler.scale_loss(value)
+            # Only call loss_scaler if it exists (not present in BF16_Optimizer)
+            if hasattr(self, 'loss_scaler') and self.loss_scaler is not None:
+                return self.loss_scaler.scale_loss(value)
 
         return value
 

--- a/deepspeed/runtime/bf16_optimizer.py
+++ b/deepspeed/runtime/bf16_optimizer.py
@@ -59,6 +59,11 @@ class BF16_Optimizer(ZeROOptimizer):
                                   ], f"BF16Optimizer: Unsupported gradient accumulation data type: {grad_acc_dtype}"
         self.grad_acc_dtype = grad_acc_dtype
 
+        # BF16 doesn't use loss scaling, but these attributes are needed for API compatibility
+        self.custom_loss_scaler = False
+        self.external_loss_scale = None
+        self.torch_autocast_gradscaler = None
+
         self.immediate_grad_update = bfloat16_config.immediate_grad_update
 
         self.clip_grad = clip_grad

--- a/deepspeed/runtime/constants.py
+++ b/deepspeed/runtime/constants.py
@@ -144,7 +144,9 @@ BFLOAT16_OPTIMIZER_STATES = "bf16_optimizer_states"
 BFLOAT16_OPTIMIZER_STATES_DEFAULT = False
 
 # DDP variant of BFLOAT16
-DDP_BFLOAT16 = "bf16"
+# DDP variant: bf16 model with bf16 grad accumulation (uses FP16_Optimizer in bf16 mode)
+# Must be different from BFLOAT16 to allow proper optimizer selection
+DDP_BFLOAT16 = "ddp_bf16"
 
 #########################################
 # FP16 support

--- a/tests/unit/runtime/zero/test_zero_tensor_fragment.py
+++ b/tests/unit/runtime/zero/test_zero_tensor_fragment.py
@@ -173,6 +173,11 @@ class TestTensorFragmentGet(DistributedTest):
             "bf16": {
                 "enabled": True
             },
+            # Use fp32 gradient accumulation to ensure BF16_Optimizer is used
+            # (bf16 model + bf16 grad_accum uses FP16_Optimizer which doesn't support tensor fragment APIs)
+            "data_types": {
+                "grad_accum_dtype": "fp32"
+            },
             "zero_optimization": {
                 "stage": 0,
             }


### PR DESCRIPTION
**Note:** Updated based on the change 64b10739a66704afc4112d10ab2d70f2b3a2266c for #7790. With the fix, `BF16_Optimizer` now requires ZeRO stage 1 to be explicitly enabled. 

The test `test_bf16_optimizer_fragments` fails with an `AssertionError` because the `BF16_Optimizer` is not being instantiated when expected. The test checks for `_hp_mapping` attribute on parameters, which is only set by `BF16_Optimizer`.

  The test `test_bf16_optimizer_fragments` fails because:
  1. The test config (`bf16=True` without grad_accum_dtype) **correctly** uses `FP16_Optimizer`, but the test expects `BF16_Optimizer` (which sets `_hp_mapping`)
  2. `BFLOAT16` and `DDP_BFLOAT16` have the same value `"bf16"`, preventing proper optimizer selection
  3. `BF16_Optimizer` is missing attributes required by the base class API

  This PR addresses these issues.

  Optimizer selection summary:

  | ZeRO Stage | Config | Optimizer | Gradient Accumulation |
  |------------|--------|-----------|----------------------|
  | 0 | `bf16=True` (default) | `FP16_Optimizer` | bf16 |
  | 0 | `bf16=True` + `grad_accum_dtype=fp32` | `NotImplementedError` | - |
  | 1 | `bf16=True` + `grad_accum_dtype=fp32` | `BF16_Optimizer` | fp32 |

  This is confusing (e.g., `FP16_Optimizer` handles both fp16 and bf16). We would need to simplify the code paths and clarify the behaviors in the future.
