### PR TITLE
Fix Muon optimizer module path

### DIFF
--- a/deepspeed/runtime/zero/utils.py
+++ b/deepspeed/runtime/zero/utils.py
@@ -47,7 +47,7 @@ ZERO_SUPPORTED_OPTIMIZERS = [
 
 # Add MuonWithAuxAdam to supported list if muon is installed
 try:
-    from deepspeed.runtime.muon_optimizer import MuonWithAuxAdam
+    from deepspeed.runtime.zero.muon.muon_optimizer import MuonWithAuxAdam
     ZERO_SUPPORTED_OPTIMIZERS.append(MuonWithAuxAdam)
 except ImportError:
     pass


### PR DESCRIPTION
Update the Muon optimizer import to its current location under deepspeed.runtime.zero.muon, so it’s correctly registered as a supported ZeRO optimizer. This prevents the “untested optimizer” assertion from firing.