### PR TITLE
Fix Zero-3 static scale assertion in fp16 test

### DIFF
--- a/tests/unit/runtime/half_precision/test_fp16.py
+++ b/tests/unit/runtime/half_precision/test_fp16.py
@@ -419,7 +419,7 @@ class TestZeroStaticScale(DistributedTest):
         model, optim, _, _ = deepspeed.initialize(config=config_dict, model=model, model_parameters=model.parameters())
 
         # Ensure the static scaler is configured.
-        assert optim.loss_scale_config.dynamic_loss_scale == False
+        assert optim.dynamic_loss_scale == False
         assert optim.loss_scaler.loss_scale == 138.
 
         # Now make sure things work..


### PR DESCRIPTION
PR #7839 introduced a regression by changing `TestZeroStaticScale` from `assert optim.dynamic_loss_scale == False` to `assert optim.loss_scale_config.dynamic_loss_scale == False`.
`loss_scale_config` is not part of the ZeRO optimizer (only non-ZeRO optimizer have it), while this test runs with ZeRO optimizers.

With this fix, `TestZeroStaticScale` now passes for stages 1/2/3.
