### PR TITLE
fix: replace deprecated fractions.gcd with math.gcd

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -67,7 +67,7 @@ def isclose(a, b, rtol=1e-09, atol=0.0):
 
 
 def lcm(x, y):
-    from fractions import gcd  # or can import gcd from `math` in Python 3
+    from math import gcd
     return x * y // gcd(x, y)
 
 

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -76,7 +76,7 @@ def isclose(a, b, rtol=1e-09, atol=0.0):
 
 
 def lcm(x, y):
-    from fractions import gcd  # or can import gcd from `math` in Python 3
+    from math import gcd
     return x * y // gcd(x, y)
 
 


### PR DESCRIPTION
## Bug
`fractions.gcd` was deprecated in Python 3.5 and removed in Python 3.9. This causes an `AttributeError` on Python 3.9+.

## Fix
Replaced `fractions.gcd` with `math.gcd` which is the standard replacement.