### PR TITLE
Fix compilation of Evoformer

### DIFF
--- a/op_builder/evoformer_attn.py
+++ b/op_builder/evoformer_attn.py
@@ -115,7 +115,7 @@ class EvoformerAttnBuilder(CUDAOpBuilder):
         if not cutlass_path.is_dir():
             raise RuntimeError(f"CUTLASS_PATH {cutlass_path} does not exist")
         include_dirs = cutlass_path / "include", cutlass_path / "tools" / "util" / "include"
-        include_dirs = [include_dir for include_dir in include_dirs if include_dir.is_dir()]
+        include_dirs = [str(include_dir) for include_dir in include_dirs if include_dir.is_dir()]
         if not include_dirs:
             raise RuntimeError(f"CUTLASS_PATH {cutlass_path} does not contain any include directories")
         return include_dirs


### PR DESCRIPTION
`EvoformerAttnBuilder` returns instances of `Path` from `include_paths` which then cause failures in `OpBuilder.builder` when passing them to `strip_empty_entries` that calls `len` on them which isn't defined for `Path` instances:
>   TypeError: object of type 'PosixPath' has no len()

Fixes regression introduced in #7760

cc @sdvillal  