### PR TITLE
Respect `$TRITON_HOME`

### DIFF
--- a/deepspeed/ops/transformer/inference/triton/matmul_ext.py
+++ b/deepspeed/ops/transformer/inference/triton/matmul_ext.py
@@ -53,7 +53,8 @@ class TritonCacheDir:
 
     @staticmethod
     def default_cache_dir():
-        tmp_path = os.path.join(Path.home(), ".triton", "autotune")
+        tt_home = os.environ.get('TRITON_HOME') or os.path.join(Path.home(), ".triton")
+        tmp_path = os.path.join(tt_home, "autotune")
         return tmp_path
 
 


### PR DESCRIPTION
The default directory for Triton is only `~/.triton` if `$TRITON_HOME` is not set or empty.

Although `TRITON_CACHE_DIR` is already supported (which deviates from `~/.triton/cache` as used by Triton) users might expect that the root dir variable is also supported to avoid having to set all `TRITON_*` variables