### PR TITLE
Fix bf16 gradient norm divergence with ZeRO stage 0

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -1230,8 +1230,9 @@ class PipelineEngine(DeepSpeedEngine):
 
         if self.global_rank == 0 and self.monitor.enabled:
             self.summary_events = [('Train/Samples/lr', self.get_lr()[0], self.global_samples)]
-            if self.fp16_enabled() and hasattr(self.optimizer, 'cur_scale'):
-                self.summary_events.append(('Train/Samples/loss_scale', self.optimizer.cur_scale, self.global_samples))
+            loss_scale = self._get_optimizer_loss_scale() if self.fp16_enabled() else None
+            if loss_scale is not None:
+                self.summary_events.append(('Train/Samples/loss_scale', loss_scale, self.global_samples))
             self.monitor.write_events(self.summary_events)
 
         if self.wall_clock_breakdown():

--- a/tests/unit/runtime/half_precision/test_fp16.py
+++ b/tests/unit/runtime/half_precision/test_fp16.py
@@ -419,7 +419,7 @@ class TestZeroStaticScale(DistributedTest):
         model, optim, _, _ = deepspeed.initialize(config=config_dict, model=model, model_parameters=model.parameters())
 
         # Ensure the static scaler is configured.
-        assert optim.dynamic_loss_scale == False
+        assert optim.loss_scale_config.dynamic_loss_scale == False
         assert optim.loss_scaler.loss_scale == 138.
 
         # Now make sure things work..

--- a/tests/unit/runtime/test_ds_initialize.py
+++ b/tests/unit/runtime/test_ds_initialize.py
@@ -282,8 +282,9 @@ class TestBf16ZeRO0UnfusedOptimizer(DistributedTest):
                                                optimizer=client_optimizer)
 
         assert isinstance(engine.optimizer, FP16_UnfusedOptimizer)
-        assert engine.optimizer.dynamic_loss_scale is False
-        assert engine.optimizer.cur_scale == 1
+        assert engine.optimizer.low_precision_dtype == torch.bfloat16
+        assert engine.optimizer.loss_scale_config.dynamic_loss_scale is False
+        assert engine.optimizer.loss_scale_config.cur_scale == 1
 
         data_loader = random_dataloader(model=engine,
                                         total_samples=1,


### PR DESCRIPTION
Fixes: #7837

ZeRO-0 + bf16 has two bugs in `engine.py`: 
1. `FP16_UnfusedOptimizer` applies `dynamic_loss_scale` with `cur_scale=65536` but `engine.backward()` never scales the loss, so `step()` divides gradients by 65536
2. `_take_model_step` skips `zero_grad` for bf16 without ZeRO, causing gradient accumulation.

Fix: disable loss scaling for bf16 and remove the `zero_optimization()` gate on `zero_grad`.