### PR TITLE
perf: use deque for FIFO queues in sequence parallel, superoffload, and compile

### DIFF
--- a/deepspeed/compile/backend.py
+++ b/deepspeed/compile/backend.py
@@ -6,7 +6,7 @@
 from typing import Dict, List, Callable, Tuple
 import time
 import gc
-from collections import OrderedDict
+from collections import OrderedDict, deque
 
 import torch
 from torch.fx import Graph, GraphModule
@@ -81,14 +81,14 @@ def init_schedule(schedule):
         assert isinstance(passes, list), f"Passes at a certain step should be a list, but got {type(passes)}"
 
     global remaining_schedule
-    remaining_schedule = schedule
+    remaining_schedule = deque(schedule)
 
 
 def launch_compile_passes(global_steps: int):
     global next_pass_step, next_passes
 
     if len(remaining_schedule) > 0 and global_steps == remaining_schedule[0][0]:
-        _, next_passes = remaining_schedule.pop(0)
+        _, next_passes = remaining_schedule.popleft()
         log_rank0(f"Launching compile passes: global_steps={global_steps} passes={next_passes}", True)
 
         torch._dynamo.reset()

--- a/deepspeed/runtime/sequence_parallel/ulysses_sp.py
+++ b/deepspeed/runtime/sequence_parallel/ulysses_sp.py
@@ -29,7 +29,7 @@ https://github.com/snowflakedb/ArcticTraining/blob/main/projects/sequence-parall
 
 """
 
-from collections import defaultdict
+from collections import defaultdict, deque
 from deepspeed.runtime.utils import see_memory_usage
 from deepspeed.sequence.layer import _DimZeroAllToAll
 from deepspeed.utils.logging import logger
@@ -550,7 +550,7 @@ class UlyssesSPDataLoaderAdapter:
         self.device = device
 
         self.iter = iter(dl)
-        self.micro_batches: list[Any] = []
+        self.micro_batches: deque[Any] = deque()
 
     def __len__(self):
         return len(self.dl) * self.sp_world_size
@@ -562,7 +562,7 @@ class UlyssesSPDataLoaderAdapter:
         if len(self.micro_batches) == 0:
             self.refill()
 
-        return self.micro_batches.pop(0)
+        return self.micro_batches.popleft()
 
     def refill(self):
         # reset the iterator if StopIteration arrives, and re-raise it to allow multiple epochs to run


### PR DESCRIPTION
## Problem

Three files use `.pop(0)` for FIFO queue processing, which is **O(n)** per removal:

1. `ulysses_sp.py`: Micro-batch queue for sequence parallel data sharding
2. `superoffload_stage3.py`: Parameter buffer for IPG gradient bucketing
3. `compile/backend.py`: Compile pass schedule queue

## Solution

Switch to `collections.deque` with `.popleft()` for **O(1)** front removal.

## Changes

| File | Pattern |
|------|---------|
| `deepspeed/runtime/sequence_parallel/ulysses_sp.py` | `micro_batches` FIFO queue |
| `deepspeed/runtime/superoffload/superoffload_stage3.py` | `params_in_ipg_bucket_buffer` drain loop |
| `deepspeed/compile/backend.py` | `remaining_schedule` step-by-step consumption |