### PR TITLE
double reduction user-friendly error

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1572,7 +1572,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     param = self.bit16_groups[group_idx][param_idx_in_group]
 
                     assert self.params_already_reduced[param_id] == False, \
-                        f"The parameter {param_id} has already been reduced. \
+                        f"The parameter {debug_param2name(param)} has already been reduced. \
                         Gradient computed twice for this partition. \
                         Multiple gradient reduction is currently not supported"
 


### PR DESCRIPTION
Currently a numerical order of the param tells nothing to the user of what param is the problem. This PR fixes that.

before:

```
AssertionError: The parameter 0 has already been reduced. ...
```

after:

```
AssertionError: The parameter model.embed_tokens.weight has already been reduced.
```