### PR TITLE
Reject non-finite fp16 loss_scale across config and ZeRO paths

### DIFF
--- a/deepspeed/runtime/loss_scale_validation.py
+++ b/deepspeed/runtime/loss_scale_validation.py
@@ -1,0 +1,47 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import math
+from numbers import Integral, Real
+
+
+def _to_finite_float(value, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a real number, got {type(value).__name__}")
+
+    numeric_value = float(value)
+    if not math.isfinite(numeric_value):
+        raise ValueError(f"{name} must be finite, got {numeric_value}")
+    return numeric_value
+
+
+def validate_loss_scale_value(value, *, name: str = "loss_scale", allow_dynamic_zero: bool = False) -> float:
+    """
+    Validate static loss scale values.
+
+    A value of 0 is accepted only when it represents dynamic loss scaling mode.
+    """
+    numeric_value = _to_finite_float(value, name=name)
+    if allow_dynamic_zero and numeric_value == 0.0:
+        return numeric_value
+    if numeric_value <= 0.0:
+        raise ValueError(f"{name} must be greater than 0, got {numeric_value}")
+    return numeric_value
+
+
+def validate_positive_finite(value, *, name: str) -> float:
+    numeric_value = _to_finite_float(value, name=name)
+    if numeric_value <= 0.0:
+        raise ValueError(f"{name} must be greater than 0, got {numeric_value}")
+    return numeric_value
+
+
+def validate_positive_int(value, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be an integer, got {type(value).__name__}")
+    int_value = int(value)
+    if int_value <= 0:
+        raise ValueError(f"{name} must be greater than 0, got {int_value}")
+    return int_value

--- a/tests/unit/runtime/half_precision/test_loss_scale_validation.py
+++ b/tests/unit/runtime/half_precision/test_loss_scale_validation.py
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from types import SimpleNamespace
+import pytest
+import torch
+
+from deepspeed.runtime.fp16.loss_scaler import (
+    CONSECUTIVE_HYSTERESIS,
+    DELAYED_SHIFT,
+    INITIAL_LOSS_SCALE,
+    MIN_LOSS_SCALE,
+    SCALE_WINDOW,
+    CreateLossScaler,
+    LossScaleConfig,
+)
+from deepspeed.runtime.zero.stage_1_and_2 import DeepSpeedZeroOptimizer
+from deepspeed.runtime.zero.stage3 import DeepSpeedZeroOptimizer_Stage3
+
+
+def test_loss_scale_config_rejects_non_finite_static_loss_scale():
+    with pytest.raises(ValueError, match="fp16.loss_scale must be finite"):
+        LossScaleConfig(low_precision_dtype=torch.float16,
+                        dynamic_loss_scale=False,
+                        static_loss_scale=float("inf"),
+                        dynamic_loss_args=None)
+
+
+def test_create_loss_scaler_rejects_non_finite_dynamic_init_scale():
+    dynamic_loss_args = {
+        INITIAL_LOSS_SCALE: float("inf"),
+        SCALE_WINDOW: 1000,
+        DELAYED_SHIFT: 2,
+        CONSECUTIVE_HYSTERESIS: False,
+        MIN_LOSS_SCALE: 1.0,
+    }
+    with pytest.raises(ValueError, match="dynamic_loss_args\\['init_scale'\\] must be finite"):
+        CreateLossScaler(torch.float16, static_loss_scale=0, dynamic_scaling=True, dynamic_loss_args=dynamic_loss_args)
+
+
+def test_stage1_override_loss_scale_validates_values():
+    optimizer = SimpleNamespace(external_loss_scale=None, custom_loss_scaler=False)
+    with pytest.raises(ValueError, match="loss_scale must be finite"):
+        DeepSpeedZeroOptimizer.override_loss_scale(optimizer, float("inf"))
+
+    DeepSpeedZeroOptimizer.override_loss_scale(optimizer, 256.0)
+    assert optimizer.custom_loss_scaler is True
+    assert optimizer.external_loss_scale == 256.0
+
+
+def test_stage3_set_loss_scale_validates_values():
+    optimizer = SimpleNamespace(loss_scaler=SimpleNamespace(cur_scale=1.0))
+    with pytest.raises(ValueError, match="loss_scale must be greater than 0"):
+        DeepSpeedZeroOptimizer_Stage3._set_loss_scale(optimizer, 0)
+
+    DeepSpeedZeroOptimizer_Stage3._set_loss_scale(optimizer, 128.0)
+    assert optimizer.loss_scaler.cur_scale == 128.0


### PR DESCRIPTION
## Describe your changes
- Added centralized loss-scale validators for finite/positive numeric constraints used by runtime configuration and optimizer paths.
- Enforced fp16 config validation for `loss_scale`, `loss_scale_window`, `hysteresis`, and `min_loss_scale` so invalid values fail during config parsing.
- Hardened `LossScaleConfig` and `CreateLossScaler` to reject invalid static/dynamic loss-scale arguments even if values are injected outside config parsing.
- Added validation to ZeRO stage 1/2 and stage 3 loss-scale override/setter methods to block non-finite/non-positive runtime overrides.
- Added targeted unit tests for config parsing, loss-scaler validation, and ZeRO override/setter guard behavior.

## Screenshot or video (only for visual changes)
- N/A

## GitHub Issue Link (if applicable)
- https://github.com/deepspeedai/DeepSpeed/issues/7852

## Testing Plan
- Explanation of why no additional tests are needed:
  - This change is fully covered with focused unit tests at config, scaler, and ZeRO runtime guard layers.
- Unit Tests (JS and/or Python):
  - `python -m pytest tests/unit/runtime/test_ds_config_model.py tests/unit/runtime/half_precision/test_loss_scale_validation.py`
- E2E Tests:
  - Not run (validation and guard logic change).
- Any manual testing needed?:
  - No.

---
**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
