### PR TITLE
Schedule nightly full test

### DIFF
--- a/tests/unit/runtime/half_precision/test_fp16.py
+++ b/tests/unit/runtime/half_precision/test_fp16.py
@@ -419,7 +419,7 @@ class TestZeroStaticScale(DistributedTest):
         model, optim, _, _ = deepspeed.initialize(config=config_dict, model=model, model_parameters=model.parameters())
 
         # Ensure the static scaler is configured.
-        assert optim.loss_scale_config.dynamic_loss_scale == False
+        assert optim.dynamic_loss_scale == False
         assert optim.loss_scaler.loss_scale == 138.
 
         # Now make sure things work..


### PR DESCRIPTION
The full test workflow passed though it is still flakey ([Success](https://github.com/deepspeedai/DeepSpeed/actions/runs/22269243373) / [Failure](https://github.com/deepspeedai/DeepSpeed/actions/runs/22266498530))

This PR schedules a nightly run of the full test. It is launched only when we have update since the last successful run.