### PR TITLE
Add option to disable SP in eval mode

### DIFF
--- a/deepspeed/runtime/sequence_parallel/ulysses_sp.py
+++ b/deepspeed/runtime/sequence_parallel/ulysses_sp.py
@@ -78,6 +78,9 @@ class UlyssesSPAttentionHF(torch.nn.Module):
         kv_head_count (int): total number of kv heads
         num_hidden_layers (int): total number of layers
         process_group (dist.ProcessGroup): Ulysses process group
+        disable_in_eval (bool): whether to disable sequence parallelism during evaluation (default: False).
+            When True, SP operations are bypassed during eval to avoid potential issues with frameworks
+            like HF Trainer that may run eval with different data distribution.
 
 
     Extras:
@@ -96,6 +99,7 @@ class UlyssesSPAttentionHF(torch.nn.Module):
         seq_length_is_variable: bool = False,
         local_seq_length: int = None,
         global_seq_length: int = None,
+        disable_in_eval: bool = False,
     ) -> None:
         super().__init__()
         self.attn = attn
@@ -107,6 +111,7 @@ class UlyssesSPAttentionHF(torch.nn.Module):
         self.seq_length_is_variable = seq_length_is_variable
         self.local_seq_length = local_seq_length
         self.global_seq_length = global_seq_length
+        self.disable_in_eval = disable_in_eval
 
         self.attn_head_size = attn_head_size
         self.attn_head_count = attn_head_count
@@ -246,6 +251,12 @@ class UlyssesSPAttentionHF(torch.nn.Module):
         # print_rank0(f"{key.shape=}")
         # print_rank0(f"{value.shape=}")
         # print_rank0(f"{self.required_input_shape=}")
+
+        # Skip SP operations during eval if disable_in_eval is True
+        # This avoids issues with frameworks like HF Trainer that may run eval with different data distribution
+        if not module.training and self.disable_in_eval:
+            return self.attn(module, query, key, value, attention_mask, *args, **kwargs)
+
         if self.seq_length_is_variable:
             current_local_seq_length = query.shape[2]
             self.local_seq_length = current_local_seq_length
@@ -350,6 +361,7 @@ class UlyssesSPAttentionHF(torch.nn.Module):
         micro_batch_size,
         seq_length=None,
         seq_length_is_variable=True,
+        disable_in_eval=False,
         # deprecated
         max_length=None,
     ):
@@ -364,6 +376,9 @@ class UlyssesSPAttentionHF(torch.nn.Module):
         - micro_batch_size (int): micro batch size
         - seq_length (int): set this argument if the sequence length is fixed in all batches
         - seq_length_is_variable (bool): whether global seqlen may change between batches an optimization flag - the default is `True`
+        - disable_in_eval (bool): whether to disable sequence parallelism during evaluation (default: False).
+            When True, SP operations are bypassed during eval to avoid issues with frameworks
+            like HF Trainer that may run eval with different data distribution.
         - max_length (int): actual global sequence length - this argument is deprecated - use `seq_length` instead
 
         """
@@ -431,6 +446,7 @@ class UlyssesSPAttentionHF(torch.nn.Module):
             seq_length_is_variable=seq_length_is_variable,
             local_seq_length=local_seq_length,
             global_seq_length=global_seq_length,
+            disable_in_eval=disable_in_eval,
         )
 
         def uattn_wrapper(

--- a/tests/unit/ulysses_alst/test_ulysses_sp_hf.py
+++ b/tests/unit/ulysses_alst/test_ulysses_sp_hf.py
@@ -232,3 +232,72 @@ class TestUlyssesSPHFPEFT(DistributedTest):
         assert sp_group is not None
         sp_world_size = mpu.get_sequence_parallel_world_size()
         assert sp_world_size == sequence_parallel_size
+
+
+class TestUlyssesSPHFDisableInEval(DistributedTest):
+    world_size = 2
+
+    def test_disable_in_eval(self):
+        """Test that disable_in_eval parameter controls SP behavior during evaluation.
+
+        When disable_in_eval=True, SP operations should be bypassed during eval mode,
+        allowing the user to pass full (non-sharded) sequences directly.
+        This should produce the same output as a model without SP registered.
+        """
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        model_name_or_path = 'hf-internal-testing/tiny-random-LlamaForCausalLM'
+        seq_length = 64
+        sequence_parallel_size = self.world_size
+        micro_batch_size = 1
+
+        dtype = preferred_dtype()
+        rank = dist.get_rank()
+
+        # Full sequence input (not sharded) - this is what users would pass during eval
+        # when they want to bypass SP and process sequences independently per rank
+        input_ids = tensor([[1, 10, 10, 10, 2, 2]], device=f"cuda:{rank}")
+        position_ids = tensor([[0, 1, 2, 3, 4, 5]], device=f"cuda:{rank}")
+
+        # 1. Baseline: model without SP, processing full sequence
+        model_baseline = AutoModelForCausalLM.from_pretrained(model_name_or_path, torch_dtype=dtype)
+        model_baseline = model_baseline.to(f"cuda:{rank}")
+        model_baseline.eval()
+
+        # Save original attention function for comparison
+        original_sdpa = ALL_ATTENTION_FUNCTIONS["sdpa"]
+
+        with torch.no_grad():
+            outputs_baseline = model_baseline(input_ids=input_ids, position_ids=position_ids)
+            logits_baseline = outputs_baseline.logits.clone()
+
+        del model_baseline
+
+        # 2. Model with SP registered but disable_in_eval=True
+        # In eval mode, SP is bypassed so full sequence can be passed directly
+        mpu = UlyssesSPAttentionHF.register_with_transformers(
+            model_name_or_path=model_name_or_path,
+            core_attn_implementation="sdpa",
+            sequence_parallel_size=sequence_parallel_size,
+            micro_batch_size=micro_batch_size,
+            seq_length=seq_length,
+            seq_length_is_variable=True,
+            disable_in_eval=True,
+        )
+
+        # Verify that register_with_transformers actually registered the wrapper
+        assert mpu is not None, "mpu should not be None when sequence_parallel_size > 1"
+        assert ALL_ATTENTION_FUNCTIONS["sdpa"] is not original_sdpa, \
+            "register_with_transformers should have replaced the attention function"
+
+        model_sp = AutoModelForCausalLM.from_pretrained(model_name_or_path, torch_dtype=dtype)
+        model_sp = model_sp.to(f"cuda:{rank}")
+        model_sp.eval()
+
+        with torch.no_grad():
+            outputs_sp = model_sp(input_ids=input_ids, position_ids=position_ids)
+            logits_sp = outputs_sp.logits.clone()
+
+        # Verify: with disable_in_eval=True, full sequence input should produce
+        # the same output as baseline (SP is bypassed)
+        torch_assert_equal(logits_baseline, logits_sp)


### PR DESCRIPTION
(Proposing as an alternative of #7821)
This PR adds `disable_in_eval` parameter to `UlyssesSPAttentionHF` that bypasses sequence parallelism operations during evaluation.
See https://github.com/huggingface/transformers/pull/43517 and https://github.com/deepspeedai/DeepSpeed/pull/7821 for the context.