### PR TITLE
feat(zero): make stage3 CUDA event queue limits configurable via JSON

### DIFF
--- a/deepspeed/runtime/zero/config.py
+++ b/deepspeed/runtime/zero/config.py
@@ -277,6 +277,22 @@ class DeepSpeedZeroConfig(DeepSpeedConfigModel):
     Recommended for scenarios with high memory pressure.
     """
 
+    max_param_reduce_events: int = Field(2, ge=1, alias="stage3_max_param_reduce_events")
+    """
+    Maximum number of in-flight CUDA events used to bound the parameter reduce (gradient all-reduce)
+    queue in ZeRO Stage 3. Limiting this prevents excessive GPU memory allocation by the host thread
+    before the async CUDA stream consumes it. Increase this value if you have ample GPU memory and
+    want to allow more overlap; decrease it to reduce memory pressure.
+    """
+
+    max_ongoing_fetch_events: int = Field(2, ge=1, alias="stage3_max_ongoing_fetch_events")
+    """
+    Maximum number of in-flight CUDA events used to bound the parameter fetch (allgather)
+    queue in ZeRO Stage 3. Limiting this prevents excessive GPU memory allocation by the host thread
+    before the async CUDA stream consumes it. Increase this value if you have ample GPU memory and
+    want to allow more overlap; decrease it to reduce memory pressure.
+    """
+
     stage3_gather_fp16_weights_on_model_save: bool = Field(False,
                                                            json_schema_extra={
                                                                "deprecated": True,

--- a/deepspeed/runtime/zero/parameter_offload.py
+++ b/deepspeed/runtime/zero/parameter_offload.py
@@ -108,6 +108,7 @@ class DeepSpeedZeRoOffload(object):
         zero_quantized_nontrainable_weights=False,
         zero_module_granularity_threshold=0,
         log_trace_cache_warnings=False,
+        max_ongoing_fetch_events=2,
     ):
 
         see_memory_usage("DeepSpeedZeRoOffload initialize [begin]", force=False)
@@ -174,6 +175,7 @@ class DeepSpeedZeRoOffload(object):
             zero_quantized_nontrainable_weights=self.zero_quantized_nontrainable_weights,
             fast_sharding_for_leaf_module=self.fast_sharding_for_leaf_module,
             log_trace_cache_warnings=self.log_trace_cache_warnings,
+            max_ongoing_fetch_events=max_ongoing_fetch_events,
         )
 
         self.forward_hooks = []

--- a/deepspeed/runtime/zero/partitioned_param_coordinator.py
+++ b/deepspeed/runtime/zero/partitioned_param_coordinator.py
@@ -90,6 +90,7 @@ class PartitionedParameterCoordinator:
         zero_quantized_nontrainable_weights=False,
         fast_sharding_for_leaf_module=False,
         log_trace_cache_warnings=False,
+        max_ongoing_fetch_events: int = 2,
     ) -> None:
         # mapping of param -> handle for each param that is currently in flight
         self.__inflight_param_registry = inflight_param_registry
@@ -124,13 +125,9 @@ class PartitionedParameterCoordinator:
         # time of the call, but not used until later by the asynchronous cuda stream.
         # allowing an infinite number of these to queue up causes a lot of memory
         # pressure that then becomes detrimental to performance.
-        # this is a much less elegant way of fixing this vs something like using
-        # cudaMallocAsync/cudaFreeAsync. Choosing to not expose this to the user now
-        # because ideally in the future its replaced by an async allocation
-        # mechanism which doesn't require any configuration by the user.
+        # configurable via zero_optimization.stage3_max_ongoing_fetch_events in the JSON config.
         self.__ongoing_fetch_events: Deque[get_accelerator().Event] = collections.deque()
-        # TODO. make this configurable via JSON
-        self.__max_ongoing_fetch_events: int = 2
+        self.__max_ongoing_fetch_events: int = max_ongoing_fetch_events
         self.__profiler = PartitionedParameterProfiler(timers if ENABLE_PROFILER else None)
 
         # Whether to log trace cache warnings, e.g. invalidation events

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -273,6 +273,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             zero_quantized_nontrainable_weights=zero_quantized_nontrainable_weights,
             zero_module_granularity_threshold=zero_module_granularity_threshold,
             log_trace_cache_warnings=log_trace_cache_warnings,
+            max_ongoing_fetch_events=ds_config.zero_config.max_ongoing_fetch_events,
         )
 
         self.persistent_parameters = self.parameter_offload.persistent_parameters
@@ -426,8 +427,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         self.is_gradient_accumulation_boundary: bool = True
 
         self.param_reduce_events: Deque[get_accelerator().Event] = collections.deque()
-        # TODO. make this configurable via JSON
-        self.max_param_reduce_events: int = 2
+        self.max_param_reduce_events: int = ds_config.zero_config.max_param_reduce_events
 
         self.param_dict = {}
 
@@ -553,6 +553,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         zero_quantized_nontrainable_weights,
         zero_module_granularity_threshold,
         log_trace_cache_warnings,
+        max_ongoing_fetch_events,
     ):
         return DeepSpeedZeRoOffload(module=module,
                                     timers=timers,
@@ -571,7 +572,8 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
                                     zero_quantized_weights=zero_quantized_weights,
                                     zero_quantized_nontrainable_weights=zero_quantized_nontrainable_weights,
                                     zero_module_granularity_threshold=zero_module_granularity_threshold,
-                                    log_trace_cache_warnings=log_trace_cache_warnings)
+                                    log_trace_cache_warnings=log_trace_cache_warnings,
+                                    max_ongoing_fetch_events=max_ongoing_fetch_events)
 
     def _get_trainable_parameter_groups(self):
         param_groups = []


### PR DESCRIPTION
feat(zero): make stage3 CUDA event queue limits configurable via JSON

ZeRO Stage 3 previously hardcoded the maximum number of in-flight CUDA
events to 2 in two places, preventing users from tuning this limit based
on their available GPU memory.

- Add `stage3_max_param_reduce_events` to ZeROConfig (default: 2)
  Controls the reduce (gradient all-reduce) event queue in stage3.py
- Add `stage3_max_ongoing_fetch_events` to ZeROConfig (default: 2)
  Controls the fetch (allgather) event queue in partitioned_param_coordinator.py
- Thread the new config values through DeepSpeedZeRoOffload and
  PartitionedParameterCoordinator constructor chains

Users with ample GPU memory can increase these values for more async
overlap; users under memory pressure can keep the default of 2.

Resolves TODO comments: "make this configurable via JSON"
