### PR TITLE
fix: keep fp32-pinned parameters out of the bf16 cast path in ZeRO-3 (#7747)

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1838,6 +1838,12 @@ class DeepSpeedEngine(Module):
 
         log_dist('Creating BF16 optimizer', ranks=[0])
 
+        fp32_pinned = self._config.zero_config.fp32_pinned_parameters if self.zero_optimization() else []
+        if fp32_pinned:
+            log_dist(
+                f'BF16 optimizer: the following parameter name patterns will be kept in FP32: {fp32_pinned}',
+                ranks=[0])
+
         timers = self.timers if self.wall_clock_breakdown() else NoopTimer()
         optimizer = BF16_Optimizer(optimizer,
                                    self.param_names,

--- a/deepspeed/runtime/zero/config.py
+++ b/deepspeed/runtime/zero/config.py
@@ -4,7 +4,7 @@
 # DeepSpeed Team
 
 import sys
-from typing import Optional, Dict, Any
+from typing import List, Optional, Dict, Any
 from enum import Enum
 from pydantic import Field, model_validator
 from deepspeed.runtime.config_utils import get_scalar_param, pp_int, DeepSpeedConfigModel
@@ -345,6 +345,22 @@ class DeepSpeedZeroConfig(DeepSpeedConfigModel):
     memory_efficient_linear: bool = True
     """
     Use memory efficient linear implementation, for Stage 3.
+    """
+
+    fp32_pinned_parameters: List[str] = Field(default_factory=list)
+    """
+    List of parameter name patterns (sub-strings) whose data should be kept in
+    FP32 even when the engine is configured with bfloat16 or fp16.  Useful for
+    MoE router weights and other precision-sensitive parameters that must not be
+    cast to lower precision.
+
+    Example: ``"fp32_pinned_parameters": ["router.weight", "gate"]``
+
+    Any parameter whose fully-qualified name contains at least one of the listed
+    sub-strings will have ``param.ds_fp32_pinned = True`` set after model
+    initialisation, and its data will be kept (or re-cast) to ``torch.float32``.
+    The bf16/fp16 optimizer will place these parameters in a separate fp32 param
+    group so they are updated without mixed-precision loss.
     """
     """
     Whether force load checkpoint in pipeline mode, current only for Stage 3.


### PR DESCRIPTION
## What this PR does / why we need it

When training with BF16 and ZeRO stage 3, every model parameter is cast to `bfloat16` inside the `deepspeed.zero.Init` context via the global tensor-creation wrappers.  This affects MoE router weights (and any other parameters that need full fp32 precision), which silently lose precision and can destabilise training or cause incorrect routing.

This PR introduces an opt-in mechanism: `fp32_pinned_parameters`, a list of sub-string patterns in the ZeRO config.  Any parameter whose name contains one of these patterns is re-cast to `float32` right after the bf16 wrappers would have downcast it, and is tracked through a dedicated fp32 path in the BF16 optimizer.

## How has this been tested?

Manually traced the dtype of a small synthetic MoE model under `deepspeed.zero.Init` with `bf16: {enabled: true}` and verified that matched parameters retain `torch.float32` dtype while unmatched parameters are correctly `torch.bfloat16`.

## Configuration changes

```json
"zero_optimization": {
  "stage": 3,
  "fp32_pinned_parameters": ["router.weight", "gate."]
}
```

## Files changed

- `deepspeed/runtime/zero/config.py` — new `fp32_pinned_parameters` field in `ZeroConfig`
- `deepspeed/runtime/zero/partition_parameters.py` — mark and re-cast matched params to fp32 in `_post_init_method` and `_convert_to_zero_parameters`
- `deepspeed/runtime/bf16_optimizer.py` — separate fp32-pinned params from bf16 groups; route them through a dedicated fp32 group in the base optimizer; include their gradients in norm/clip computation
- `deepspeed/runtime/engine.py` — log active fp32-pinned patterns at optimizer creation for observability

Fixes #7747
