### PR TITLE
Run Evoformer tests sequentially

### DIFF
--- a/tests/unit/ops/deepspeed4science/test_DS4Sci_EvoformerAttention.py
+++ b/tests/unit/ops/deepspeed4science/test_DS4Sci_EvoformerAttention.py
@@ -40,6 +40,7 @@ def attention_reference(
     return o
 
 
+@pytest.mark.sequential
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("tensor_shape", [(1, 256, 256, 4, 32), (1, 512, 256, 8, 8)])
 def test_DS4Sci_EvoformerAttention(dtype, tensor_shape):


### PR DESCRIPTION
Evoformer tests fail when we run them in parallel with other tests. 
```
RuntimeError: Cannot re-initialize CUDA in forked subprocess.
```
This PR adds `@pytest.mark.sequential` to the tests.

See the full test log for details: https://github.com/deepspeedai/DeepSpeed/actions/runs/21303530770/job/61326548592