### PR TITLE
Skip empty parameters in gradient reduction

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -2940,6 +2940,11 @@ class DeepSpeedEngine(Module):
             if not param.requires_grad:
                 continue
 
+            # Skip empty parameters (numel=0) as they contribute nothing to gradient reduction
+            # and cause issues with flatten/unflatten operations
+            if param.numel() == 0:
+                continue
+
             if param.grad is None:
                 # In cases where there is an imbalance of empty grads across
                 # ranks we must create empty grads, this will ensure that every


### PR DESCRIPTION
#7736 fixed an issue with OnebitLamb NaN propagation. With the fix, the optimizer correctly filters out empty parameters, but DeepSpeed engine's gradient allreduce operation (which runs separately from the optimizer) still includes empty parameters' gradients.

This PR addresses the issue by skipping empty parameters (numel=0) in `_get_gradients_for_reduction()`.