### PR TITLE
Fix AutoTP test numerical tolerance with rtol

### DIFF
--- a/tests/unit/model_parallelism/test_autotp_training.py
+++ b/tests/unit/model_parallelism/test_autotp_training.py
@@ -220,9 +220,15 @@ class TestTpLayerFwdBwd(DistributedTest):
         torch_grad = torch.chunk(torch_linear.weight.grad, tp_size, dim=1)[groups.get_tensor_model_parallel_rank()]
         torch_bias_grad = torch_linear.bias.grad
         # Use assert_close with rtol for proper floating-point comparisons
-        torch.testing.assert_close(linear.bias.grad, torch_bias_grad.to(get_accelerator().current_device()), atol=1e-3, rtol=1e-3)
+        torch.testing.assert_close(linear.bias.grad,
+                                   torch_bias_grad.to(get_accelerator().current_device()),
+                                   atol=1e-3,
+                                   rtol=1e-3)
         # The gradient of the weight is not the same as the torch_linear.weight.grad
-        torch.testing.assert_close(linear.weight.grad, torch_grad.to(get_accelerator().current_device()), atol=1e-3, rtol=1e-3)
+        torch.testing.assert_close(linear.weight.grad,
+                                   torch_grad.to(get_accelerator().current_device()),
+                                   atol=1e-3,
+                                   rtol=1e-3)
         torch.testing.assert_close(out, torch_out.to(get_accelerator().current_device()), atol=1e-2, rtol=1e-2)
 
     def testColumnParallel(self, tp_size: int, tp_overlap_comm: bool):
@@ -276,12 +282,19 @@ class TestTpLayerFwdBwd(DistributedTest):
 
         torch_bias_grad = torch.chunk(torch_linear.bias.grad, tp_size, dim=0)[groups.get_tensor_model_parallel_rank()]
         # Use assert_close with rtol for proper floating-point comparisons
-        torch.testing.assert_close(linear.bias.grad, torch_bias_grad.to(get_accelerator().current_device()), atol=1e-3, rtol=1e-3)
+        torch.testing.assert_close(linear.bias.grad,
+                                   torch_bias_grad.to(get_accelerator().current_device()),
+                                   atol=1e-3,
+                                   rtol=1e-3)
 
-        torch.testing.assert_close(linear.weight.grad, torch_grad.to(get_accelerator().current_device()), atol=1e-3, rtol=1e-3)
+        torch.testing.assert_close(linear.weight.grad,
+                                   torch_grad.to(get_accelerator().current_device()),
+                                   atol=1e-3,
+                                   rtol=1e-3)
         torch.testing.assert_close(cur_device_out.to(get_accelerator().current_device()).contiguous(),
-                              out.contiguous(),
-                              atol=1e-2, rtol=1e-2)
+                                   out.contiguous(),
+                                   atol=1e-2,
+                                   rtol=1e-2)
 
 
 # @pytest.mark.sequential


### PR DESCRIPTION
Replace torch.allclose() with torch.testing.assert_close() and add rtol parameter for proper floating-point comparisons in testRowParallel and testColumnParallel tests.
The tests were failing intermittently in CI because they only used absolute tolerance (atol) without relative tolerance. Adding rtol allows for proper numerical comparisons will improve stability of the tests.