### PR TITLE
Fix performance regression in grad_handling_hook

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1046,12 +1046,14 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     def wrapper(param, i):
 
                         def grad_handling_hook(*notneeded):
-                            self.reenter_backward_if_needed()
-                            self.process_gradients(param, i)
                             if self._remaining_grad_acc_hooks == 0:
-                                self.current_expected_hooks = count_used_parameters_in_backward(all_params_requiring_grad)
-                            self.update_hook_state_and_maybe_run_epilogue(self.current_expected_hooks)
-                            self._remaining_grad_acc_hooks -= 1
+                                self.reenter_backward_if_needed()
+                            self.process_gradients(param, i)
+                            if self._hooks_fired_this_backward == 0:
+                                current_expected = count_used_parameters_in_backward(all_params_requiring_grad)
+                            else:
+                                current_expected = self._max_expected_hooks_seen
+                            self.update_hook_state_and_maybe_run_epilogue(current_expected)
 
                         self._grad_acc_hooks.append(register_grad_hook(param, grad_handling_hook))
 


### PR DESCRIPTION
This PR fixes a performance drop introduced by calling count_used_parameters_in_backward() inside every gradient hook.

In the previous implementation, the expected hook count was computed once per backward phase. After a recent PR changes (https://github.com/deepspeedai/DeepSpeed/commit/311674ffadc7e456819b3e66950c8a5fe1320749#diff-99dcf26ea2876ff5bbf05b5165c4133eaa0d0f36b170685643c2f7e2eb566addL1002-L1010), it is being recomputed on every hook invocation, resulting in a drop in samples/sec values.

With the fix in this PR performance returns to pre-regression samples/sec values.